### PR TITLE
kernel-module: Replace pr_* with dev_* logging and improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ lint-format:
 		-not -path './.git/*' \
 		-not -path './stebates-*/*' \
 		-not -path './include/external/*' \
+		-not -path './gda-experiments/rocSHMEM/*' \
 		| xargs $(CLANG_FORMAT) --dry-run --Werror --style=file \
 		&& echo "✓ All files pass clang-format check" \
 		|| (echo "✗ Formatting issues found. Run 'make format' to fix." && exit 1)
@@ -254,6 +255,7 @@ format:
 		-not -path './.git/*' \
 		-not -path './stebates-*/*' \
 		-not -path './include/external/*' \
+		-not -path './gda-experiments/rocSHMEM/*' \
 		| xargs $(CLANG_FORMAT) -i --style=file
 	@echo "✓ Formatting complete"
 

--- a/kernel-module/Makefile
+++ b/kernel-module/Makefile
@@ -14,9 +14,32 @@ all:
 clean:
 	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) clean
 
+# Installation directory (can be overridden with DESTDIR)
+INSTALL_MOD_PATH ?=
+INSTALL_MOD_DIR ?= extra
+
 install:
-	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules_install
-	depmod -a
+	@echo "Installing nvme_axiio module..."
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) \
+		INSTALL_MOD_PATH=$(INSTALL_MOD_PATH) \
+		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR) \
+		modules_install
+	@if [ -z "$(INSTALL_MOD_PATH)" ]; then \
+		echo "Updating module dependencies..."; \
+		depmod -a; \
+	fi
+	@echo "✓ Module installed to /lib/modules/$$(uname -r)/$(INSTALL_MOD_DIR)/"
+
+uninstall:
+	@echo "Uninstalling nvme_axiio module..."
+	@MODULE_PATH="/lib/modules/$$(uname -r)/$(INSTALL_MOD_DIR)/nvme_axiio.ko"; \
+	if [ -f "$$MODULE_PATH" ]; then \
+		rm -f "$$MODULE_PATH"; \
+		echo "✓ Module removed from $$MODULE_PATH"; \
+		depmod -a; \
+	else \
+		echo "✗ Module not found at $$MODULE_PATH"; \
+	fi
 
 load:
 	sudo insmod nvme_axiio.ko
@@ -34,5 +57,5 @@ test:
 	@dmesg | tail -20
 	@sudo rmmod nvme_axiio || true
 
-.PHONY: all clean install load unload reload test
+.PHONY: all clean install uninstall load unload reload test
 

--- a/kernel-module/nvme_admin_cmd.h
+++ b/kernel-module/nvme_admin_cmd.h
@@ -15,7 +15,8 @@
 /*
  * Submit admin command and wait for completion
  */
