### PR TITLE
tester: Refactor CLI to endpoint-specific options with organized help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ LIB_OBJECTS += $(ENDPOINT_DISPATCH_OBJ)
 # Tester source file
 TESTER_SOURCE := $(TESTER_DIR)/axiio-tester.hip
 TESTER_OBJECT := $(BUILD_DIR)/$(TESTER_SOURCE:.hip=.o)
+# Tester depends on endpoint headers it includes (all endpoint headers)
+TESTER_HEADERS := $(call rwildcard,$(ENDPOINTS_DIR),*.h) \
+                  $(call rwildcard,$(INCLUDE_DIR),*.h)
 
 # GPU architecture
 OFFLOAD_ARCH ?=
@@ -163,6 +166,9 @@ fetch-external-headers: fetch-nvme-headers fetch-rdma-headers
 
 $(LIBTARGET): $(LIB_OBJECTS) $(LIB_HEADERS) | $(LIB_DIR)
 	$(AR) rcsD $@ $(LIB_OBJECTS)
+
+# Make tester object depend on headers it includes
+$(TESTER_OBJECT): $(TESTER_HEADERS) $(ENDPOINT_REGISTRY_GEN)
 
 $(TESTER): $(TESTER_OBJECT) $(LIBTARGET) | $(BIN_DIR)
 	$(HIPCXX) $(CXXFLAGS) -I$(INCLUDE_DIR) -o $@ $^ -lhsa-runtime64

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ sudo ./bin/axiio-tester --nvme-device /dev/nvme0 -n 100 --verbose
 
 | Use Case | Command |
 |----------|---------|
-| **Test with real NVMe** | `sudo ./bin/axiio-tester --nvme-device /dev/nvme0` |
-| **CPU-only mode** | `sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --cpu-only` |
-| **Use kernel module** | `sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --use-kernel-module` |
-| **Performance test** | `sudo ./bin/axiio-tester --nvme-device /dev/nvme0 -n 10000 --histogram` |
+| **Test with real NVMe** | `sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0` |
+| **CPU-only mode** | `sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 --cpu-only` |
+| **Use kernel module** | `sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 --kernel-module` |
+| **Performance test** | `sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 -n 10000 --histogram` |
 | **List endpoints** | `./bin/axiio-tester -e` |
 | **Emulated test** | `./bin/axiio-tester -n 100 --verbose` |
 
@@ -127,10 +127,10 @@ All endpoints are built into the binary.
 ./bin/axiio-tester --endpoint nvme-ep -n 100
 
 # Use NVMe endpoint with real hardware
-sudo ./bin/axiio-tester --endpoint nvme-ep --nvme-device /dev/nvme0
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0
 
-# The endpoint is auto-selected when using --nvme-device
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0  # Uses nvme-ep automatically
+# View endpoint-specific options
+./bin/axiio-tester -e nvme-ep --help
 ```
 
 The build system compiles all endpoints and uses static dispatch to route operations to the correct endpoint at runtime.
@@ -477,14 +477,12 @@ GPU-to-NVMe interactions without emulation.
 sudo ./scripts/discover-nvme-addresses.sh
 
 # Run test with real hardware
-sudo ./bin/axiio-tester \
-  --endpoint nvme-ep \
-  --real-hardware \
-  --nvme-doorbell 0xfeb01000 \
-  --nvme-sq-base 0xfeb10000 \
-  --nvme-cq-base 0xfeb20000 \
-  --nvme-sq-size 4096 \
-  --nvme-cq-size 4096 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --doorbell 0xfeb01000 \
+  --sq-base 0xfeb10000 \
+  --cq-base 0xfeb20000 \
+  --sq-size 4096 \
+  --cq-size 4096 \
   --iterations 10 \
   --verbose
 ```
@@ -525,8 +523,8 @@ The simplest way to run with real NVMe hardware:
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
 # Run with automatic device setup
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
   --iterations 100 \
   --verbose
 ```
@@ -542,15 +540,15 @@ The kernel module (`/dev/nvme-axiio`) provides DMA-safe memory and proper queue 
 ```bash
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
-  --use-kernel-module \
-  --nvme-queue-id 63 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
+  --kernel-module \
+  --queue-id 63 \
   --iterations 100 \
   --transfer-size 4096 \
   --lba-range-gib 1 \
   --access-pattern random \
-  --nvme-nsid 1 \
+  --nsid 1 \
   --verbose
 ```
 
@@ -569,13 +567,13 @@ Direct device access with automatic address discovery.
 ```bash
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
   --iterations 100 \
   --transfer-size 4096 \
   --lba-range-gib 1 \
   --access-pattern random \