-static inline int nvme_submit_admin_cmd_sync(void __iomem* bar0,
+static inline int nvme_submit_admin_cmd_sync(struct device* dev,
+                                             void __iomem* bar0,
                                              struct nvme_admin_queue* admin_q,
                                              struct nvme_command* cmd,
                                              u32* result, unsigned timeout_ms) {
@@ -29,8 +30,8 @@ static inline int nvme_submit_admin_cmd_sync(void __iomem* bar0,
   u32 doorbell_stride;
   volatile u32 __iomem* sq_doorbell;
 
-  pr_debug("nvme_axiio: Submitting admin command opcode=0x%02x\n",
-           cmd->common.opcode);
+  dev_dbg(dev, "nvme_axiio: Submitting admin command opcode=0x%02x\n",
+          cmd->common.opcode);
 
   spin_lock_irqsave(&admin_q->sq_lock, flags);
 
@@ -53,7 +54,7 @@ static inline int nvme_submit_admin_cmd_sync(void __iomem* bar0,
   sq_doorbell = (volatile u32 __iomem*)(bar0 + 0x1000);
   writel(sq_tail, sq_doorbell);
 
-  pr_debug("nvme_axiio: Rang admin SQ doorbell (tail=%u)\n", sq_tail);
+  dev_dbg(dev, "nvme_axiio: Rang admin SQ doorbell (tail=%u)\n", sq_tail);
 
   spin_unlock_irqrestore(&admin_q->sq_lock, flags);
 
@@ -73,7 +74,8 @@ static inline int nvme_submit_admin_cmd_sync(void __iomem* bar0,
       if (result)
         *result = le32_to_cpu(cq_entry->result.u32);
 
-      pr_debug(
+      dev_dbg(
+        dev,
         "nvme_axiio: Admin command completed: status=0x%04x result=0x%08x\n",
         status, *result);
 
@@ -94,7 +96,8 @@ static inline int nvme_submit_admin_cmd_sync(void __iomem* bar0,
 
       /* Check status */
       if (status != 0) {
-        pr_err("nvme_axiio: Admin command failed: status=0x%04x\n", status);
+        dev_err(dev, "nvme_axiio: Admin command failed: status=0x%04x\n",
+                status);
         return -EIO;
       }
 
@@ -105,7 +108,7 @@ static inline int nvme_submit_admin_cmd_sync(void __iomem* bar0,
     usleep_range(10, 100);
   }
 
-  pr_err("nvme_axiio: Timeout waiting for admin command completion\n");
+  dev_err(dev, "nvme_axiio: Timeout waiting for admin command completion\n");
   return -ETIMEDOUT;
 }
 
@@ -121,12 +124,12 @@ static inline int nvme_identify_ctrl(void __iomem* bar0,
   u32 result;
   int ret;
 
-  pr_info("nvme_axiio: Identifying controller...\n");
+  dev_info(dev, "nvme_axiio: Identifying controller...\n");
 
   /* Allocate DMA buffer for identify data */
   buffer = dma_alloc_coherent(dev, 4096, &dma_addr, GFP_KERNEL);
   if (!buffer) {
-    pr_err("nvme_axiio: Failed to allocate identify buffer\n");
+    dev_err(dev, "nvme_axiio: Failed to allocate identify buffer\n");
     return -ENOMEM;
   }
 
@@ -138,11 +141,11 @@ static inline int nvme_identify_ctrl(void __iomem* bar0,
   cmd.identify.cns = NVME_ID_CNS_CTRL;
 
   /* Submit command - use longer timeout for real hardware (30 seconds) */
-  ret = nvme_submit_admin_cmd_sync(bar0, admin_q, &cmd, &result, 30000);
+  ret = nvme_submit_admin_cmd_sync(dev, bar0, admin_q, &cmd, &result, 30000);
 
   if (ret == 0 && identify_data) {
     memcpy(identify_data, buffer, 4096);
-    pr_info("nvme_axiio: ✓ Controller identified\n");
+    dev_info(dev, "nvme_axiio: ✓ Controller identified\n");
   }
 
   dma_free_coherent(dev, 4096, buffer, dma_addr);
@@ -152,14 +155,15 @@ static inline int nvme_identify_ctrl(void __iomem* bar0,
 /*
  * Create I/O Completion Queue
  */
-static inline int nvme_create_io_cq_cmd(void __iomem* bar0,
+static inline int nvme_create_io_cq_cmd(struct device* dev, void __iomem* bar0,
                                         struct nvme_admin_queue* admin_q,
                                         u16 qid, u16 qsize, dma_addr_t cq_dma,
                                         u16 iv) {
   struct nvme_command cmd;
   u32 result;
 
-  pr_info("nvme_axiio: Creating I/O CQ (qid=%u, size=%u)...\n", qid, qsize);
+  dev_info(dev, "nvme_axiio: Creating I/O CQ (qid=%u, size=%u)...\n", qid,
+           qsize);
 
   memset(&cmd, 0, sizeof(cmd));
   cmd.create_cq.opcode = nvme_admin_create_cq;
@@ -171,21 +175,21 @@ static inline int nvme_create_io_cq_cmd(void __iomem* bar0,
   cmd.create_cq.irq_vector = cpu_to_le16(iv);
 
   /* Use longer timeout for real hardware (30 seconds) vs QEMU (5 seconds) */
-  return nvme_submit_admin_cmd_sync(bar0, admin_q, &cmd, &result, 30000);
+  return nvme_submit_admin_cmd_sync(dev, bar0, admin_q, &cmd, &result, 30000);
 }
 
 /*
  * Create I/O Submission Queue
  */
-static inline int nvme_create_io_sq_cmd(void __iomem* bar0,
+static inline int nvme_create_io_sq_cmd(struct device* dev, void __iomem* bar0,
                                         struct nvme_admin_queue* admin_q,
                                         u16 qid, u16 cqid, u16 qsize,
                                         dma_addr_t sq_dma) {
   struct nvme_command cmd;
   u32 result;
 
-  pr_info("nvme_axiio: Creating I/O SQ (qid=%u, cqid=%u, size=%u)...\n", qid,
-          cqid, qsize);
+  dev_info(dev, "nvme_axiio: Creating I/O SQ (qid=%u, cqid=%u, size=%u)...\n",
+           qid, cqid, qsize);
 
   memset(&cmd, 0, sizeof(cmd));
   cmd.create_sq.opcode = nvme_admin_create_sq;
@@ -197,45 +201,45 @@ static inline int nvme_create_io_sq_cmd(void __iomem* bar0,
   cmd.create_sq.cqid = cpu_to_le16(cqid);
 
   /* Use longer timeout for real hardware (30 seconds) vs QEMU (5 seconds) */
-  return nvme_submit_admin_cmd_sync(bar0, admin_q, &cmd, &result, 30000);
+  return nvme_submit_admin_cmd_sync(dev, bar0, admin_q, &cmd, &result, 30000);
 }
 
 /*
  * Delete I/O Submission Queue
  */
-static inline int nvme_delete_io_sq_cmd(void __iomem* bar0,
+static inline int nvme_delete_io_sq_cmd(struct device* dev, void __iomem* bar0,
                                         struct nvme_admin_queue* admin_q,
                                         u16 qid) {
   struct nvme_command cmd;
   u32 result;
 
-  pr_info("nvme_axiio: Deleting I/O SQ (qid=%u)...\n", qid);
+  dev_info(dev, "nvme_axiio: Deleting I/O SQ (qid=%u)...\n", qid);
 
   memset(&cmd, 0, sizeof(cmd));
   cmd.delete_queue.opcode = nvme_admin_delete_sq;
   cmd.delete_queue.qid = cpu_to_le16(qid);
 
   /* Use longer timeout for real hardware (30 seconds) vs QEMU (5 seconds) */
-  return nvme_submit_admin_cmd_sync(bar0, admin_q, &cmd, &result, 30000);
+  return nvme_submit_admin_cmd_sync(dev, bar0, admin_q, &cmd, &result, 30000);
 }
 
 /*
  * Delete I/O Completion Queue
  */
-static inline int nvme_delete_io_cq_cmd(void __iomem* bar0,
+static inline int nvme_delete_io_cq_cmd(struct device* dev, void __iomem* bar0,
                                         struct nvme_admin_queue* admin_q,
                                         u16 qid) {
   struct nvme_command cmd;
   u32 result;
 
-  pr_info("nvme_axiio: Deleting I/O CQ (qid=%u)...\n", qid);
+  dev_info(dev, "nvme_axiio: Deleting I/O CQ (qid=%u)...\n", qid);
 
   memset(&cmd, 0, sizeof(cmd));
   cmd.delete_queue.opcode = nvme_admin_delete_cq;
   cmd.delete_queue.qid = cpu_to_le16(qid);
 
   /* Use longer timeout for real hardware (30 seconds) vs QEMU (5 seconds) */
-  return nvme_submit_admin_cmd_sync(bar0, admin_q, &cmd, &result, 30000);
+  return nvme_submit_admin_cmd_sync(dev, bar0, admin_q, &cmd, &result, 30000);
 }
 
 #endif /* NVME_ADMIN_CMD_H */

--- a/kernel-module/nvme_admin_direct.h
+++ b/kernel-module/nvme_admin_direct.h
@@ -54,10 +54,10 @@ static inline int nvme_admin_queue_init(struct nvme_admin_queue* admin,
   /* Read Admin Completion Queue Base Address (ACQ) at offset 0x30 */
   acq = readq(bar0 + 0x30);
 
-  pr_info("nvme_axiio: Admin queue initialization:\n");
-  pr_info("  Queue size: %u entries\n", admin->queue_size);
-  pr_info("  ASQ: 0x%llx\n", asq);
-  pr_info("  ACQ: 0x%llx\n", acq);
+  dev_info(&pdev->dev, "nvme_axiio: Admin queue initialization:\n");
+  dev_info(&pdev->dev, "  Queue size: %u entries\n", admin->queue_size);
+  dev_info(&pdev->dev, "  ASQ: 0x%llx\n", asq);
+  dev_info(&pdev->dev, "  ACQ: 0x%llx\n", acq);
 
   /* We can't easily map these physical addresses from another driver
    * because they belong to the kernel nvme driver's DMA allocations.
@@ -66,9 +66,12 @@ static inline int nvme_admin_queue_init(struct nvme_admin_queue* admin,
    */
 
   /* For now, mark this as not implemented */
-  pr_warn("nvme_axiio: Direct admin queue access not fully implemented\n");
-  pr_warn("  Reason: Cannot safely map kernel driver's admin queue memory\n");
-  pr_warn("  Alternative: Use nvme_submit_admin_command() kernel API\n");
+  dev_warn(&pdev->dev,
+           "nvme_axiio: Direct admin queue access not fully implemented\n");
+  dev_warn(&pdev->dev,
+           "  Reason: Cannot safely map kernel driver's admin queue memory\n");
+  dev_warn(&pdev->dev,
+           "  Alternative: Use nvme_submit_admin_command() kernel API\n");
 
   return -ENOTSUPP;
 }
@@ -85,8 +88,10 @@ static inline int nvme_submit_admin_cmd_direct(struct nvme_admin_queue* admin,
    *
    * The kernel driver uses locks and has exclusive access.
    */
-  pr_err("nvme_axiio: Direct admin command submission not supported\n");
-  pr_err("  Reason: Would conflict with kernel driver's admin queue usage\n");
+  dev_err(&pdev->dev,
+          "nvme_axiio: Direct admin command submission not supported\n");
+  dev_err(&pdev->dev,
+          "  Reason: Would conflict with kernel driver's admin queue usage\n");
   return -ENOTSUPP;
 }
 

--- a/kernel-module/nvme_amdgpu_integration.h
+++ b/kernel-module/nvme_amdgpu_integration.h
@@ -75,7 +75,8 @@ static struct amdgpu_integration_ops amdgpu_ops = {NULL};
  * If it fails, we fall back to standard mapping (no GPU MMU registration).
  */
 static inline int nvme_amdgpu_init(void) {
-  pr_info("nvme_axiio: Attempting to initialize amdgpu integration...\n");
+  dev_info(&pdev->dev,
+           "nvme_axiio: Attempting to initialize amdgpu integration...\n");
 
 #ifdef CONFIG_DRM_AMDGPU
   /* Try to find amdgpu symbols dynamically */
@@ -91,11 +92,13 @@ static inline int nvme_amdgpu_init(void) {
    * Alternative: Build as part of amdgpu tree.
    */
 
-  pr_warn("nvme_axiio: amdgpu symbol linking not yet implemented\n");
-  pr_warn("  Will use fallback mapping (no GPU MMU registration)\n");
+  dev_warn(&pdev->dev,
+           "nvme_axiio: amdgpu symbol linking not yet implemented\n");
+  dev_warn(&pdev->dev,
+           "  Will use fallback mapping (no GPU MMU registration)\n");
   return -ENOSYS;
 #else
-  pr_info("nvme_axiio: amdgpu not available in kernel config\n");
+  dev_info(&pdev->dev, "nvme_axiio: amdgpu not available in kernel config\n");
   return -ENODEV;
 #endif
 }
@@ -112,24 +115,25 @@ static inline int nvme_register_doorbell_with_amdgpu(
   uint64_t gpu_va = 0;
   int ret;
 
-  pr_info("nvme_axiio: Registering doorbell with amdgpu...\n");
+  dev_info(&pdev->dev, "nvme_axiio: Registering doorbell with amdgpu...\n");
 
   /* Check if amdgpu ops are available */
   if (!amdgpu_ops.get_adev_from_drm) {
-    pr_warn("nvme_axiio: amdgpu integration not available\n");
-    pr_warn("  Doorbell will be mapped but NOT registered with GPU MMU\n");
-    pr_warn("  This may cause GPU page faults!\n");
+    dev_warn(&pdev->dev, "nvme_axiio: amdgpu integration not available\n");
+    dev_warn(&pdev->dev,
+             "  Doorbell will be mapped but NOT registered with GPU MMU\n");
+    dev_warn(&pdev->dev, "  This may cause GPU page faults!\n");
     return -ENOSYS;
   }
 
   /* Get amdgpu device */
   adev = amdgpu_ops.get_adev_from_drm(drm_dev);
   if (!adev) {
-    pr_err("nvme_axiio: Could not get amdgpu device\n");
+    dev_err(&pdev->dev, "nvme_axiio: Could not get amdgpu device\n");
     return -ENODEV;
   }
 
-  pr_info("nvme_axiio: Got amdgpu device\n");
+  dev_info(&pdev->dev, "nvme_axiio: Got amdgpu device\n");
 
   /*
    * Create kernel buffer object for doorbell MMIO
@@ -140,12 +144,13 @@ static inline int nvme_register_doorbell_with_amdgpu(
                                     2, /* AMDGPU_GEM_DOMAIN_GTT */
                                     &doorbell_bo, &gpu_va, NULL);
   if (ret) {
-    pr_err("nvme_axiio: amdgpu_bo_create_kernel failed: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: amdgpu_bo_create_kernel failed: %d\n",
+            ret);
     return ret;
   }
 
-  pr_info("nvme_axiio: Created amdgpu BO for doorbell\n");
-  pr_info("  GPU VA: 0x%llx\n", gpu_va);
+  dev_info(&pdev->dev, "nvme_axiio: Created amdgpu BO for doorbell\n");
+  dev_info(&pdev->dev, "  GPU VA: 0x%llx\n", gpu_va);
 
   /*
    * Map the physical doorbell address into the BO
@@ -155,15 +160,16 @@ static inline int nvme_register_doorbell_with_amdgpu(
   ret = amdgpu_ops.vm_bo_map(adev, doorbell_bo, ctx->doorbell_phys, 0,
                              ctx->size, 0);
   if (ret) {
-    pr_err("nvme_axiio: amdgpu_vm_bo_map failed: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: amdgpu_vm_bo_map failed: %d\n", ret);
     amdgpu_ops.bo_free(doorbell_bo);
     return ret;
   }
 
-  pr_info("nvme_axiio: ✓✓✓ Doorbell registered with GPU MMU! ✓✓✓\n");
-  pr_info("  Physical: 0x%llx\n", (u64)ctx->doorbell_phys);
-  pr_info("  GPU VA:   0x%llx\n", gpu_va);
-  pr_info("  GPU can now access doorbell directly!\n");
+  dev_info(&pdev->dev,
+           "nvme_axiio: ✓✓✓ Doorbell registered with GPU MMU! ✓✓✓\n");
+  dev_info(&pdev->dev, "  Physical: 0x%llx\n", (u64)ctx->doorbell_phys);
+  dev_info(&pdev->dev, "  GPU VA:   0x%llx\n", gpu_va);
+  dev_info(&pdev->dev, "  GPU can now access doorbell directly!\n");
 
   /* Store for cleanup */
   ctx->amdgpu_bo = doorbell_bo;
@@ -184,18 +190,19 @@ static inline int nvme_setup_gpu_doorbell(struct nvme_amdgpu_doorbell* ctx,
   struct drm_device* drm_dev = NULL;
   int ret;
 
-  pr_info("nvme_axiio: Setting up GPU-direct doorbell...\n");
-  pr_info("  GPU FD: %d\n", gpu_fd);
-  pr_info("  Doorbell phys: 0x%llx\n", (u64)doorbell_phys);
+  dev_info(&pdev->dev, "nvme_axiio: Setting up GPU-direct doorbell...\n");
+  dev_info(&pdev->dev, "  GPU FD: %d\n", gpu_fd);
+  dev_info(&pdev->dev, "  Doorbell phys: 0x%llx\n", (u64)doorbell_phys);
 
   /* Get GPU file */
   gpu_file = fget(gpu_fd);
   if (!gpu_file) {
-    pr_err("nvme_axiio: Invalid GPU FD\n");
+    dev_err(&pdev->dev, "nvme_axiio: Invalid GPU FD\n");
     return -EBADF;
   }
 
-  pr_info("nvme_axiio: GPU file: %s\n", gpu_file->f_path.dentry->d_name.name);
+  dev_info(&pdev->dev, "nvme_axiio: GPU file: %s\n",
+           gpu_file->f_path.dentry->d_name.name);
 
   /* Initialize context */
   ctx->gpu_file = gpu_file;
@@ -209,7 +216,7 @@ static inline int nvme_setup_gpu_doorbell(struct nvme_amdgpu_doorbell* ctx,
   if (gpu_file->f_op && gpu_file->private_data) {
     /* This is where we'd extract drm_device */
     /* For now, skip - will use fallback */
-    pr_info("nvme_axiio: GPU file looks like DRM device\n");
+    dev_info(&pdev->dev, "nvme_axiio: GPU file looks like DRM device\n");
   }
 #endif
 
@@ -217,16 +224,18 @@ static inline int nvme_setup_gpu_doorbell(struct nvme_amdgpu_doorbell* ctx,
   if (drm_dev && amdgpu_ops.get_adev_from_drm) {
     ret = nvme_register_doorbell_with_amdgpu(ctx, drm_dev);
     if (ret == 0) {
-      pr_info("nvme_axiio: ✓ TRUE GPU-DIRECT enabled!\n");
+      dev_info(&pdev->dev, "nvme_axiio: ✓ TRUE GPU-DIRECT enabled!\n");
       return 0;
     }
-    pr_warn("nvme_axiio: amdgpu registration failed, using fallback\n");
+    dev_warn(&pdev->dev,
+             "nvme_axiio: amdgpu registration failed, using fallback\n");
   }
 
   /* Fallback: Regular mapping (no GPU MMU registration) */
-  pr_info("nvme_axiio: Using fallback mapping\n");
-  pr_info("  Will map with GPU-friendly VMA flags\n");
-  pr_info("  But GPU MMU will NOT be registered - may cause page faults\n");
+  dev_info(&pdev->dev, "nvme_axiio: Using fallback mapping\n");
+  dev_info(&pdev->dev, "  Will map with GPU-friendly VMA flags\n");
+  dev_info(&pdev->dev,
+           "  But GPU MMU will NOT be registered - may cause page faults\n");
 
   return 0;
 }
@@ -247,7 +256,7 @@ static inline void nvme_cleanup_gpu_doorbell(struct nvme_amdgpu_doorbell* ctx) {
 
   ctx->gpu_mapped = false;
 
-  pr_info("nvme_axiio: GPU doorbell cleaned up\n");
+  dev_info(&pdev->dev, "nvme_axiio: GPU doorbell cleaned up\n");
 }
 
 /*
@@ -264,10 +273,10 @@ static inline int nvme_mmap_gpu_doorbell(struct vm_area_struct* vma,
   page_base = ctx->doorbell_phys & PAGE_MASK;
   pfn = page_base >> PAGE_SHIFT;
 
-  pr_info("nvme_axiio: mmap GPU doorbell\n");
-  pr_info("  PFN: 0x%lx\n", pfn);
-  pr_info("  Size: %zu\n", ctx->size);
-  pr_info("  GPU mapped: %s\n", ctx->gpu_mapped ? "YES" : "NO");
+  dev_info(&pdev->dev, "nvme_axiio: mmap GPU doorbell\n");
+  dev_info(&pdev->dev, "  PFN: 0x%lx\n", pfn);
+  dev_info(&pdev->dev, "  Size: %zu\n", ctx->size);
+  dev_info(&pdev->dev, "  GPU mapped: %s\n", ctx->gpu_mapped ? "YES" : "NO");
 
   /* GPU-friendly page protection */
   vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
@@ -286,18 +295,20 @@ static inline int nvme_mmap_gpu_doorbell(struct vm_area_struct* vma,
   /* Map the physical pages */
   ret = remap_pfn_range(vma, vma->vm_start, pfn, ctx->size, vma->vm_page_prot);
   if (ret) {
-    pr_err("nvme_axiio: remap_pfn_range failed: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: remap_pfn_range failed: %d\n", ret);
     return ret;
   }
 
   if (ctx->gpu_mapped) {
-    pr_info("nvme_axiio: ✓✓✓ TRUE GPU-DIRECT doorbell mapped! ✓✓✓\n");
-    pr_info("  GPU VA: 0x%llx\n", (u64)ctx->gpu_va);
-    pr_info("  GPU MMU has this address - no page faults!\n");
+    dev_info(&pdev->dev,
+             "nvme_axiio: ✓✓✓ TRUE GPU-DIRECT doorbell mapped! ✓✓✓\n");
+    dev_info(&pdev->dev, "  GPU VA: 0x%llx\n", (u64)ctx->gpu_va);
+    dev_info(&pdev->dev, "  GPU MMU has this address - no page faults!\n");
   } else {
-    pr_info("nvme_axiio: ✓ Doorbell mapped with GPU-friendly flags\n");
-    pr_warn("  GPU MMU NOT registered - may cause page faults\n");
-    pr_warn("  For TRUE GPU-direct, need amdgpu integration\n");
+    dev_info(&pdev->dev,
+             "nvme_axiio: ✓ Doorbell mapped with GPU-friendly flags\n");
+    dev_warn(&pdev->dev, "  GPU MMU NOT registered - may cause page faults\n");
+    dev_warn(&pdev->dev, "  For TRUE GPU-direct, need amdgpu integration\n");
   }
 
   return 0;

--- a/kernel-module/nvme_axiio.c
+++ b/kernel-module/nvme_axiio.c
@@ -230,7 +230,7 @@ static int axiio_release(struct inode* inode, struct file* filp) {
   if (ctx && ctx->pci_dev)
     pci_info(ctx->pci_dev, "Device closed\n");
   else
-    pr_info("nvme_axiio: Device closed\n");
+    dev_info(&ctx->pci_dev->dev, "nvme_axiio: Device closed\n");
 
   if (ctx) {
     /* Free allocated DMA buffers */
@@ -283,7 +283,7 @@ static int axiio_release(struct inode* inode, struct file* filp) {
 
     /* Clean up GPU mapping */
     if (ctx->gpu_mapping.gpu_file) {
-      nvme_unmap_doorbell_from_gpu(&ctx->gpu_mapping);
+      nvme_unmap_doorbell_from_gpu(&ctx->pci_dev->dev, &ctx->gpu_mapping);
     }
 
     kfree(ctx);
@@ -606,7 +606,7 @@ static int axiio_ioctl_get_gpu_doorbell(
     return -EFAULT;
 
   if (!ctrl || !ctrl->bar0) {
-    pr_err("nvme_axiio: No exclusive controller access\n");
+    dev_err(&ctx->pci_dev->dev, "nvme_axiio: No exclusive controller access\n");
     return -ENODEV;
   }
 
@@ -630,8 +630,9 @@ static int axiio_ioctl_get_gpu_doorbell(
   if (info.gpu_fd >= 0) {
     pci_info(ctx->pci_dev, "🚀 Setting up GPU-direct doorbell...\n");
 
-    ret = nvme_map_doorbell_for_gpu(&ctx->gpu_mapping, info.gpu_fd,
-                                    info.doorbell_phys, info.mmap_size);
+    ret = nvme_map_doorbell_for_gpu(&ctx->pci_dev->dev, &ctx->gpu_mapping,
+                                    info.gpu_fd, info.doorbell_phys,
+                                    info.mmap_size);
     if (ret < 0) {
       pci_err(ctx->pci_dev, "GPU mapping setup failed: %d\n", ret);
       /* Continue anyway - fallback to regular mapping */
@@ -712,7 +713,7 @@ static int axiio_ioctl_alloc_dma(struct axiio_file_ctx* ctx,
 /*
  * Export doorbell as dmabuf (Standard Linux GPU-Direct!)
  */
-static int axiio_ioctl_export_doorbell_dmabuf(
+static __maybe_unused int axiio_ioctl_export_doorbell_dmabuf(
   struct axiio_file_ctx* ctx,
   struct nvme_doorbell_dmabuf_export __user* uinfo) {
   struct axiio_controller* ctrl = nvme_axiio_get_controller();
@@ -724,7 +725,7 @@ static int axiio_ioctl_export_doorbell_dmabuf(
     return -EFAULT;
 
   if (!ctrl || !ctrl->bar0) {
-    pr_err("nvme_axiio: No exclusive controller access\n");
+    dev_err(&ctx->pci_dev->dev, "nvme_axiio: No exclusive controller access\n");
     return -ENODEV;
   }
 
@@ -908,17 +909,19 @@ static int axiio_mmap(struct file* filp, struct vm_area_struct* vma) {
     if (ctrl && ctrl->using_iova) {
       /* QEMU P2P: Use IOVA address (page-aligned) */
       pfn = ctrl->p2p_iova.doorbell_iova >> PAGE_SHIFT;
-      pr_info("nvme_axiio: mmap IOVA doorbell for GPU (queue_id=%u, "
-              "iova=0x%llx, pfn=0x%lx)\n",
-              ctx->queue_id, ctrl->p2p_iova.doorbell_iova, pfn);
+      dev_info(&ctx->pci_dev->dev,
+               "nvme_axiio: mmap IOVA doorbell for GPU (queue_id=%u, "
+               "iova=0x%llx, pfn=0x%lx)\n",
+               ctx->queue_id, ctrl->p2p_iova.doorbell_iova, pfn);
     } else {
       /* Physical hardware: Use normal BAR0 address */
       doorbell_offset = 0x1000 + (ctx->queue_id * 2 * ctx->doorbell_stride);
       unsigned long page_offset = doorbell_offset & PAGE_MASK;
       pfn = (ctx->bar0_phys + page_offset) >> PAGE_SHIFT;
-      pr_info("nvme_axiio: mmap doorbell BAR (queue_id=%u, phys=0x%llx, "
-              "pfn=0x%lx)\n",
-              ctx->queue_id, ctx->bar0_phys + doorbell_offset, pfn);
+      dev_info(&ctx->pci_dev->dev,
+               "nvme_axiio: mmap doorbell BAR (queue_id=%u, phys=0x%llx, "
+               "pfn=0x%lx)\n",
+               ctx->queue_id, ctx->bar0_phys + doorbell_offset, pfn);
     }
 
     /* Set GPU-compatible page protection flags */
@@ -932,46 +935,55 @@ static int axiio_mmap(struct file* filp, struct vm_area_struct* vma) {
     /* This mapping will be GPU-accessible! */
     ret = remap_pfn_range(vma, vma->vm_start, pfn, size, vma->vm_page_prot);
     if (ret < 0) {
-      pr_err("nvme_axiio: remap_pfn_range failed for doorbell: %d\n", ret);
+      dev_err(&ctx->pci_dev->dev,
+              "nvme_axiio: remap_pfn_range failed for doorbell: %d\n", ret);
       return ret;
     }
 
-    pr_info(
+    dev_info(
+      &ctx->pci_dev->dev,
       "nvme_axiio: ✓ Doorbell mapped with GPU-compatible flags (WC + IO)\n");
 
   } else if (vma->vm_pgoff == 3) {
     /* Map GPU doorbell with GPU MMU registration! */
 
-    pr_info("nvme_axiio: mmap GPU doorbell (GPU-DIRECT mode)\n");
-    pr_info("  Queue ID: %u\n", ctx->queue_id);
+    dev_info(&ctx->pci_dev->dev,
+             "nvme_axiio: mmap GPU doorbell (GPU-DIRECT mode)\n");
+    dev_info(&ctx->pci_dev->dev, "  Queue ID: %u\n", ctx->queue_id);
 
     /* Check if GPU context was set up via IOCTL */
     if (ctx->gpu_mapping.gpu_file) {
-      pr_info("nvme_axiio: 🚀 Using GPU-aware mapping!\n");
-      pr_info("  GPU file present - doorbell will be GPU-accessible\n");
+      dev_info(&ctx->pci_dev->dev, "nvme_axiio: 🚀 Using GPU-aware mapping!\n");
+      dev_info(&ctx->pci_dev->dev,
+               "  GPU file present - doorbell will be GPU-accessible\n");
 
       /* Use GPU-aware mmap - pass queue ID and PCI device for IOVA lookup */
       ret = nvme_mmap_doorbell_for_gpu(vma, &ctx->gpu_mapping, ctx->queue_id,
                                        ctx->pci_dev);
       if (ret < 0) {
-        pr_err("nvme_axiio: GPU-aware mmap failed: %d\n", ret);
+        dev_err(&ctx->pci_dev->dev, "nvme_axiio: GPU-aware mmap failed: %d\n",
+                ret);
         /* Fall through to regular mapping */
       } else {
-        pr_info("nvme_axiio: ✓ TRUE GPU-DIRECT doorbell mapped!\n");
-        pr_info("  GPU VA: 0x%lx\n", vma->vm_start);
-        pr_info("  GPU can now write directly to NVMe doorbell!\n");
+        dev_info(&ctx->pci_dev->dev,
+                 "nvme_axiio: ✓ TRUE GPU-DIRECT doorbell mapped!\n");
+        dev_info(&ctx->pci_dev->dev, "  GPU VA: 0x%lx\n", vma->vm_start);
+        dev_info(&ctx->pci_dev->dev,
+                 "  GPU can now write directly to NVMe doorbell!\n");
         return 0;
       }
     }
 
     /* Fallback: Regular mapping (no GPU MMU registration) */
-    pr_info("nvme_axiio: Using standard mapping (no GPU FD provided)\n");
+    dev_info(&ctx->pci_dev->dev,
+             "nvme_axiio: Using standard mapping (no GPU FD provided)\n");
 
     struct axiio_controller* ctrl = nvme_axiio_get_controller();
     resource_size_t doorbell_phys;
 
     if (!ctrl || !ctrl->bar0) {
-      pr_err("nvme_axiio: No exclusive controller for doorbell mapping\n");
+      dev_err(&ctx->pci_dev->dev,
+              "nvme_axiio: No exclusive controller for doorbell mapping\n");
       return -ENODEV;
     }
 
@@ -980,16 +992,19 @@ static int axiio_mmap(struct file* filp, struct vm_area_struct* vma) {
                                            true, /* SQ doorbell */
                                            ctrl->doorbell_stride);
 
-    pr_info("  Doorbell phys: 0x%llx\n", (u64)doorbell_phys);
+    dev_info(&ctx->pci_dev->dev, "  Doorbell phys: 0x%llx\n",
+             (u64)doorbell_phys);
 
     /* Setup standard doorbell mapping */
-    ret = nvme_setup_gpu_doorbell_vma(vma, doorbell_phys, size);
+    ret = nvme_setup_gpu_doorbell_vma(&ctx->pci_dev->dev, vma, doorbell_phys,
+                                      size);
     if (ret < 0) {
-      pr_err("nvme_axiio: Failed to setup doorbell VMA: %d\n", ret);
+      dev_err(&ctx->pci_dev->dev,
+              "nvme_axiio: Failed to setup doorbell VMA: %d\n", ret);
       return ret;
     }
 
-    pr_info("nvme_axiio: ✓ Standard doorbell mapped\n");
+    dev_info(&ctx->pci_dev->dev, "nvme_axiio: ✓ Standard doorbell mapped\n");
 
   } else if (vma->vm_pgoff >= 4) {
     /* Map DMA buffers (offset 4+)
@@ -1001,8 +1016,9 @@ static int axiio_mmap(struct file* filp, struct vm_area_struct* vma) {
     int buffer_index = vma->vm_pgoff - 4;
     int found_index = 0;
 
-    pr_info("nvme_axiio: mmap DMA buffer (index=%d, size=%lu)\n", buffer_index,
-            size);
+    dev_info(&ctx->pci_dev->dev,
+             "nvme_axiio: mmap DMA buffer (index=%d, size=%lu)\n", buffer_index,
+             size);
 
     /* Find the DMA buffer at the requested index */
     mutex_lock(&ctx->dma_lock);
@@ -1015,13 +1031,15 @@ static int axiio_mmap(struct file* filp, struct vm_area_struct* vma) {
     mutex_unlock(&ctx->dma_lock);
 
     if (!entry || found_index != buffer_index) {
-      pr_err("nvme_axiio: DMA buffer index %d not found\n", buffer_index);
+      dev_err(&ctx->pci_dev->dev, "nvme_axiio: DMA buffer index %d not found\n",
+              buffer_index);
       return -EINVAL;
     }
 
     if (size > entry->size) {
-      pr_err("nvme_axiio: Requested size %lu exceeds buffer size %zu\n", size,
-             entry->size);
+      dev_err(&ctx->pci_dev->dev,
+              "nvme_axiio: Requested size %lu exceeds buffer size %zu\n", size,
+              entry->size);
       return -EINVAL;
     }
 
@@ -1030,12 +1048,14 @@ static int axiio_mmap(struct file* filp, struct vm_area_struct* vma) {
     ret = dma_mmap_coherent(&ctx->pci_dev->dev, vma, entry->virt_addr,
                             entry->dma_addr, size);
     if (ret < 0) {
-      pr_err("nvme_axiio: dma_mmap_coherent failed for DMA buffer: %d\n", ret);
+      dev_err(&ctx->pci_dev->dev,
+              "nvme_axiio: dma_mmap_coherent failed for DMA buffer: %d\n", ret);
       return ret;
     }
 
-    pr_info("nvme_axiio: ✓ DMA buffer mapped (index=%d, DMA=0x%llx)\n",
-            buffer_index, (u64)entry->dma_addr);
+    dev_info(&ctx->pci_dev->dev,
+             "nvme_axiio: ✓ DMA buffer mapped (index=%d, DMA=0x%llx)\n",
+             buffer_index, (u64)entry->dma_addr);
 
   } else {
     return -EINVAL;
@@ -1099,15 +1119,20 @@ static int __init nvme_axiio_init(void) {
     return PTR_ERR(axiio_device);
   }
 
-  pr_info("nvme_axiio: Module loaded successfully, device /dev/%s created\n",
-          NVME_AXIIO_NAME);
+  if (axiio_device)
+    dev_info(axiio_device,
+             "nvme_axiio: Module loaded successfully, device /dev/%s created\n",
+             NVME_AXIIO_NAME);
+  else
+    pr_info("nvme_axiio: Module loaded successfully, device /dev/%s created\n",
+            NVME_AXIIO_NAME);
 
   /* Register as PCI driver for device binding */
   ret = nvme_axiio_register_pci_driver();
   if (ret < 0) {
     pr_warn("nvme_axiio: PCI driver registration failed: %d\n", ret);
-    pr_warn(
-      "  Character device still available, but cannot bind to PCI devices\n");
+    pr_warn("nvme_axiio: Character device still available, but cannot bind to "
+            "PCI devices\n");
     /* Don't fail module load - character device still works */
   }
 

--- a/kernel-module/nvme_axiio_pci_driver.h
+++ b/kernel-module/nvme_axiio_pci_driver.h
@@ -65,22 +65,22 @@ static int nvme_axiio_pci_probe(struct pci_dev* pdev,
 
   /* Only allow one device at a time for now */
   if (axiio_bound_pci_dev) {
-    pr_err("nvme_axiio: Already bound to device %s\n",
-           pci_name(axiio_bound_pci_dev));
+    dev_err(&pdev->dev, "nvme_axiio: Already bound to device %s\n",
+            pci_name(axiio_bound_pci_dev));
     return -EBUSY;
   }
 
   /* Enable PCI device */
   ret = pci_enable_device_mem(pdev);
   if (ret) {
-    pr_err("nvme_axiio: Failed to enable PCI device: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: Failed to enable PCI device: %d\n", ret);
     return ret;
   }
 
   /* Request memory regions */
   ret = pci_request_regions(pdev, "nvme_axiio");
   if (ret) {
-    pr_err("nvme_axiio: Failed to request PCI regions: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: Failed to request PCI regions: %d\n", ret);
     pci_disable_device(pdev);
     return ret;
   }
@@ -88,10 +88,11 @@ static int nvme_axiio_pci_probe(struct pci_dev* pdev,
   /* Set DMA mask (NVMe supports 64-bit DMA) */
   ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
   if (ret) {
-    pr_warn("nvme_axiio: 64-bit DMA not available, trying 32-bit\n");
+    dev_warn(&pdev->dev,
+             "nvme_axiio: 64-bit DMA not available, trying 32-bit\n");
     ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
     if (ret) {
-      pr_err("nvme_axiio: Failed to set DMA mask: %d\n", ret);
+      dev_err(&pdev->dev, "nvme_axiio: Failed to set DMA mask: %d\n", ret);
       goto release_regions;
     }
   }
@@ -104,14 +105,14 @@ static int nvme_axiio_pci_probe(struct pci_dev* pdev,
   bar0_size = pci_resource_len(pdev, 0);
 
   if (!bar0_phys || !bar0_size) {
-    pr_err("nvme_axiio: Invalid BAR0\n");
+    dev_err(&pdev->dev, "nvme_axiio: Invalid BAR0\n");
     ret = -ENXIO;
     goto release_regions;
   }
 
   bar0 = pci_ioremap_bar(pdev, 0);
   if (!bar0) {
-    pr_err("nvme_axiio: Failed to map BAR0\n");
+    dev_err(&pdev->dev, "nvme_axiio: Failed to map BAR0\n");
     ret = -ENOMEM;
     goto release_regions;
   }
@@ -119,7 +120,7 @@ static int nvme_axiio_pci_probe(struct pci_dev* pdev,
   /* Allocate controller context */
   axiio_ctrl = kzalloc(sizeof(*axiio_ctrl), GFP_KERNEL);
   if (!axiio_ctrl) {
-    pr_err("nvme_axiio: Failed to allocate controller context\n");
+    dev_err(&pdev->dev, "nvme_axiio: Failed to allocate controller context\n");
     ret = -ENOMEM;
     goto unmap_bar0;
   }
@@ -136,26 +137,30 @@ static int nvme_axiio_pci_probe(struct pci_dev* pdev,
   axiio_ctrl->max_queue_entries = nvme_get_max_queue_entries(bar0);
   dstrd = (cap >> 32) & 0xF;
 
-  pr_info("nvme_axiio: ✓ Successfully bound to NVMe controller\n");
-  pr_info("  PCI: %s\n", pci_name(pdev));
-  pr_info("  BAR0: phys=0x%llx size=0x%llx\n", (u64)bar0_phys, (u64)bar0_size);
-  pr_info("  Version: %u.%u.%u\n", (axiio_ctrl->version >> 16) & 0xFFFF,
-          (axiio_ctrl->version >> 8) & 0xFF, axiio_ctrl->version & 0xFF);
-  pr_info("  CAP: 0x%016llx (DSTRD=%u, MQES=%u)\n", cap, dstrd,
-          axiio_ctrl->max_queue_entries);
+  dev_info(&pdev->dev, "nvme_axiio: ✓ Successfully bound to NVMe controller\n");
+  dev_info(&pdev->dev, "  PCI: %s\n", pci_name(pdev));
+  dev_info(&pdev->dev, "  BAR0: phys=0x%llx size=0x%llx\n", (u64)bar0_phys,
+           (u64)bar0_size);
+  dev_info(&pdev->dev, "  Version: %u.%u.%u\n",
+           (axiio_ctrl->version >> 16) & 0xFFFF,
+           (axiio_ctrl->version >> 8) & 0xFF, axiio_ctrl->version & 0xFF);
+  dev_info(&pdev->dev, "  CAP: 0x%016llx (DSTRD=%u, MQES=%u)\n", cap, dstrd,
+           axiio_ctrl->max_queue_entries);
 
   /* Initialize controller and admin queue */
-  pr_info("nvme_axiio: Initializing NVMe controller...\n");
+  dev_info(&pdev->dev, "nvme_axiio: Initializing NVMe controller...\n");
   ret = nvme_init_admin_queue(&pdev->dev, bar0, &axiio_ctrl->admin_q, 64);
   if (ret < 0) {
-    pr_err("nvme_axiio: Failed to initialize admin queue: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: Failed to initialize admin queue: %d\n",
+            ret);
     goto free_ctrl;
   }
 
   /* Identify controller */
   ret = nvme_identify_ctrl(bar0, &axiio_ctrl->admin_q, &pdev->dev, NULL);
   if (ret < 0) {
-    pr_warn("nvme_axiio: Failed to identify controller: %d\n", ret);
+    dev_warn(&pdev->dev, "nvme_axiio: Failed to identify controller: %d\n",
+             ret);
     /* Continue anyway - not fatal */
   }
 
@@ -168,20 +173,25 @@ static int nvme_axiio_pci_probe(struct pci_dev* pdev,
                                  &axiio_ctrl->p2p_iova);
     if (ret == 0) {
       axiio_ctrl->using_iova = true;
-      pr_info("nvme_axiio: ✅ Using IOVA addresses for GPU access\n");
-      pr_info("  Note: These are admin queue IOVAs\n");
-      pr_info("  I/O queue IOVAs will be retrieved when queues are created\n");
+      dev_info(&pdev->dev,
+               "nvme_axiio: ✅ Using IOVA addresses for GPU access\n");
+      dev_info(&pdev->dev, "  Note: These are admin queue IOVAs\n");
+      dev_info(&pdev->dev,
+               "  I/O queue IOVAs will be retrieved when queues are created\n");
     } else {
-      pr_warn("nvme_axiio: QEMU detected but P2P IOVA unavailable\n");
-      pr_warn("  Will fall back to physical addresses\n");
+      dev_warn(&pdev->dev,
+               "nvme_axiio: QEMU detected but P2P IOVA unavailable\n");
+      dev_warn(&pdev->dev, "  Will fall back to physical addresses\n");
     }
   }
 
-  pr_info("nvme_axiio: ✓ Controller initialized and ready\n");
-  pr_info("  Admin queue: SQ/CQ size=64 entries\n");
-  pr_info("  Max I/O queue size: %u entries\n", axiio_ctrl->max_queue_entries);
-  pr_info("  Controller is now under AXIIO control\n");
-  pr_info("  WARNING: Device is no longer accessible via /dev/nvmeX\n");
+  dev_info(&pdev->dev, "nvme_axiio: ✓ Controller initialized and ready\n");
+  dev_info(&pdev->dev, "  Admin queue: SQ/CQ size=64 entries\n");
+  dev_info(&pdev->dev, "  Max I/O queue size: %u entries\n",
+           axiio_ctrl->max_queue_entries);
+  dev_info(&pdev->dev, "  Controller is now under AXIIO control\n");
+  dev_info(&pdev->dev,
+           "  WARNING: Device is no longer accessible via /dev/nvmeX\n");
 
   /* Store device reference */
   axiio_bound_pci_dev = pdev;
@@ -207,7 +217,8 @@ release_regions:
 static void nvme_axiio_pci_remove(struct pci_dev* pdev) {
   struct axiio_controller* ctrl;
 
-  pr_info("nvme_axiio: PCI remove called for device %s\n", pci_name(pdev));
+  dev_info(&pdev->dev, "nvme_axiio: PCI remove called for device %s\n",
+           pci_name(pdev));
 
   /* Get controller context from driver data */
   ctrl = pci_get_drvdata(pdev);
@@ -235,9 +246,10 @@ static void nvme_axiio_pci_remove(struct pci_dev* pdev) {
   }
   axiio_ctrl = NULL;
 
-  pr_info("nvme_axiio: ✓ Device %s released\n", pci_name(pdev));
-  pr_info("  Controller shut down cleanly\n");
-  pr_info("  Device can now be bound back to kernel nvme driver\n");
+  dev_info(&pdev->dev, "nvme_axiio: ✓ Device %s released\n", pci_name(pdev));
+  dev_info(&pdev->dev, "  Controller shut down cleanly\n");
+  dev_info(&pdev->dev,
+           "  Device can now be bound back to kernel nvme driver\n");
 }
 
 /*
@@ -263,8 +275,9 @@ static inline int nvme_axiio_register_pci_driver(void) {
   }
 
   pr_info("nvme_axiio: PCI driver registered\n");
-  pr_info("  Devices can now be bound via sysfs:\n");
-  pr_info("    echo 0000:XX:00.0 > /sys/bus/pci/drivers/nvme_axiio/bind\n");
+  pr_info("nvme_axiio: Devices can now be bound via sysfs:\n");
+  pr_info(
+    "nvme_axiio:   echo 0000:XX:00.0 > /sys/bus/pci/drivers/nvme_axiio/bind\n");
 
   return 0;
 }
@@ -323,12 +336,14 @@ static inline int nvme_axiio_create_io_queues(u16 qid, u16 qsize,
   /* Try to delete existing queues first (in case of previous crash) */
   pci_info(ctrl->pdev,
            "nvme_axiio: Cleaning up any existing queues (qid=%u)...\n", qid);
-  nvme_delete_io_sq_cmd(ctrl->bar0, &ctrl->admin_q, qid); // Ignore error
-  nvme_delete_io_cq_cmd(ctrl->bar0, &ctrl->admin_q, qid); // Ignore error
+  nvme_delete_io_sq_cmd(&ctrl->pdev->dev, ctrl->bar0, &ctrl->admin_q,
+                        qid); // Ignore error
+  nvme_delete_io_cq_cmd(&ctrl->pdev->dev, ctrl->bar0, &ctrl->admin_q,
+                        qid); // Ignore error
 
   /* Create CQ first */
-  ret = nvme_create_io_cq_cmd(ctrl->bar0, &ctrl->admin_q, qid, qsize, cq_dma,
-                              0);
+  ret = nvme_create_io_cq_cmd(&ctrl->pdev->dev, ctrl->bar0, &ctrl->admin_q, qid,
+                              qsize, cq_dma, 0);
   if (ret < 0) {
     pci_err(ctrl->pdev, "nvme_axiio: Failed to create I/O CQ %u: %d\n", qid,
             ret);
@@ -338,18 +353,19 @@ static inline int nvme_axiio_create_io_queues(u16 qid, u16 qsize,
   pci_info(ctrl->pdev, "nvme_axiio: ✓ I/O CQ %u created\n", qid);
 
   /* Create SQ */
-  ret = nvme_create_io_sq_cmd(ctrl->bar0, &ctrl->admin_q, qid, qid, qsize,
-                              sq_dma);
+  ret = nvme_create_io_sq_cmd(&ctrl->pdev->dev, ctrl->bar0, &ctrl->admin_q, qid,
+                              qid, qsize, sq_dma);
   if (ret < 0) {
     pci_err(ctrl->pdev, "nvme_axiio: Failed to create I/O SQ %u: %d\n", qid,
             ret);
     /* Try to clean up CQ */
-    nvme_delete_io_cq_cmd(ctrl->bar0, &ctrl->admin_q, qid);
+    nvme_delete_io_cq_cmd(&ctrl->pdev->dev, ctrl->bar0, &ctrl->admin_q, qid);
     return ret;
   }
 
-  pr_info("nvme_axiio: ✓ I/O SQ %u created\n", qid);
-  pr_info("nvme_axiio: ✓ I/O queue pair %u ready for GPU-direct I/O!\n", qid);
+  pci_info(ctrl->pdev, "nvme_axiio: ✓ I/O SQ %u created\n", qid);
+  pci_info(ctrl->pdev,
+           "nvme_axiio: ✓ I/O queue pair %u ready for GPU-direct I/O!\n", qid);
 
   return 0;
 }

--- a/kernel-module/nvme_controller_init.h
+++ b/kernel-module/nvme_controller_init.h
@@ -54,8 +54,8 @@ struct nvme_admin_queue {
 /*
  * Wait for controller status bit
  */
-static inline int nvme_wait_csts(void __iomem* bar0, u32 mask, u32 val,
-                                 unsigned timeout_ms) {
+static inline int nvme_wait_csts(struct device* dev, void __iomem* bar0,
+                                 u32 mask, u32 val, unsigned timeout_ms) {
   unsigned long timeout = jiffies + msecs_to_jiffies(timeout_ms);
   u32 csts;
 
@@ -66,35 +66,37 @@ static inline int nvme_wait_csts(void __iomem* bar0, u32 mask, u32 val,
     msleep(10);
   }
 
-  pr_err("nvme_axiio: Timeout waiting for CSTS 0x%x (got 0x%x)\n", val, csts);
+  dev_err(dev, "nvme_axiio: Timeout waiting for CSTS 0x%x (got 0x%x)\n", val,
+          csts);
   return -ETIMEDOUT;
 }
 
 /*
  * Disable controller
  */
-static inline int nvme_disable_ctrl(void __iomem* bar0) {
+static inline int nvme_disable_ctrl(struct device* dev, void __iomem* bar0) {
   u32 cc;
 
-  pr_info("nvme_axiio: Disabling controller...\n");
+  dev_info(dev, "nvme_axiio: Disabling controller...\n");
 
   cc = readl(bar0 + NVME_REG_CC);
   cc &= ~NVME_CC_ENABLE;
   writel(cc, bar0 + NVME_REG_CC);
 
   /* Wait for controller to indicate ready=0 */
-  return nvme_wait_csts(bar0, NVME_CSTS_RDY, 0, 5000);
+  return nvme_wait_csts(dev, bar0, NVME_CSTS_RDY, 0, 5000);
 }
 
 /*
  * Enable controller
  */
-static inline int nvme_enable_ctrl(void __iomem* bar0, u32 page_size_shift) {
+static inline int nvme_enable_ctrl(struct device* dev, void __iomem* bar0,
+                                   u32 page_size_shift) {
   u32 cc;
   u64 cap;
   u32 mps;
 
-  pr_info("nvme_axiio: Enabling controller...\n");
+  dev_info(dev, "nvme_axiio: Enabling controller...\n");
 
   /* Read CAP to get page size requirements */
   cap = readq(bar0 + NVME_REG_CAP);
@@ -106,10 +108,10 @@ static inline int nvme_enable_ctrl(void __iomem* bar0, u32 page_size_shift) {
 
   writel(cc, bar0 + NVME_REG_CC);
 
-  pr_info("nvme_axiio: CC register: 0x%08x\n", cc);
+  dev_info(dev, "nvme_axiio: CC register: 0x%08x\n", cc);
 
   /* Wait for controller to become ready */
-  return nvme_wait_csts(bar0, NVME_CSTS_RDY, NVME_CSTS_RDY, 10000);
+  return nvme_wait_csts(dev, bar0, NVME_CSTS_RDY, NVME_CSTS_RDY, 10000);
 }
 
 /*
@@ -121,14 +123,15 @@ static inline int nvme_init_admin_queue(struct device* dev, void __iomem* bar0,
   u32 aqa;
   int ret;
 
-  pr_info("nvme_axiio: Initializing admin queue (size=%u)...\n", queue_size);
+  dev_info(dev, "nvme_axiio: Initializing admin queue (size=%u)...\n",
+           queue_size);
 
   /* Allocate admin submission queue */
   admin_q->queue_size = queue_size;
   admin_q->sq_virt = dma_alloc_coherent(dev, queue_size * 64, &admin_q->sq_dma,
                                         GFP_KERNEL);
   if (!admin_q->sq_virt) {
-    pr_err("nvme_axiio: Failed to allocate admin SQ\n");
+    dev_err(dev, "nvme_axiio: Failed to allocate admin SQ\n");
     return -ENOMEM;
   }
   memset(admin_q->sq_virt, 0, queue_size * 64);
@@ -137,7 +140,7 @@ static inline int nvme_init_admin_queue(struct device* dev, void __iomem* bar0,
   admin_q->cq_virt = dma_alloc_coherent(dev, queue_size * 16, &admin_q->cq_dma,
                                         GFP_KERNEL);
   if (!admin_q->cq_virt) {
-    pr_err("nvme_axiio: Failed to allocate admin CQ\n");
+    dev_err(dev, "nvme_axiio: Failed to allocate admin CQ\n");
     dma_free_coherent(dev, queue_size * 64, admin_q->sq_virt, admin_q->sq_dma);
     return -ENOMEM;
   }
@@ -148,32 +151,36 @@ static inline int nvme_init_admin_queue(struct device* dev, void __iomem* bar0,
   admin_q->cq_phase = 1;
   spin_lock_init(&admin_q->sq_lock);
 
-  pr_info("nvme_axiio: Admin queues allocated:\n");
-  pr_info("  ASQ: virt=%p dma=0x%llx\n", admin_q->sq_virt,
-          (u64)admin_q->sq_dma);
-  pr_info("  ACQ: virt=%p dma=0x%llx\n", admin_q->cq_virt,
-          (u64)admin_q->cq_dma);
+  dev_info(dev, "nvme_axiio: Admin queues allocated:\n");
+  dev_info(dev, "  ASQ: virt=%p dma=0x%llx\n", admin_q->sq_virt,
+           (u64)admin_q->sq_dma);
+  dev_info(dev, "  ACQ: virt=%p dma=0x%llx\n", admin_q->cq_virt,
+           (u64)admin_q->cq_dma);
 
   /* Check controller state - don't disable real hardware */
   /* Real hardware controllers are typically already disabled when unbound from
    * nvme driver */
   u32 csts = readl(bar0 + NVME_REG_CSTS);
-  pr_info("nvme_axiio: Controller status (CSTS): 0x%x\n", csts);
+  dev_info(dev, "nvme_axiio: Controller status (CSTS): 0x%x\n", csts);
 
   if (csts & NVME_CSTS_RDY) {
     /* Controller is enabled - try to disable (only works for QEMU) */
-    pr_info("nvme_axiio: Controller is enabled, attempting to disable...\n");
-    ret = nvme_disable_ctrl(bar0);
+    dev_info(dev,
+             "nvme_axiio: Controller is enabled, attempting to disable...\n");
+    ret = nvme_disable_ctrl(dev, bar0);
     if (ret < 0) {
       /* Disable failed - likely real hardware that we shouldn't disable */
-      pr_warn(
+      dev_warn(
+        dev,
         "nvme_axiio: Failed to disable controller (may be real hardware)\n");
-      pr_warn("nvme_axiio: Continuing anyway - controller may already be in "
-              "correct state\n");
+      dev_warn(dev,
+               "nvme_axiio: Continuing anyway - controller may already be in "
+               "correct state\n");
       /* Don't fail - continue with initialization */
     }
   } else {
-    pr_info("nvme_axiio: Controller already disabled (CSTS=0x%x)\n", csts);
+    dev_info(dev, "nvme_axiio: Controller already disabled (CSTS=0x%x)\n",
+             csts);
   }
 
   /* Configure admin queue attributes */
@@ -184,19 +191,19 @@ static inline int nvme_init_admin_queue(struct device* dev, void __iomem* bar0,
   writeq(admin_q->sq_dma, bar0 + NVME_REG_ASQ);
   writeq(admin_q->cq_dma, bar0 + NVME_REG_ACQ);
 
-  pr_info("nvme_axiio: Admin queue registers configured:\n");
-  pr_info("  AQA: 0x%08x\n", aqa);
-  pr_info("  ASQ: 0x%016llx\n", admin_q->sq_dma);
-  pr_info("  ACQ: 0x%016llx\n", admin_q->cq_dma);
+  dev_info(dev, "nvme_axiio: Admin queue registers configured:\n");
+  dev_info(dev, "  AQA: 0x%08x\n", aqa);
+  dev_info(dev, "  ASQ: 0x%016llx\n", admin_q->sq_dma);
+  dev_info(dev, "  ACQ: 0x%016llx\n", admin_q->cq_dma);
 
   /* Enable controller */
-  ret = nvme_enable_ctrl(bar0, PAGE_SHIFT);
+  ret = nvme_enable_ctrl(dev, bar0, PAGE_SHIFT);
   if (ret < 0) {
-    pr_err("nvme_axiio: Failed to enable controller\n");
+    dev_err(dev, "nvme_axiio: Failed to enable controller\n");
     goto free_queues;
   }
 
-  pr_info("nvme_axiio: ✓ Controller enabled, admin queue ready\n");
+  dev_info(dev, "nvme_axiio: ✓ Controller enabled, admin queue ready\n");
   return 0;
 
 free_queues:
@@ -211,10 +218,10 @@ free_queues:
 static inline void nvme_shutdown_admin_queue(struct device* dev,
                                              void __iomem* bar0,
                                              struct nvme_admin_queue* admin_q) {
-  pr_info("nvme_axiio: Shutting down admin queue...\n");
+  dev_info(dev, "nvme_axiio: Shutting down admin queue...\n");
 
   /* Disable controller */
-  nvme_disable_ctrl(bar0);
+  nvme_disable_ctrl(dev, bar0);
 
   /* Free admin queues */
   if (admin_q->cq_virt) {
@@ -229,7 +236,7 @@ static inline void nvme_shutdown_admin_queue(struct device* dev,
     admin_q->sq_virt = NULL;
   }
 
-  pr_info("nvme_axiio: ✓ Admin queue shut down\n");
+  dev_info(dev, "nvme_axiio: ✓ Admin queue shut down\n");
 }
 
 /*

--- a/kernel-module/nvme_gpu_doorbell.h
+++ b/kernel-module/nvme_gpu_doorbell.h
@@ -27,7 +27,8 @@
 /*
  * Setup VMA for GPU-accessible doorbell mapping
  */
-static inline int nvme_setup_gpu_doorbell_vma(struct vm_area_struct* vma,
+static inline int nvme_setup_gpu_doorbell_vma(struct device* dev,
+                                              struct vm_area_struct* vma,
                                               resource_size_t doorbell_phys,
                                               size_t size) {
   unsigned long pfn;
@@ -37,10 +38,10 @@ static inline int nvme_setup_gpu_doorbell_vma(struct vm_area_struct* vma,
   unsigned long page_base = doorbell_phys & PAGE_MASK;
   pfn = page_base >> PAGE_SHIFT;
 
-  pr_info("nvme_axiio: Setting up GPU doorbell mapping\n");
-  pr_info("  Physical address: 0x%llx\n", (u64)doorbell_phys);
-  pr_info("  PFN: 0x%lx\n", pfn);
-  pr_info("  Size: %zu bytes\n", size);
+  dev_info(dev, "nvme_axiio: Setting up GPU doorbell mapping\n");
+  dev_info(dev, "  Physical address: 0x%llx\n", (u64)doorbell_phys);
+  dev_info(dev, "  PFN: 0x%lx\n", pfn);
+  dev_info(dev, "  Size: %zu bytes\n", size);
 
   /* Set GPU-compatible page protection */
   vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
@@ -51,13 +52,13 @@ static inline int nvme_setup_gpu_doorbell_vma(struct vm_area_struct* vma,
   /* Map physical pages to userspace */
   ret = remap_pfn_range(vma, vma->vm_start, pfn, size, vma->vm_page_prot);
   if (ret < 0) {
-    pr_err("nvme_axiio: remap_pfn_range failed: %d\n", ret);
+    dev_err(dev, "nvme_axiio: remap_pfn_range failed: %d\n", ret);
     return ret;
   }
 
-  pr_info("nvme_axiio: ✓ GPU doorbell mapped with WC+IO flags\n");
-  pr_info("  Userspace VA: 0x%lx\n", vma->vm_start);
-  pr_info("  GPU can now write with system-scope atomics!\n");
+  dev_info(dev, "nvme_axiio: ✓ GPU doorbell mapped with WC+IO flags\n");
+  dev_info(dev, "  Userspace VA: 0x%lx\n", vma->vm_start);
+  dev_info(dev, "  GPU can now write with system-scope atomics!\n");
 
   return 0;
 }

--- a/kernel-module/nvme_gpu_integration.h
+++ b/kernel-module/nvme_gpu_integration.h
@@ -45,26 +45,27 @@ struct nvme_gpu_mapping {
  *
  * Similar to how rocSHMEM GDA maps InfiniBand doorbells.
  */
-static inline int nvme_map_doorbell_for_gpu(struct nvme_gpu_mapping* mapping,
+static inline int nvme_map_doorbell_for_gpu(struct device* dev,
+                                            struct nvme_gpu_mapping* mapping,
                                             int gpu_fd,
                                             resource_size_t doorbell_phys,
                                             size_t size) {
   struct file* gpu_file;
 
-  pr_info("nvme_axiio: Setting up GPU doorbell mapping...\n");
-  pr_info("  GPU FD: %d\n", gpu_fd);
-  pr_info("  Doorbell phys: 0x%llx\n", (u64)doorbell_phys);
-  pr_info("  Size: %zu bytes\n", size);
+  dev_info(dev, "nvme_axiio: Setting up GPU doorbell mapping...\n");
+  dev_info(dev, "  GPU FD: %d\n", gpu_fd);
+  dev_info(dev, "  Doorbell phys: 0x%llx\n", (u64)doorbell_phys);
+  dev_info(dev, "  Size: %zu bytes\n", size);
 
   /* Get GPU device file to verify it's valid */
   gpu_file = fget(gpu_fd);
   if (!gpu_file) {
-    pr_err("nvme_axiio: Invalid GPU file descriptor\n");
+    dev_err(dev, "nvme_axiio: Invalid GPU file descriptor\n");
     return -EBADF;
   }
 
-  pr_info("nvme_axiio: GPU file descriptor valid\n");
-  pr_info("  File: %s\n", gpu_file->f_path.dentry->d_name.name);
+  dev_info(dev, "nvme_axiio: GPU file descriptor valid\n");
+  dev_info(dev, "  File: %s\n", gpu_file->f_path.dentry->d_name.name);
 
   /*
    * Strategy for GPU-direct doorbell:
@@ -85,9 +86,9 @@ static inline int nvme_map_doorbell_for_gpu(struct nvme_gpu_mapping* mapping,
   mapping->size = size;
   mapping->mapped = false;
 
-  pr_info("nvme_axiio: ✓ GPU mapping context prepared\n");
-  pr_info("  mmap will use GPU-aware VMA flags\n");
-  pr_info("  GPU driver should handle MMU setup via page faults\n");
+  dev_info(dev, "nvme_axiio: ✓ GPU mapping context prepared\n");
+  dev_info(dev, "  mmap will use GPU-aware VMA flags\n");
+  dev_info(dev, "  GPU driver should handle MMU setup via page faults\n");
 
   /* Actual mapping happens in mmap handler */
   return 0;
@@ -97,13 +98,13 @@ static inline int nvme_map_doorbell_for_gpu(struct nvme_gpu_mapping* mapping,
  * Unmap doorbell from GPU
  */
 static inline void nvme_unmap_doorbell_from_gpu(
-  struct nvme_gpu_mapping* mapping) {
+  struct device* dev, struct nvme_gpu_mapping* mapping) {
   if (mapping->gpu_file) {
     fput(mapping->gpu_file);
     mapping->gpu_file = NULL;
   }
   mapping->mapped = false;
-  pr_info("nvme_axiio: GPU doorbell unmapped\n");
+  dev_info(dev, "nvme_axiio: GPU doorbell unmapped\n");
 }
 
 /*
@@ -129,31 +130,34 @@ static inline int nvme_mmap_doorbell_for_gpu(
       /* Use queue-specific IOVA - QEMU has mapped this in GPU's VFIO container
        */
       doorbell_addr = queue_iova.doorbell_iova;
-      pr_info(
+      dev_info(
+        &pdev->dev,
         "nvme_axiio: Using queue-specific IOVA address for GPU mapping\n");
-      pr_info("  Queue ID: %u\n", (unsigned int)queue_id);
-      pr_info("  IOVA: 0x%llx\n", (u64)doorbell_addr);
+      dev_info(&pdev->dev, "  Queue ID: %u\n", (unsigned int)queue_id);
+      dev_info(&pdev->dev, "  IOVA: 0x%llx\n", (u64)doorbell_addr);
     } else {
       /* Fallback to controller base IOVA */
       doorbell_addr = ctrl->p2p_iova.doorbell_iova;
-      pr_info("nvme_axiio: Using controller base IOVA for GPU mapping\n");
-      pr_info("  IOVA: 0x%llx\n", (u64)doorbell_addr);
+      dev_info(&pdev->dev,
+               "nvme_axiio: Using controller base IOVA for GPU mapping\n");
+      dev_info(&pdev->dev, "  IOVA: 0x%llx\n", (u64)doorbell_addr);
     }
   } else {
     /* Use physical address */
     doorbell_addr = gpu_mapping->doorbell_phys;
-    pr_info("nvme_axiio: Using physical address for GPU mapping\n");
-    pr_info("  Physical: 0x%llx\n", (u64)doorbell_addr);
+    dev_info(&pdev->dev,
+             "nvme_axiio: Using physical address for GPU mapping\n");
+    dev_info(&pdev->dev, "  Physical: 0x%llx\n", (u64)doorbell_addr);
   }
 
   /* Align doorbell to page boundary */
   unsigned long page_base = doorbell_addr & PAGE_MASK;
   pfn = page_base >> PAGE_SHIFT;
 
-  pr_info("nvme_axiio: GPU-aware mmap setup\n");
-  pr_info("  PFN: 0x%lx\n", pfn);
-  pr_info("  VMA start: 0x%lx\n", vma->vm_start);
-  pr_info("  Size: %zu\n", gpu_mapping->size);
+  dev_info(&pdev->dev, "nvme_axiio: GPU-aware mmap setup\n");
+  dev_info(&pdev->dev, "  PFN: 0x%lx\n", pfn);
+  dev_info(&pdev->dev, "  VMA start: 0x%lx\n", vma->vm_start);
+  dev_info(&pdev->dev, "  Size: %zu\n", gpu_mapping->size);
 
   /*
    * Critical flags for GPU accessibility:
@@ -183,12 +187,15 @@ static inline int nvme_mmap_doorbell_for_gpu(
      * handles it. However, we still need to set up the VMA properly so mmap
      * succeeds. We'll create an anonymous mapping that userspace can use.
      */
-    pr_info(
+    dev_info(
+      &pdev->dev,
       "nvme_axiio: IOVA mode - setting up VMA for userspace IOVA mapping\n");
-    pr_info("  IOVA address: 0x%llx (userspace will map this directly)\n",
-            (u64)doorbell_addr);
-    pr_info("  Physical BAR0: 0x%llx (not used for GPU in IOVA mode)\n",
-            (u64)gpu_mapping->doorbell_phys);
+    dev_info(&pdev->dev,
+             "  IOVA address: 0x%llx (userspace will map this directly)\n",
+             (u64)doorbell_addr);
+    dev_info(&pdev->dev,
+             "  Physical BAR0: 0x%llx (not used for GPU in IOVA mode)\n",
+             (u64)gpu_mapping->doorbell_phys);
 
     /* For IOVA mode, we don't map physical BAR0 here.
      * Instead, we set up the VMA to allow userspace to map the IOVA address.
@@ -207,8 +214,9 @@ static inline int nvme_mmap_doorbell_for_gpu(
     /* Just mark the VMA as valid - userspace mapping will happen separately */
     ret = 0; /* Success - VMA is set up, userspace will do the actual mapping */
 
-    pr_info("nvme_axiio: ✓ VMA set up for IOVA mode (userspace will map IOVA "
-            "directly)\n");
+    dev_info(&pdev->dev,
+             "nvme_axiio: ✓ VMA set up for IOVA mode (userspace will map IOVA "
+             "directly)\n");
   } else {
     /* Physical mode: Use remap_pfn_range with physical PFN */
     ret = remap_pfn_range(vma, vma->vm_start, pfn, gpu_mapping->size,
@@ -216,16 +224,16 @@ static inline int nvme_mmap_doorbell_for_gpu(
   }
 
   if (ret < 0) {
-    pr_err("nvme_axiio: remap_pfn_range failed: %d\n", ret);
+    dev_err(&pdev->dev, "nvme_axiio: remap_pfn_range failed: %d\n", ret);
     return ret;
   }
 
   gpu_mapping->gpu_va = (void __user*)vma->vm_start;
   gpu_mapping->mapped = true;
 
-  pr_info("nvme_axiio: ✓ GPU doorbell mapped!\n");
-  pr_info("  GPU VA: 0x%lx\n", vma->vm_start);
-  pr_info("  GPU can now access doorbell!\n");
+  dev_info(&pdev->dev, "nvme_axiio: ✓ GPU doorbell mapped!\n");
+  dev_info(&pdev->dev, "  GPU VA: 0x%lx\n", vma->vm_start);
+  dev_info(&pdev->dev, "  GPU can now access doorbell!\n");
 
   return 0;
 }

--- a/kernel-module/nvme_p2p_iova.h
+++ b/kernel-module/nvme_p2p_iova.h
@@ -54,14 +54,15 @@ static inline int nvme_get_p2p_iova_info(void __iomem* bar0,
   u32 result;
   int ret;
 
-  pr_info("nvme_axiio: Requesting P2P IOVA info for QID %u from QEMU (vendor "
-          "cmd 0xC0)...\n",
-          queue_id);
+  dev_info(dev,
+           "nvme_axiio: Requesting P2P IOVA info for QID %u from QEMU (vendor "
+           "cmd 0xC0)...\n",
+           queue_id);
 
   /* Allocate DMA buffer for IOVA info */
   buffer = dma_alloc_coherent(dev, sizeof(*iova_info), &dma_addr, GFP_KERNEL);
   if (!buffer) {
-    pr_err("nvme_axiio: Failed to allocate IOVA info buffer\n");
+    dev_err(dev, "nvme_axiio: Failed to allocate IOVA info buffer\n");
     return -ENOMEM;
   }
 
@@ -75,27 +76,28 @@ static inline int nvme_get_p2p_iova_info(void __iomem* bar0,
 
   /* Submit command */
   /* Use longer timeout for real hardware (30 seconds) vs QEMU (5 seconds) */
-  ret = nvme_submit_admin_cmd_sync(bar0, admin_q, &cmd, &result, 30000);
+  ret = nvme_submit_admin_cmd_sync(dev, bar0, admin_q, &cmd, &result, 30000);
 
   if (ret == 0) {
     /* Copy IOVA info from DMA buffer */
     memcpy(iova_info, buffer, sizeof(*iova_info));
 
-    pr_info("nvme_axiio: ✅ P2P IOVA mappings retrieved from QEMU:\n");
-    pr_info("  SQE IOVA:      0x%016llx (size: %u bytes)\n",
-            iova_info->sqe_iova, iova_info->sqe_size);
-    pr_info("  CQE IOVA:      0x%016llx (size: %u bytes)\n",
-            iova_info->cqe_iova, iova_info->cqe_size);
-    pr_info("  Doorbell IOVA: 0x%016llx (size: %u bytes)\n",
-            iova_info->doorbell_iova, iova_info->doorbell_size);
-    pr_info("  Queue depth:   %u\n", iova_info->queue_depth);
-    pr_info("  🎉 QEMU P2P setup complete - GPU can access these IOVAs!\n");
+    dev_info(dev, "nvme_axiio: ✅ P2P IOVA mappings retrieved from QEMU:\n");
+    dev_info(dev, "  SQE IOVA:      0x%016llx (size: %u bytes)\n",
+             iova_info->sqe_iova, iova_info->sqe_size);
+    dev_info(dev, "  CQE IOVA:      0x%016llx (size: %u bytes)\n",
+             iova_info->cqe_iova, iova_info->cqe_size);
+    dev_info(dev, "  Doorbell IOVA: 0x%016llx (size: %u bytes)\n",
+             iova_info->doorbell_iova, iova_info->doorbell_size);
+    dev_info(dev, "  Queue depth:   %u\n", iova_info->queue_depth);
+    dev_info(dev,
+             "  🎉 QEMU P2P setup complete - GPU can access these IOVAs!\n");
   } else if (ret == -EIO) {
-    pr_warn("nvme_axiio: Vendor command 0xC0 failed (not supported)\n");
-    pr_warn("  This is expected for real hardware (not emulated)\n");
-    pr_warn("  Will use physical addresses instead of IOVA\n");
+    dev_warn(dev, "nvme_axiio: Vendor command 0xC0 failed (not supported)\n");
+    dev_warn(dev, "  This is expected for real hardware (not emulated)\n");
+    dev_warn(dev, "  Will use physical addresses instead of IOVA\n");
   } else {
-    pr_err("nvme_axiio: Failed to get P2P IOVA info: %d\n", ret);
+    dev_err(dev, "nvme_axiio: Failed to get P2P IOVA info: %d\n", ret);
   }
 
   dma_free_coherent(dev, sizeof(*iova_info), buffer, dma_addr);
@@ -113,18 +115,18 @@ static inline bool is_qemu_emulated_nvme(struct pci_dev* pdev) {
   /* Check for QEMU vendor IDs */
   if (pdev->vendor == 0x1b36 ||           /* Red Hat / QEMU */
       pdev->subsystem_vendor == 0x1af4) { /* virtio */
-    pr_info("nvme_axiio: Detected QEMU emulated NVMe device\n");
+    dev_info(&pdev->dev, "nvme_axiio: Detected QEMU emulated NVMe device\n");
     return true;
   }
 
   /* Also check device ID - QEMU often uses specific IDs */
   if (pdev->device == 0x0010 && pdev->vendor == 0x1b36) {
-    pr_info("nvme_axiio: Detected QEMU NVMe controller\n");
+    dev_info(&pdev->dev, "nvme_axiio: Detected QEMU NVMe controller\n");
     return true;
   }
 
-  pr_debug("nvme_axiio: Real hardware NVMe device (vendor=0x%04x)\n",
-           pdev->vendor);
+  dev_dbg(&pdev->dev, "nvme_axiio: Real hardware NVMe device (vendor=0x%04x)\n",
+          pdev->vendor);
   return false;
 }
 


### PR DESCRIPTION
Replace all pr_info/pr_err/pr_warn/pr_debug calls with device-aware dev_info/dev_err/dev_warn/dev_dbg equivalents throughout the kernel module. This provides better kernel log filtering and debugging capabilities by associating log messages with specific PCI devices.

Changes:
- Replace ~200+ pr_* calls with dev_* equivalents using &pdev->dev or dev parameter
- Add struct device* dev parameter to functions that needed it:
  * nvme_submit_admin_cmd_sync()
  * nvme_create_io_cq_cmd()
  * nvme_create_io_sq_cmd()
  * nvme_delete_io_sq_cmd()
  * nvme_delete_io_cq_cmd()
  * nvme_wait_csts()
  * nvme_disable_ctrl()
  * nvme_enable_ctrl()
  * nvme_setup_gpu_doorbell_vma()
  * nvme_map_doorbell_for_gpu()
  * nvme_unmap_doorbell_from_gpu()
- Update all call sites to pass device pointer appropriately
- Keep pr_* for module init/exit and device search functions where no device context is available (appropriate use case)

Makefile improvements:
- Enhance install target with better feedback and DESTDIR support
- Add uninstall target for module removal
- Make depmod conditional (skip when using DESTDIR for packaging)
- Add INSTALL_MOD_DIR variable (defaults to 'extra')

This change improves kernel log management and follows Linux kernel best practices for device driver logging.

Tested: Module compiles and loads successfully in VM with QEMU emulated NVMe.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