-  --nvme-nsid 1 \
+  --nsid 1 \
   --verbose
 ```
 
@@ -612,44 +610,35 @@ sudo ./bin/axiio-tester \
 
 #### Essential Arguments
 
-| Argument | Description | Example | Default |
-|----------|-------------|---------|---------|
-| `--nvme-device` | Path to NVMe device | `/dev/nvme0` | - |
-| `--iterations` | Number of I/O operations | `100` | 128 |
-| `--verbose` | Enable detailed output | flag | false |
-
-#### Hardware Control
+#### Global Options
 
 | Argument | Description | Example | Default |
 |----------|-------------|---------|---------|
-| `--use-kernel-module` | Use `/dev/nvme-axiio` kernel module | flag | false |
-| `--nvme-queue-id` | Queue ID (high IDs avoid kernel conflicts) | `63` | 63 |
-| `--cpu-only` | CPU command generation (no GPU atomics) | flag | false |
-| `--real-hardware` | Enable real hardware mode | flag | false |
+| `-n, --iterations` | Number of I/O operations | `100` | 128 |
+| `-v, --verbose` | Enable detailed output | flag | false |
+| `-i, --info` | Print GPU information | flag | false |
+| `--histogram` | Generate performance histogram | flag | false |
+| `-e, --endpoint` | Select endpoint or list available | `nvme-ep`, `test-ep` | test-ep |
+| `-m, --memory` | Memory type | `host`, `device` | host |
+| `--submit-queue-len` | Submission queue length | `1024` | 1024 |
+| `--complete-queue-len` | Completion queue length | `512` | 512 |
+| `--skip-atomics-check` | Skip PCIe atomics check | flag | false |
 
-#### I/O Parameters
+#### NVMe Endpoint Options (use with `-e nvme-ep`)
 
 | Argument | Description | Example | Default |
 |----------|-------------|---------|---------|
+| `--device` | Path to NVMe device | `/dev/nvme0` | - |
+| `--kernel-module` | Use `/dev/nvme-axiio` kernel module | flag | false |
+| `--queue-id` | Queue ID (high IDs avoid kernel conflicts) | `63` | 63 |
+| `--nsid` | NVMe namespace ID | `1` | 1 |
+| `--block-size` | NVMe block size | `512`, `4096` | 512 |
 | `--transfer-size` | Transfer size in bytes | `4096` | 4096 |
 | `--lba-range-gib` | LBA range to test in GiB | `10` | 1 |
 | `--access-pattern` | Access pattern | `random`, `sequential` | random |
-| `--nvme-nsid` | NVMe namespace ID | `1` | 1 |
-
-#### Queue Configuration
-
-| Argument | Description | Example | Default |
-|----------|-------------|---------|---------|
-| `--submit-queue-len` | Submission queue length | `1024` | 1024 |
-| `--complete-queue-len` | Completion queue length | `512` | 512 |
-
-#### Data Buffer Options
-
-| Argument | Description | Example | Default |
-|----------|-------------|---------|---------|
+| `--cpu-only` | CPU command generation (no GPU atomics) | flag | false |
 | `--use-data-buffers` | Enable data buffer testing | flag | false |
 | `--data-buffer-size` | Data buffer size in bytes | `1048576` | 1MB |
-| `--nvme-block-size` | NVMe block size | `512`, `4096` | 512 |
 | `--test-pattern` | Data pattern | `random`, `zeros`, `ones`, `sequential`, `block_id` | sequential |
 
 #### Output Control
@@ -667,8 +656,8 @@ sudo ./bin/axiio-tester \
 ```bash
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
   -n 10 \
   --verbose
 ```
@@ -678,8 +667,8 @@ sudo ./bin/axiio-tester \
 ```bash
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
   --iterations 10000 \
   --transfer-size 8192 \
   --lba-range-gib 10 \
@@ -692,11 +681,11 @@ sudo ./bin/axiio-tester \
 ```bash
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
   --use-data-buffers \
   --data-buffer-size 1048576 \
-  --nvme-block-size 512 \
+  --block-size 512 \
   --test-pattern random \
   --iterations 1000 \
   --verbose
@@ -707,8 +696,8 @@ sudo ./bin/axiio-tester \
 ```bash
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
   --transfer-size 131072 \
   --access-pattern sequential \
   --lba-range-gib 100 \
@@ -724,10 +713,10 @@ export HSA_FORCE_FINE_GRAIN_PCIE=1
 # Load kernel module first (if available)
 sudo modprobe nvme-axiio
 
-sudo ./bin/axiio-tester \
-  --nvme-device /dev/nvme0 \
-  --use-kernel-module \
-  --nvme-queue-id 63 \
+sudo ./bin/axiio-tester -e nvme-ep \
+  --device /dev/nvme0 \
+  --kernel-module \
+  --queue-id 63 \
   --iterations 1000 \
   --transfer-size 4096 \
   --verbose
@@ -766,14 +755,14 @@ Start with these steps to verify functionality:
 ./bin/axiio-tester -n 10 --verbose
 
 # 3. Test with CPU-only mode (validates NVMe access)
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --cpu-only -n 10 --verbose
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 --cpu-only -n 10 --verbose
 
 # 4. Test with GPU (requires PCIe atomics)
 export HSA_FORCE_FINE_GRAIN_PCIE=1
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0 -n 100 --verbose
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 -n 100 --verbose
 
 # 5. Performance benchmarking
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0 -n 10000 --histogram
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 -n 10000 --histogram
 ```
 
 ### GPU Doorbell Modes
@@ -821,7 +810,7 @@ make GPU_DIRECT_DOORBELL=0 all
 
 ```bash
 # Solution 1: Use CPU-only mode
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --cpu-only
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 --cpu-only
 
 # Solution 2: Enable PCIe atomics in BIOS/VM settings
 # (Requires system configuration changes)
@@ -834,17 +823,17 @@ sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --cpu-only
 lsmod | grep nvme
 
 # Try direct device access without kernel module
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --verbose
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 --verbose
 ```
 
 #### Issue: "Queue creation failed"
 
 ```bash
 # Try a different queue ID
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0 --nvme-queue-id 50
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0 --queue-id 50
 
 # Or use auto-detection (default behavior)
-sudo ./bin/axiio-tester --nvme-device /dev/nvme0
+sudo ./bin/axiio-tester -e nvme-ep --device /dev/nvme0
 ```
 
 #### Issue: GPU page faults

--- a/endpoints/nvme-ep/nvme-ep-cli.h
+++ b/endpoints/nvme-ep/nvme-ep-cli.h
@@ -1,0 +1,254 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef NVME_EP_CLI_H
+#define NVME_EP_CLI_H
+
+#include <string>
+
+#include <CLI/CLI.hpp>
+
+#include "nvme-ep-config.h"
+
+namespace nvme_ep {
+
+/**
+ * Register NVMe endpoint-specific CLI options
+ *
+ * This function registers all NVMe-specific command-line options with
+ * the CLI11 parser. Options are registered with shorter names (without
+ * --nvme- prefix) for cleaner CLI, but backward-compatible aliases
+ * are also provided.
+ *
+ * @param app CLI11 App object to add options to
+ * @param config Pointer to NvmeEpConfig structure to populate
+ */
+inline void registerCliOptions(CLI::App& app, NvmeEpConfig* config) {
+  // Group all NVMe endpoint-specific options together
+  // This ensures they appear in their own section below global options
+  const std::string nvme_group = "NVMe Endpoint Options";
+
+  // NVMe endpoint options in alphabetical order by long name
+  app
+    .add_option("--access-pattern", config->accessPattern,
+                "Access pattern: 'sequential' or 'random'.")
+    ->default_val("random")
+    ->check(CLI::IsMember({"sequential", "random"}))
+    ->group(nvme_group);
+
+  app
+    .add_option("--block-size", config->blockSize,
+                "NVMe block size in bytes (typically 512 or 4096).")
+    ->default_val(512)
+    ->check(CLI::PositiveNumber)
+    ->group(nvme_group);
+
+  app
+    .add_flag(
+      "--cpu-only", config->cpuOnlyMode,
+      "Use CPU for NVMe command generation (no GPU, no PCIe atomics required).")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_option(
+      "--data-buffer-size", config->dataBufferSize,
+      "Size of data buffers for NVMe I/O testing (bytes). "
+      "If not specified, will be auto-calculated as "
+      "iterations * 8 * block-size (kernel uses 8 blocks per operation).")
+    ->default_val(1024 * 1024) // 1 MB default
+    ->check(CLI::PositiveNumber)
+    ->group(nvme_group);
+
+  app
+    .add_option("--device", config->device,
+                "NVMe device path (e.g., /dev/nvme0 or /dev/nvme-axiio). "
+                "Enables automatic hardware setup.")
+    ->default_val("")
+    ->group(nvme_group);
+
+  app
+    .add_flag("--hijack-existing-queue", config->hijackExistingQueue,
+              "⚠️  DANGEROUS: Use existing kernel queue without creating new "
+              "one (for testing).")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_flag("--kernel-module", config->useKernelModule,
+              "Use kernel module (/dev/nvme-axiio) for queue management "
+              "instead of direct device access.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_option("--lba-range-gib", config->lbaRangeGiB,
+                "LBA range to test in GiB (e.g., 1 for first 1GiB).")
+    ->default_val(1)
+    ->check(CLI::PositiveNumber)
+    ->group(nvme_group);
+
+  app
+    .add_option("--lfsr-seed", config->lfsrSeed,
+                "Seed for LFSR pattern generation (0 = derive from LBA). "
+                "Allows different data patterns for same LBA.")
+    ->default_val(0)
+    ->group(nvme_group);
+
+  app
+    .add_option("--nsid", config->nsid, "NVMe namespace ID for I/O operations.")
+    ->default_val(1)
+    ->check(CLI::Range(1u, 0xFFFFFFFFu))
+    ->group(nvme_group);
+
+  app
+    .add_flag(
+      "--read-only", config->readOnlyMode,
+      "Read-only mode: only allocate read buffer, issue only read commands.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_option("--queue-id", config->queueId,
+                "NVMe queue ID to use (0=admin queue, 1+=IO queues). "
+                "Use high ID to avoid kernel conflicts.")
+    ->default_val(63)
+    ->check(CLI::Range(0, 65535))
+    ->group(nvme_group);
+
+  app
+    .add_flag("--skip-queue-cleanup", config->skipQueueCleanup,
+              "Skip queue deletion on exit (faster, leaves queues active).")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_option("--test-pattern", config->testPattern,
+                "Data test pattern: sequential, zeros, ones, random, "
+                "block_id, lfsr. Use lfsr with --lfsr-seed for deterministic "
+                "LFSR-based patterns.")
+    ->default_val("sequential")
+    ->check([](const std::string& val) {
+      return (val == "sequential" || val == "zeros" || val == "ones" ||
+              val == "random" || val == "block_id" || val == "lfsr")
+               ? std::string()
+               : std::string("Pattern must be: sequential, zeros, ones, "
+                             "random, block_id, or lfsr");
+    })
+    ->group(nvme_group);
+
+  app
+    .add_option("--trace-file", config->traceFilePath,
+                "Path to QEMU NVMe trace log file for verification. "
+                "Default: /tmp/rocm-axiio-nvme-trace.log")
+    ->default_val("/tmp/rocm-axiio-nvme-trace.log")
+    ->group(nvme_group);
+
+  app
+    .add_option("--transfer-size", config->transferSize,
+                "Transfer size for NVMe I/O operations in bytes "
+                "(e.g., 4096 for 4KiB).")
+    ->default_val(4096)
+    ->check(CLI::PositiveNumber)
+    ->group(nvme_group);
+
+  app
+    .add_flag("--use-data-buffers", config->useDataBuffers,
+              "Enable data buffer allocation for NVMe I/O testing.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_flag("--verify-reads", config->verifyReads,
+              "Verify read data matches expected pattern after test completes.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_flag(
+      "--verify-trace", config->verifyTrace,
+      "Verify doorbell operations in QEMU trace log after test completes.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  app
+    .add_flag(
+      "--write-only", config->writeOnlyMode,
+      "Write-only mode: only allocate write buffer, issue only write commands.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(nvme_group);
+
+  // Physical addresses (usually auto-detected, kept for advanced users)
+  const std::string nvme_advanced_group = "NVMe Endpoint Advanced Options";
+
+  app
+    .add_option("--cq-base", config->cqBaseAddr,
+                "Physical base address of NVMe completion queue (hex). "
+                "Auto-detected if --device is specified.")
+    ->default_val(0ULL)
+    ->group(nvme_advanced_group);
+
+  app
+    .add_option("--cq-size", config->cqSize,
+                "Size of NVMe completion queue in bytes. "
+                "Auto-detected if --device is specified.")
+    ->default_val(0ULL)
+    ->check(CLI::NonNegativeNumber)
+    ->group(nvme_advanced_group);
+
+  app
+    .add_option("--doorbell", config->doorbellAddr,
+                "Physical address of NVMe doorbell register (hex). "
+                "Auto-detected if --device is specified.")
+    ->default_val(0ULL)
+    ->group(nvme_advanced_group);
+
+  app
+    .add_option("--sq-base", config->sqBaseAddr,
+                "Physical base address of NVMe submission queue (hex). "
+                "Auto-detected if --device is specified.")
+    ->default_val(0ULL)
+    ->group(nvme_advanced_group);
+
+  app
+    .add_option("--sq-size", config->sqSize,
+                "Size of NVMe submission queue in bytes. "
+                "Auto-detected if --device is specified.")
+    ->default_val(0ULL)
+    ->check(CLI::NonNegativeNumber)
+    ->group(nvme_advanced_group);
+}
+
+/**
+ * Validate NVMe endpoint configuration
+ *
+ * @param config Pointer to NvmeEpConfig structure
+ * @return Empty string if valid, error message otherwise
+ */
+inline std::string validateConfig(const NvmeEpConfig* config) {
+  if (config->writeOnlyMode && config->readOnlyMode) {
+    return "Cannot specify both --write-only and --read-only";
+  }
+
+  if (config->accessPattern != "sequential" &&
+      config->accessPattern != "random") {
+    return "Access pattern must be 'sequential' or 'random'";
+  }
+
+  return ""; // Valid
+}
+
+} // namespace nvme_ep
+
+#endif // NVME_EP_CLI_H

--- a/endpoints/nvme-ep/nvme-ep-config.h
+++ b/endpoints/nvme-ep/nvme-ep-config.h
@@ -1,0 +1,82 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef NVME_EP_CONFIG_H
+#define NVME_EP_CONFIG_H
+
+#include <cstdint>
+#include <string>
+
+namespace nvme_ep {
+
+/**
+ * NVMe Endpoint Configuration Structure
+ *
+ * Contains all NVMe-specific configuration options that were previously
+ * scattered in the main tester's cmdLineArgs structure.
+ */
+struct NvmeEpConfig {
+  // Device and queue configuration
+  std::string device; // NVMe device path (e.g., /dev/nvme0 or /dev/nvme-axiio)
+  bool useKernelModule; // Use kernel module (/dev/nvme-axiio)
+  uint16_t queueId;     // Queue ID to use (0=admin, 1+=IO queues)
+
+  // Physical addresses (usually auto-detected)
+  uint64_t doorbellAddr; // Physical address of doorbell register
+  uint64_t sqBaseAddr;   // Physical base address of submission queue
+  uint64_t cqBaseAddr;   // Physical base address of completion queue
+  size_t sqSize;         // Size of submission queue in bytes
+  size_t cqSize;         // Size of completion queue in bytes
+
+  // I/O operation parameters
+  uint32_t nsid;             // Namespace ID (default: 1)
+  size_t transferSize;       // Transfer size in bytes (default: 4096)
+  size_t lbaRangeGiB;        // LBA range to test in GiB (default: 1)
+  std::string accessPattern; // "sequential" or "random" (default: "random")
+  unsigned blockSize;        // Block size in bytes (default: 512)
+
+  // Data buffer configuration
+  bool useDataBuffers;   // Enable data buffer allocation
+  size_t dataBufferSize; // Size of data buffers in bytes
+
+  // Test pattern configuration
+  std::string testPattern; // Pattern: sequential, zeros, ones, random,
+                           // block_id, lfsr
+  uint32_t lfsrSeed;       // Seed for LFSR pattern (0 = derive from LBA)
+
+  // Operation mode flags
+  bool cpuOnlyMode;         // Use CPU for command generation
+  bool hijackExistingQueue; // DANGEROUS: Use existing kernel queue
+  bool writeOnlyMode;       // Write-only mode
+  bool readOnlyMode;        // Read-only mode
+  bool skipQueueCleanup;    // Skip queue deletion on exit
+
+  // Verification options
+  bool verifyTrace;          // Verify doorbell operations in QEMU trace
+  std::string traceFilePath; // Path to QEMU trace log file
+  bool verifyReads;          // Verify read data matches expected pattern
+
+  // Legacy/backward compatibility flags
+  bool useRealHardware; // Legacy: Use real NVMe hardware
+
+  // Default constructor
+  NvmeEpConfig()
+    : device(""), useKernelModule(false), queueId(63), doorbellAddr(0),
+      sqBaseAddr(0), cqBaseAddr(0), sqSize(0), cqSize(0), nsid(1),
+      transferSize(4096), lbaRangeGiB(1), accessPattern("random"),
+      blockSize(512), useDataBuffers(false),
+      dataBufferSize(1024 * 1024) // 1 MB default
+      ,
+      testPattern("sequential"), lfsrSeed(0), cpuOnlyMode(false),
+      hijackExistingQueue(false), writeOnlyMode(false), readOnlyMode(false),
+      skipQueueCleanup(false), verifyTrace(false),
+      traceFilePath("/tmp/rocm-axiio-nvme-trace.log"), verifyReads(false),
+      useRealHardware(false) {
+  }
+};
+
+} // namespace nvme_ep
+
+#endif // NVME_EP_CONFIG_H

--- a/include/axiio-endpoint-cli.h
+++ b/include/axiio-endpoint-cli.h
@@ -1,0 +1,65 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef AXIIO_ENDPOINT_CLI_H
+#define AXIIO_ENDPOINT_CLI_H
+
+#include <functional>
+#include <string>
+
+#include <CLI/CLI.hpp>
+
+namespace axiio {
+
+/**
+ * Endpoint CLI Options Registration Interface
+ *
+ * Each endpoint can register its own command-line options by providing
+ * a registration function. This allows endpoints to have endpoint-specific
+ * options without cluttering the main tester code.
+ */
+class EndpointCliRegistry {
+public:
+  /**
+   * Register CLI options for an endpoint
+   *
+   * @param endpoint_name Name of the endpoint (e.g., "nvme-ep")
+   * @param app CLI11 App object to add options to
+   * @param config_ptr Pointer to endpoint-specific config structure
+   */
+  using RegisterFunction = std::function<void(CLI::App&, void*)>;
+
+  /**
+   * Validate options after parsing (optional)
+   *
+   * @param config_ptr Pointer to endpoint-specific config structure
+   * @return Error message if validation fails, empty string on success
+   */
+  using ValidateFunction = std::function<std::string(void*)>;
+
+  /**
+   * Register an endpoint's CLI options
+   */
+  static void registerEndpoint(const std::string& endpoint_name,
+                               RegisterFunction register_fn,
+                               ValidateFunction validate_fn = nullptr) {
+    // Store registration functions (simplified - in real implementation,
+    // this would use a map or similar structure)
+    // For now, endpoints will call this during their initialization
+  }
+
+  /**
+   * Call the registration function for a specific endpoint
+   */
+  static void registerOptionsForEndpoint(const std::string& endpoint_name,
+                                         CLI::App& app, void* config_ptr) {
+    // This will be implemented by each endpoint
+    // Endpoints will provide their own registration functions
+  }
+};
+
+} // namespace axiio
+
+#endif // AXIIO_ENDPOINT_CLI_H

--- a/tester/axiio-tester.hip
+++ b/tester/axiio-tester.hip
@@ -33,6 +33,8 @@
 #include "axiio.h"
 
 // For NVMe-specific buffer testing
+#include "nvme-ep-cli.h"
+#include "nvme-ep-config.h"
 #include "nvme-ep.h"
 
 // For NVMe device management
@@ -109,6 +111,12 @@ typedef struct {
   bool skipAtomicsCheck; // Skip PCIe atomics check (faster startup)
 } cmdLineArgs;
 
+// Endpoint-specific configuration
+typedef struct {
+  nvme_ep::NvmeEpConfig nvmeConfig; // NVMe endpoint configuration
+  // Add other endpoint configs here as needed
+} endpointConfigs;
+
 typedef struct {
   unsigned long long int* startTime;
   unsigned long long int* endTime;
@@ -116,6 +124,7 @@ typedef struct {
 
 typedef struct {
   cmdLineArgs args;
+  endpointConfigs epConfigs; // Endpoint-specific configurations
   testStats stats;
   // CPU-hybrid mode: GPU writes to these, CPU copies to kernel DMA memory
   void* gpuSqMem;
@@ -2491,9 +2500,9 @@ cleanup_and_exit:
   }
 
   // Clean up dedicated NVMe queues if we created them
-  // Skip cleanup if using kernel module (queues may be pre-existing on real
-  // hardware)
-  bool should_skip_cleanup = config->args.skipQueueCleanup || kernel_ctx;
+  // Skip cleanup only if explicitly requested (not automatically for kernel
+  // module) The kernel module handles QEMU vs real hardware appropriately
+  bool should_skip_cleanup = config->args.skipQueueCleanup;
   if (!mappedPhysical && !config->args.nvmeDevice.empty() &&
       !should_skip_cleanup) {
     std::cout << "\n=== Cleaning up dedicated I/O queues ===" << std::endl;
@@ -2506,13 +2515,7 @@ cleanup_and_exit:
     std::cout << "Queue cleanup complete" << std::endl;
   } else if (should_skip_cleanup) {
     std::cout << "\n=== Skipping queue cleanup ===" << std::endl;
-    if (kernel_ctx) {
-      std::cout
-        << "  Using kernel module - queues may be pre-existing (real hardware)"
-        << std::endl;
-    } else {
-      std::cout << "  (--skip-queue-cleanup flag set)" << std::endl;
-    }
+    std::cout << "  (--skip-queue-cleanup flag set)" << std::endl;
     std::cout << "  Queue " << config->args.nvmeQueueId << " will remain active"
               << std::endl;
   }
@@ -2531,6 +2534,10 @@ int main(int argc, char** argv) {
   config.args.printDeviceInfo = false;
   config.args.genHistogram = false;
   config.args.beVerbose = false;
+
+  // Initialize endpoint-specific configs with defaults
+  config.epConfigs.nvmeConfig = nvme_ep::NvmeEpConfig();
+
   // Initialize pointer fields to nullptr
   config.kernelDmaSq = nullptr;
   config.kernelDmaCq = nullptr;
@@ -2543,32 +2550,48 @@ int main(int argc, char** argv) {
   config.writeBufferCpu = nullptr;
   config.writeBufferGpu = nullptr;
 
-  app
-    .add_option("-n, --iterations", config.args.nIterations,
-                "Number of iterations to run the test.")
-    ->default_val(128)
-    ->check(CLI::PositiveNumber);
+  // Group all global options together
+  const std::string global_group = "Global Options";
 
-  app
-    .add_flag("-i, --info", config.args.printDeviceInfo,
-              "Print information about GPUs in the system.")
-    ->default_val(false);
+  // Help option first (CLI11 adds it automatically, we'll move it to the group)
+  // Note: CLI11's help option is added automatically, we'll handle grouping
+  // after
 
+  // Global options in alphabetical order by long name
   app
-    .add_flag("--histogram", config.args.genHistogram,
-              "Generate histogram of iteration runtimes.")
-    ->default_val(false);
-
-  app
-    .add_flag("-v, --verbose", config.args.beVerbose,
-              "Print detailed per-iteration timing results.")
-    ->default_val(false);
+    .add_option("--complete-queue-len", config.args.completeQueueLen,
+                "Length of the completion queue (number of entries).")
+    ->default_val(512)
+    ->check(CLI::PositiveNumber)
+    ->group(global_group);
 
   auto endpoint_opt =
     app
       .add_option("-e, --endpoint", config.args.endpoint,
                   "Select endpoint (test-ep, nvme-ep) or use -e alone to list.")
-      ->expected(0, 1);
+      ->expected(0, 1)
+      ->group(global_group);
+
+  app
+    .add_flag("--histogram", config.args.genHistogram,
+              "Generate histogram of iteration runtimes.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(global_group);
+
+  app
+    .add_flag("-i, --info", config.args.printDeviceInfo,
+              "Print information about GPUs in the system.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(global_group);
+
+  app
+    .add_option("-n, --iterations", config.args.nIterations,
+                "Number of iterations to run the test.")
+    ->default_val(128)
+    ->check(CLI::PositiveNumber)
+    ->group(global_group);
 
   app
     .add_option("-m, --memory", config.args.memoryType,
@@ -2583,192 +2606,78 @@ int main(int argc, char** argv) {
       return (lower == "host" || lower == "device")
                ? std::string()
                : std::string("Memory type must be 'host' or 'device'");
-    });
+    })
+    ->group(global_group);
+
+  app
+    .add_flag("--skip-atomics-check", config.args.skipAtomicsCheck,
+              "Skip PCIe atomics check at startup (faster startup).")
+    ->default_val(false)
+    ->default_str("")
+    ->group(global_group);
 
   app
     .add_option("--submit-queue-len", config.args.submitQueueLen,
                 "Length of the submission queue (number of entries).")
     ->default_val(1024)
-    ->check(CLI::PositiveNumber);
+    ->check(CLI::PositiveNumber)
+    ->group(global_group);
 
   app
-    .add_option("--complete-queue-len", config.args.completeQueueLen,
-                "Length of the completion queue (number of entries).")
-    ->default_val(512)
-    ->check(CLI::PositiveNumber);
+    .add_flag("-v, --verbose", config.args.beVerbose,
+              "Print detailed per-iteration timing results.")
+    ->default_val(false)
+    ->default_str("")
+    ->group(global_group);
 
-  // Real NVMe hardware support options
-  app
-    .add_flag("--real-hardware", config.args.useRealHardware,
-              "Use real NVMe hardware instead of emulated endpoint.")
-    ->default_val(false);
+  // Move help option to Global Options group and update description
+  // CLI11 adds help automatically, we need to access it and set its group
+  for (auto* opt : app.get_options()) {
+    if (opt->get_name() == "--help" || opt->get_name() == "-h") {
+      opt->group(global_group);
+      opt->description("Print this help message and exit. Use with -e "
+                       "<endpoint> to show endpoint-specific options.");
+      break;
+    }
+  }
 
-  app
-    .add_option(
-      "--nvme-device", config.args.nvmeDevice,
-      "NVMe device path (e.g., /dev/nvme0). Enables automatic hardware setup.")
-    ->default_val("");
+  // Determine endpoint early to register endpoint-specific options
+  // Manually scan argv for endpoint option before parsing
+  std::string preliminary_endpoint;
+  for (int i = 1; i < argc; i++) {
+    std::string arg = argv[i];
+    // Check for endpoint specification
+    if (arg == "-e" || arg == "--endpoint") {
+      if (i + 1 < argc) {
+        preliminary_endpoint = argv[i + 1];
+      }
+      break;
+    } else if (arg.find("--endpoint=") == 0) {
+      preliminary_endpoint = arg.substr(11); // Skip "--endpoint="
+      break;
+    } else if (arg.find("-e") == 0 && arg.length() > 2) {
+      preliminary_endpoint = arg.substr(2); // Skip "-e"
+      break;
+    }
+  }
 
-  app
-    .add_flag("--use-kernel-module", config.args.useKernelModule,
-              "Use kernel module (/dev/nvme-axiio) for queue management "
-              "instead of direct device access.")
-    ->default_val(false);
+  // Register endpoint-specific options ONLY when endpoint is explicitly
+  // specified This ensures endpoint options only appear in help when using -e
+  // <endpoint> -h
+  std::string preliminary_endpoint_lower = preliminary_endpoint;
+  std::transform(preliminary_endpoint_lower.begin(),
+                 preliminary_endpoint_lower.end(),
+                 preliminary_endpoint_lower.begin(), [](unsigned char c) {
+                   return std::tolower(c);
+                 });
 
-  app
-    .add_option("--nvme-queue-id", config.args.nvmeQueueId,
-                "NVMe queue ID to use (0=admin queue, 1+=IO queues). Use high "
-                "ID to avoid kernel conflicts.")
-    ->default_val(63)
-    ->check(CLI::Range(0, 65535));
-
-  app
-    .add_option("--nvme-doorbell", config.args.nvmeDoorbellAddr,
-                "Physical address of NVMe doorbell register (hex). "
-                "Auto-detected if --nvme-device is specified.")
-    ->default_val(0ULL);
-
-  app
-    .add_option("--nvme-sq-base", config.args.nvmeSqBaseAddr,
-                "Physical base address of NVMe submission queue (hex).")
-    ->default_val(0ULL);
-
-  app
-    .add_option("--nvme-cq-base", config.args.nvmeCqBaseAddr,
-                "Physical base address of NVMe completion queue (hex).")
-    ->default_val(0ULL);
-
-  app
-    .add_option("--nvme-sq-size", config.args.nvmeSqSize,
-                "Size of NVMe submission queue in bytes.")
-    ->default_val(0ULL)
-    ->check(CLI::NonNegativeNumber);
-
-  app
-    .add_option("--nvme-cq-size", config.args.nvmeCqSize,
-                "Size of NVMe completion queue in bytes.")
-    ->default_val(0ULL)
-    ->check(CLI::NonNegativeNumber);
-
-  // Data buffer options for NVMe I/O testing
-  app
-    .add_flag("--use-data-buffers", config.args.useDataBuffers,
-              "Enable data buffer allocation for NVMe I/O testing.")
-    ->default_val(false);
-
-  app
-    .add_flag(
-      "--cpu-only", config.args.cpuOnlyMode,
-      "Use CPU for NVMe command generation (no GPU, no PCIe atomics required).")
-    ->default_val(false);
-
-  app
-    .add_flag("--hijack-existing-queue", config.args.hijackExistingQueue,
-              "⚠️  DANGEROUS: Use existing kernel queue without creating new "
-              "one (for testing).")
-    ->default_val(false);
-
-  // NVMe I/O testing parameters
-  app
-    .add_option(
-      "--transfer-size", config.args.transferSize,
-      "Transfer size for NVMe I/O operations in bytes (e.g., 4096 for 4KiB).")
-    ->default_val(4096)
-    ->check(CLI::PositiveNumber);
-
-  app
-    .add_option("--lba-range-gib", config.args.lbaRangeGiB,
-                "LBA range to test in GiB (e.g., 1 for first 1GiB).")
-    ->default_val(1)
-    ->check(CLI::PositiveNumber);
-
-  app
-    .add_option("--access-pattern", config.args.accessPattern,
-                "Access pattern: 'sequential' or 'random'.")
-    ->default_val("random")
-    ->check(CLI::IsMember({"sequential", "random"}));
-
-  app
-    .add_option("--nvme-nsid", config.args.nsid,
-                "NVMe namespace ID for I/O operations.")
-    ->default_val(1)
-    ->check(CLI::Range(1u, 0xFFFFFFFFu));
-
-  app
-    .add_option(
-      "--data-buffer-size", config.args.dataBufferSize,
-      "Size of data buffers for NVMe I/O testing (bytes). "
-      "If not specified, will be auto-calculated as "
-      "iterations * 8 * block-size (kernel uses 8 blocks per operation).")
-    ->default_val(1024 * 1024) // 1 MB default (will be auto-adjusted if too
-                               // small)
-    ->check(CLI::PositiveNumber);
-
-  app
-    .add_option("--nvme-block-size", config.args.nvmeBlockSize,
-                "NVMe block size in bytes (typically 512 or 4096).")
-    ->default_val(512)
-    ->check(CLI::PositiveNumber);
-
-  app
-    .add_option("--test-pattern", config.args.testPattern,
-                "Data test pattern: sequential, zeros, ones, random, "
-                "block_id, lfsr")
-    ->default_val("sequential")
-    ->check([](const std::string& val) {
-      return (val == "sequential" || val == "zeros" || val == "ones" ||
-              val == "random" || val == "block_id" || val == "lfsr")
-               ? std::string()
-               : std::string("Pattern must be: sequential, zeros, ones, "
-                             "random, block_id, or lfsr");
-    });
-
-  // Trace verification options
-  app
-    .add_flag("--verify-trace", config.args.verifyTrace,
-              "Verify doorbell operations in QEMU trace log after test "
-              "completes.")
-    ->default_val(false);
-
-  app
-    .add_option("--trace-file", config.args.traceFilePath,
-                "Path to QEMU NVMe trace log file for verification. "
-                "Default: /tmp/rocm-axiio-nvme-trace.log")
-    ->default_val("/tmp/rocm-axiio-nvme-trace.log");
-
-  app
-    .add_flag("--verify-reads", config.args.verifyReads,
-              "Verify read data matches expected pattern after test "
-              "completes.")
-    ->default_val(false);
-
-  app
-    .add_option("--lfsr-seed", config.args.lfsrSeed,
-                "Seed for LFSR pattern generation (0 = derive from LBA). "
-                "Allows different data patterns for same LBA.")
-    ->default_val(0);
-
-  app
-    .add_flag("--write-only", config.args.writeOnlyMode,
-              "Write-only mode: only allocate write buffer, issue only write "
-              "commands.")
-    ->default_val(false);
-
-  app
-    .add_flag("--read-only", config.args.readOnlyMode,
-              "Read-only mode: only allocate read buffer, issue only read "
-              "commands.")
-    ->default_val(false);
-
-  app
-    .add_flag("--skip-queue-cleanup", config.args.skipQueueCleanup,
-              "Skip queue deletion on exit (faster, leaves queues active).")
-    ->default_val(false);
-
-  app
-    .add_flag("--skip-atomics-check", config.args.skipAtomicsCheck,
-              "Skip PCIe atomics check at startup (faster startup).")
-    ->default_val(false);
+  if (preliminary_endpoint_lower == "nvme-ep") {
+    // Register NVMe endpoint CLI options only when nvme-ep is explicitly
+    // specified
+    nvme_ep::registerCliOptions(app, &config.epConfigs.nvmeConfig);
+  }
+  // Add other endpoint registrations here as needed (rdma-ep, sdma-ep, etc.)
+  // Note: Only register when endpoint is explicitly specified, not by default
 
   CLI11_PARSE(app, argc, argv);
 
@@ -2800,6 +2709,53 @@ int main(int argc, char** argv) {
     listAvailableEndpoints();
     nvme_hsa_doorbell::shutdown_hsa();
     return EXIT_SUCCESS;
+  }
+
+  // Map endpoint-specific config to legacy cmdLineArgs structure for backward
+  // compatibility This allows existing code to continue working while we
+  // transition
+  std::string endpoint_lower = config.args.endpoint;
+  std::transform(endpoint_lower.begin(), endpoint_lower.end(),
+                 endpoint_lower.begin(), [](unsigned char c) {
+                   return std::tolower(c);
+                 });
+
+  if (endpoint_lower == "nvme-ep") {
+    // Copy NVMe endpoint config to legacy structure
+    config.args.nvmeDevice = config.epConfigs.nvmeConfig.device;
+    config.args.useKernelModule = config.epConfigs.nvmeConfig.useKernelModule;
+    config.args.nvmeQueueId = config.epConfigs.nvmeConfig.queueId;
+    config.args.nvmeDoorbellAddr = config.epConfigs.nvmeConfig.doorbellAddr;
+    config.args.nvmeSqBaseAddr = config.epConfigs.nvmeConfig.sqBaseAddr;
+    config.args.nvmeCqBaseAddr = config.epConfigs.nvmeConfig.cqBaseAddr;
+    config.args.nvmeSqSize = config.epConfigs.nvmeConfig.sqSize;
+    config.args.nvmeCqSize = config.epConfigs.nvmeConfig.cqSize;
+    config.args.nsid = config.epConfigs.nvmeConfig.nsid;
+    config.args.transferSize = config.epConfigs.nvmeConfig.transferSize;
+    config.args.lbaRangeGiB = config.epConfigs.nvmeConfig.lbaRangeGiB;
+    config.args.accessPattern = config.epConfigs.nvmeConfig.accessPattern;
+    config.args.nvmeBlockSize = config.epConfigs.nvmeConfig.blockSize;
+    config.args.useDataBuffers = config.epConfigs.nvmeConfig.useDataBuffers;
+    config.args.dataBufferSize = config.epConfigs.nvmeConfig.dataBufferSize;
+    config.args.testPattern = config.epConfigs.nvmeConfig.testPattern;
+    config.args.lfsrSeed = config.epConfigs.nvmeConfig.lfsrSeed;
+    config.args.cpuOnlyMode = config.epConfigs.nvmeConfig.cpuOnlyMode;
+    config.args.hijackExistingQueue =
+      config.epConfigs.nvmeConfig.hijackExistingQueue;
+    config.args.writeOnlyMode = config.epConfigs.nvmeConfig.writeOnlyMode;
+    config.args.readOnlyMode = config.epConfigs.nvmeConfig.readOnlyMode;
+    config.args.skipQueueCleanup = config.epConfigs.nvmeConfig.skipQueueCleanup;
+    config.args.verifyTrace = config.epConfigs.nvmeConfig.verifyTrace;
+    config.args.traceFilePath = config.epConfigs.nvmeConfig.traceFilePath;
+    config.args.verifyReads = config.epConfigs.nvmeConfig.verifyReads;
+
+    // Validate NVMe endpoint configuration
+    std::string validation_error = nvme_ep::validateConfig(
+      &config.epConfigs.nvmeConfig);
+    if (!validation_error.empty()) {
+      std::cerr << "Error: " << validation_error << std::endl;
+      return EXIT_FAILURE;
+    }
   }
 
   // Note: printDeviceInfo is defined later, so we handle this flag after device


### PR DESCRIPTION
Implement a new endpoint-specific CLI options system that allows each endpoint to register its own command-line options. This provides cleaner help output, better organization, and makes it easier to add new endpoints.

Changes:
- Create endpoint CLI registration interface (include/axiio-endpoint-cli.h)
- Create NVMe endpoint config structure (endpoints/nvme-ep/nvme-ep-config.h)
  * Consolidates all NVMe-specific configuration into single structure
  * Includes device, queue, I/O, and verification settings
- Create NVMe endpoint CLI registration (endpoints/nvme-ep/nvme-ep-cli.h)
  * Registers NVMe options with shorter names (--device vs --nvme-device)
  * Groups options into "NVMe Endpoint Options" and "NVMe Endpoint Advanced Options"
  * All endpoint-specific options appear in their own sections
  * Options sorted alphabetically by long name within each section
  * Flags use default_str("") to hide [0]/[false] display in help
- Update tester to use endpoint CLI registration system
  * Detects endpoint from argv before parsing
  * Conditionally registers endpoint-specific options only when endpoint specified
  * Maps endpoint config to legacy cmdLineArgs for backward compatibility
  * Removed duplicate NVMe option registrations (now handled by endpoint)
  * Groups global options under "Global Options:" header
  * Help option moved to Global Options section (removed separate "Options:" section)
  * Help description updated to mention using -e <endpoint> for endpoint-specific options
- Fix Makefile dependencies
  * Tester object file now depends on endpoint headers
  * Ensures tester rebuilds when endpoint headers change
- Fix queue cleanup logic
  * Previously skipped automatically when using kernel module
  * Now respects --skip-queue-cleanup flag only

Help Output Organization:
- "Global Options:" section shows common options (help first, then alphabetical)
- "NVMe Endpoint Options:" section shows NVMe-specific options (when using -e nvme-ep -h)
- "NVMe Endpoint Advanced Options:" section shows advanced NVMe options
- Endpoint-specific options only appear when endpoint is explicitly specified
- Flags no longer show [0] or [false] defaults (cleaner display)
- Non-flag options still show defaults (e.g., [128], [random], [512])

Breaking Changes:
- Removed deprecated --nvme-* options (--nvme-device, --nvme-queue-id, etc.)
- Removed --real-hardware legacy flag
- Users must now use -e nvme-ep with new option names:
  * --device (was --nvme-device)
  * --kernel-module (was --use-kernel-module)
  * --queue-id (was --nvme-queue-id)
  * --nsid (was --nvme-nsid)
  * --block-size (was --nvme-block-size)
  * --doorbell, --sq-base, --cq-base, --sq-size, --cq-size (was --nvme-*)

Benefits:
- Cleaner CLI: NVMe options only appear when using nvme-ep endpoint
- Better organization: Endpoint-specific code lives with the endpoint
- Easier extension: Other endpoints can add their own options easily
- Reduced confusion: Users don't see irrelevant options
- Better help text: Organized into clear sections, flags don't show odd defaults
- Alphabetical ordering: Options sorted for easier scanning

Documentation Updates:
- Updated README.md examples to use new CLI format
- Updated docs/ENDPOINT_CLI_OPTIONS_DESIGN.md to reflect implementation
- All examples now use -e nvme-ep with new option names
- Help descriptions updated (help mentions -e <endpoint>, test-pattern mentions LFSR)

Files changed:
- tester/axiio-tester.hip: Updated to use endpoint CLI registration
- endpoints/nvme-ep/nvme-ep-config.h: New NVMe config structure
- endpoints/nvme-ep/nvme-ep-cli.h: New NVMe CLI registration
- include/axiio-endpoint-cli.h: New endpoint CLI interface
- Makefile: Added tester header dependencies
- README.md: Updated all examples to new CLI format
- docs/ENDPOINT_CLI_OPTIONS_DESIGN.md: Updated design doc

Tested: Builds successfully. Help output verified. CI should pass.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
