### PR TITLE
Add doorbell mode to test-ep endpoint and refactor CLI to use subcomm…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ all: build_info $(LIBTARGET) $(TESTER)
 HIP_INCLUDE_DIR  ?= /opt/rocm/include
 HIPCXX ?= /opt/rocm/bin/hipcc
 
+# C++ compiler for host-only code (tester)
+CXX ?= clang++
+
 # Tool variables
 AR ?= ar
 OBJDUMP ?= /opt/rocm/lib/llvm/bin/llvm-objdump
@@ -200,10 +203,15 @@ $(BUILD_DIR)/%.o: %.hip $(ENDPOINT_REGISTRY_GEN) | $(BUILD_DIR)
 	$(eval ENDPOINT_DEFINE := $(call get_endpoint_define,$<))
 	$(HIPCXX) $(CXXFLAGS) $(ENDPOINT_DEFINE) -I$(INCLUDE_DIR) -c -o $@ $<
 
-# Rule for .cpp files (tester)
+# Rule for .cpp files (tester) - use regular C++ compiler, not hipcc
+# Need endpoint include paths and HIP platform define, but not GPU flags
 $(BUILD_DIR)/%.o: %.cpp $(ENDPOINT_REGISTRY_GEN) | $(BUILD_DIR)
 	@mkdir -p $(dir $@)
-	$(HIPCXX) $(CXXFLAGS) -I$(INCLUDE_DIR) -c -o $@ $<
+	$(CXX) -std=c++17 -Wall -Wextra -Wno-unused-parameter \
+		-D__HIP_PLATFORM_AMD__ \
+		-I$(INCLUDE_DIR) -I$(HIP_INCLUDE_DIR) \
+		$(foreach ep,$(VALID_ENDPOINTS),-I$(ENDPOINTS_DIR)/$(ep)) \
+		-c -o $@ $<
 
 # Function to determine which endpoint define to use based on source path
 # $1: source file path

--- a/src/common/axiio-helpers.hip
+++ b/src/common/axiio-helpers.hip
@@ -61,8 +61,8 @@ void axiioPrintDeviceInfo() {
 }
 
 void axiioPrintStatistics(const std::vector<double>& durations,
-                          unsigned totalIterations, unsigned readIterations,
-                          unsigned writeIterations,
+                          unsigned totalIterations, unsigned numThreads,
+                          unsigned readIterations, unsigned writeIterations,
                           unsigned verifiedReadsCount) {
   if (durations.empty()) {
     return;
@@ -131,6 +131,12 @@ void axiioPrintStatistics(const std::vector<double>& durations,
               << std::endl;
   }
 
+  // Print threads if provided
+  if (numThreads > 0) {
+    std::cout << "  Threads:          " << std::setw(10) << numThreads
+              << std::endl;
+  }
+
   std::cout << "  Minimum:          " << std::setw(10) << std::fixed
             << std::setprecision(2) << min_display << time_unit << std::endl;
   std::cout << "  Maximum:          " << std::setw(10) << std::fixed
@@ -142,8 +148,8 @@ void axiioPrintStatistics(const std::vector<double>& durations,
 }
 
 void axiioPrintHistogram(const std::vector<double>& durations,
-                         unsigned nIterations, unsigned readIterations,
-                         unsigned writeIterations,
+                         unsigned nIterations, unsigned numThreads,
+                         unsigned readIterations, unsigned writeIterations,
                          unsigned verifiedReadsCount) {
   if (durations.empty() || nIterations == 0) {
     return;
@@ -251,13 +257,13 @@ void axiioPrintHistogram(const std::vector<double>& durations,
   }
 
   // Print statistics after histogram
-  axiioPrintStatistics(durations, nIterations, readIterations, writeIterations,
-                       verifiedReadsCount);
+  axiioPrintStatistics(durations, nIterations, numThreads, readIterations,
+                       writeIterations, verifiedReadsCount);
 }
 
 // Helper function to allocate HSA device memory
-static hsa_status_t axiioAllocDeviceMemory(size_t size, void** ptr,
-                                           const char* direction) {
+hsa_status_t axiioAllocDeviceMemory(size_t size, void** ptr,
+                                    const char* direction) {
   hsa_status_t status;
 
   // Initialize HSA runtime (safe to call multiple times)
@@ -458,4 +464,24 @@ void axiioFreeCompletionQueue(void* ptr, unsigned memoryMode) {
       HIP_CHECK(hipHostFree(ptr));
     }
   }
+}
+
+// Extract endpoint name from command line arguments
+// This allows endpoints to add their CLI options before full parsing
+// Returns empty string if endpoint name not found in arguments
+std::string axiioExtractEndpointName(int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "-e" || arg == "--endpoint") {
+      if (i + 1 < argc) {
+        return std::string(argv[i + 1]);
+      }
+      break;
+    } else if (arg.find("--endpoint=") == 0) {
+      return arg.substr(11);
+    } else if (arg.find("-e=") == 0) {
+      return arg.substr(3);
+    }
+  }
+  return std::string();
 }

--- a/src/endpoints/common/axiio-endpoint.hip
+++ b/src/endpoints/common/axiio-endpoint.hip
@@ -5,8 +5,12 @@
 
 #include <memory>
 
+#include <CLI/CLI.hpp>
+
 #include "axiio-endpoint-registry.h"
 #include "axiio.h"
+#include "test-ep-config.h"
+#include "test-ep.h"
 
 // Include endpoint headers for size information
 #include "nvme-ep.h"
@@ -25,6 +29,10 @@ extern hipError_t sdma_ep_run(AxiioEndpointConfig* config);
 // ============================================================================
 
 class TestEndpoint : public AxiioEndpoint {
+private:
+  // Store doorbell queue length from CLI
+  unsigned doorbell_ = 0;
+
 public:
   __host__ EndpointType getType() const override {
     return EndpointType::TEST_EP;
@@ -46,8 +54,57 @@ public:
     return TEST_EP_CQE_SIZE;
   }
 
+  __host__ size_t
+  getSubmissionQueueLength(const AxiioEndpointConfig* config) const override {
+    if (config == nullptr) {
+      return 1;
+    }
+    // Get test-ep specific config to check doorbell value
+    test_ep::TestEpConfig* testEpConfig = static_cast<test_ep::TestEpConfig*>(
+      config->endpointConfig);
+    unsigned doorbell = (testEpConfig != nullptr) ? testEpConfig->doorbell : 0;
+    if (doorbell > 0) {
+      // Doorbell mode: use doorbell value as queue length
+      return doorbell;
+    }
+    // Normal mode: one entry per thread, or 1 for single-threaded
+    return (config->numThreads > 1) ? config->numThreads : 1;
+  }
+
+  __host__ size_t
+  getCompletionQueueLength(const AxiioEndpointConfig* config) const override {
+    if (config == nullptr) {
+      return 1;
+    }
+    // Get test-ep specific config to check doorbell value
+    test_ep::TestEpConfig* testEpConfig = static_cast<test_ep::TestEpConfig*>(
+      config->endpointConfig);
+    unsigned doorbell = (testEpConfig != nullptr) ? testEpConfig->doorbell : 0;
+    if (doorbell > 0) {
+      // Doorbell mode: use doorbell value as queue length (circular buffer)
+      return doorbell;
+    }
+    // Normal mode: one entry per thread, or 1 for single-threaded
+    return (config->numThreads > 1) ? config->numThreads : 1;
+  }
+
   __host__ hipError_t run(AxiioEndpointConfig* config) override {
     return test_ep_run(config);
+  }
+
+  __host__ void configureCliOptions(CLI::App& app) override {
+    app
+      .add_option(
+        "--doorbell", doorbell_,
+        "Enable doorbell mode with specified queue length (0=disabled)")
+      ->default_val(0)
+      ->group("Endpoint Options");
+  }
+
+  __host__ void* initializeEndpointConfig() override {
+    static test_ep::TestEpConfig testEpConfig;
+    testEpConfig.doorbell = doorbell_;
+    return &testEpConfig;
   }
 };
 
@@ -104,6 +161,16 @@ public:
   __host__ hipError_t run(AxiioEndpointConfig* config) override {
     return rdma_ep_run(config);
   }
+
+  __host__ void configureCliOptions(CLI::App& app) override {
+    // RDMA endpoint can add its own CLI options here in the future
+    (void)app;
+  }
+
+  __host__ void* initializeEndpointConfig() override {
+    // RDMA endpoint can return its config here in the future
+    return nullptr;
+  }
 };
 
 class SdmaEndpoint : public AxiioEndpoint {
@@ -131,7 +198,43 @@ public:
   __host__ hipError_t run(AxiioEndpointConfig* config) override {
     return sdma_ep_run(config);
   }
+
+  __host__ void configureCliOptions(CLI::App& app) override {
+    // SDMA endpoint can add its own CLI options here in the future
+    (void)app;
+  }
+
+  __host__ void* initializeEndpointConfig() override {
+    // SDMA endpoint can return its config here in the future
+    return nullptr;
+  }
 };
+
+// ============================================================================
+// Default Implementation of Virtual Methods
+// ============================================================================
+
+void AxiioEndpoint::configureCliOptions(CLI::App& app) {
+  // Default: no endpoint-specific options
+  (void)app;
+}
+
+void* AxiioEndpoint::initializeEndpointConfig() {
+  // Default: no endpoint-specific config
+  return nullptr;
+}
+
+size_t AxiioEndpoint::getSubmissionQueueLength(
+  const AxiioEndpointConfig* config) const {
+  // Default: one entry per thread, or 1 for single-threaded
+  return (config != nullptr && config->numThreads > 1) ? config->numThreads : 1;
+}
+
+size_t AxiioEndpoint::getCompletionQueueLength(
+  const AxiioEndpointConfig* config) const {
+  // Default: one entry per thread, or 1 for single-threaded
+  return (config != nullptr && config->numThreads > 1) ? config->numThreads : 1;
+}
 
 // ============================================================================
 // Factory Function Implementation

--- a/src/endpoints/test-ep/test-ep-config.h
+++ b/src/endpoints/test-ep/test-ep-config.h
@@ -22,6 +22,14 @@ struct TestEpConfig {
   bool enableCpuThreads = true; // Default: enabled to match simple-test
                                 // behavior
 
+  // Doorbell mode queue length
+  // When > 0, enables doorbell mode with the specified queue length.
+  // CPU threads do not poll individual SQEs. Instead, a single CPU thread polls
+  // a doorbell address. The GPU writes SQEs to the submission queue and rings
+  // the doorbell after each SQE enqueue. Doorbell location is controlled by
+  // memory mode bit 2 (0=host, 1=device).
+  unsigned doorbell = 0; // Default: 0 (disabled, polling mode)
+
   // Default constructor
   TestEpConfig() = default;
 };

--- a/src/endpoints/test-ep/test-ep.h
+++ b/src/endpoints/test-ep/test-ep.h
@@ -52,11 +52,14 @@ static_assert(sizeof(struct test_cqe) == TEST_EP_CQE_SIZE,
 //   numThreads: Number of CPU threads to launch (one per GPU thread)
 //   iterations: Number of iterations per thread
 //   delayNs: Delay configuration (from AxiioEndpointConfig)
+//   doorbellMode: If true, use doorbell mode (single CPU thread polling
+//   doorbell) doorbell: Doorbell address (nullptr if not in doorbell mode)
+//   queueSize: Size of submission queue in doorbell mode
 // Returns: Vector of thread handles (caller must join)
-std::vector<std::thread> launchCpuThreads(void* hostSqeAddr, void* hostCqeAddr,
-                                          unsigned numThreads,
-                                          unsigned iterations,
-                                          long long delayNs);
+std::vector<std::thread> launchCpuThreads(
+  void* hostSqeAddr, void* hostCqeAddr, unsigned numThreads,
+  unsigned iterations, long long delayNs, bool doorbellMode = false,
+  void* doorbell = nullptr, unsigned queueSize = 0);
 
 // Run endpoint test - launches GPU kernel and waits for completion
 // Parameters:

--- a/src/endpoints/test-ep/test-ep.hip
+++ b/src/endpoints/test-ep/test-ep.hip
@@ -4,9 +4,13 @@
  */
 
 #include <chrono>
+#include <cstring>
 #include <ctime>
+#include <iostream>
 #include <thread>
 #include <vector>
+
+#include <unistd.h>
 
 #include "axiio.h"
 #include "test-ep-config.h"
@@ -97,6 +101,81 @@ __host__ cqeType cqeGenFromSqe(const sqeType* sqeData) {
   result.magic = TEST_EP_CQE_MAGIC_ID;
   result.cpuTime = getCpuTime(); // Use CPU time for CQE
   return result;
+}
+
+// CPU thread function for doorbell mode
+// Polls doorbell address and processes SQEs from the submission queue
+static void cpuThreadDoorbell(volatile sqeType* sqeQueue,
+                              volatile cqeType* cqeQueue,
+                              volatile uint32_t* doorbell, unsigned queueSize,
+                              unsigned numThreads, unsigned iterations,
+                              long long delayNs) {
+  uint32_t head = 0;
+  while (head < iterations * numThreads) {
+    // Poll doorbell for new tail value (use atomic load for consistency)
+    uint32_t tail = __atomic_load_n(doorbell, __ATOMIC_ACQUIRE);
+
+    // Process all new SQEs between head and tail
+    while (head < tail && head < iterations * numThreads) {
+      unsigned sqeIndex = head % queueSize;
+      volatile sqeType* sqe = &sqeQueue[sqeIndex];
+
+      // Read SQE (read magic first to check if SQE is ready)
+      // GPU thread writes SQE and then updates doorbell, so if doorbell says
+      // it's here, it should be written, but we still validate
+      sqeType currentMsg;
+      currentMsg.magic = sqe->magic;
+
+      // If magic is not set, SQE hasn't been written yet - wait for it
+      if (currentMsg.magic != TEST_EP_MAGIC_ID) {
+        std::this_thread::yield();
+        continue;
+      }
+
+      // Read rest of SQE after confirming magic is set
+      currentMsg.iteration = sqe->iteration;
+      currentMsg.gpuTime = sqe->gpuTime;
+      for (int j = 0; j < 5; ++j) {
+        currentMsg.data[j] = sqe->data[j];
+      }
+
+      // Use same sequence number (head) as SQE for circular buffer indexing
+      unsigned cqeIndex = head % queueSize;
+      // Store sequence number for validation (head is the sequence number)
+      uint32_t sqeSeq = head;
+
+      // Read delay value from data[0]
+      uint64_t actualDelayNs = currentMsg.data[0];
+
+      // Implement delay before responding
+      if (actualDelayNs > 0) {
+        if (actualDelayNs < 1000000) {
+          uint64_t startTime = getCpuTime();
+          while (getCpuTime() - startTime < actualDelayNs) {
+            // Busy-wait loop
+          }
+        } else {
+          std::this_thread::sleep_for(std::chrono::nanoseconds(actualDelayNs));
+        }
+      }
+
+      // Get CPU wall clock time AFTER delay is applied
+      uint64_t cpuTime = getCpuTime();
+
+      // Write CQE response
+      // Store sequence number in upper 32 bits, CPU time in lower 32 bits
+      // This allows GPU to verify CQE corresponds to its SQE
+      volatile cqeType* cqe = &cqeQueue[cqeIndex];
+      cqe->magic = TEST_EP_CQE_MAGIC_ID;
+      cqe->cpuTime = ((uint64_t)sqeSeq << 32) | (cpuTime & 0xFFFFFFFFULL);
+
+      head++;
+    }
+
+    if (head >= tail) {
+      std::this_thread::yield();
+    }
+  }
 }
 
 // CPU thread function that polls for GPU SQEs and generates CQEs
@@ -202,14 +281,23 @@ __host__ __device__ void test_ep_emulateEndpoint(unsigned sqeIterations,
 std::vector<std::thread> launchCpuThreads(void* hostSqeAddr, void* hostCqeAddr,
                                           unsigned numThreads,
                                           unsigned iterations,
-                                          long long delayNs) {
+                                          long long delayNs, unsigned doorbell,
+                                          void* doorbellAddr,
+                                          unsigned queueSize) {
   std::vector<std::thread> cpuThreadHandles;
 
   // Cast void* to endpoint-specific types
   volatile sqeType* sqePtr = static_cast<volatile sqeType*>(hostSqeAddr);
   volatile cqeType* cqePtr = static_cast<volatile cqeType*>(hostCqeAddr);
 
-  if (numThreads == 1) {
+  if (doorbell > 0) {
+    // Doorbell mode: single CPU thread polls doorbell
+    volatile uint32_t* doorbellPtr = static_cast<volatile uint32_t*>(
+      doorbellAddr);
+    cpuThreadHandles.emplace_back(cpuThreadDoorbell, sqePtr, cqePtr,
+                                  doorbellPtr, queueSize, numThreads,
+                                  iterations, delayNs);
+  } else if (numThreads == 1) {
     // Single-threaded mode
     cpuThreadHandles.emplace_back(cpuThread, sqePtr, cqePtr, iterations, 0,
                                   delayNs);
@@ -229,16 +317,18 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
                                 unsigned long long int* startTimes,
                                 unsigned long long int* endTimes,
                                 unsigned iterations, unsigned numThreads,
-                                long long delayNs) {
+                                long long delayNs, unsigned doorbell,
+                                uint32_t* doorbellAddr, unsigned queueSize) {
   // Get thread ID for multi-threading
   unsigned tid = blockIdx.x * blockDim.x + threadIdx.x;
   if (tid >= numThreads) {
     return;
   }
 
-  // Use per-thread buffers if multi-threaded
-  sqeType* mySqe = (numThreads > 1) ? &sqePtr[tid] : sqePtr;
-  cqeType* myCqe = (numThreads > 1) ? &cqePtr[tid] : cqePtr;
+  // Use per-thread buffers if multi-threaded (non-doorbell mode)
+  bool doorbellMode = (doorbell > 0);
+  sqeType* mySqe = (numThreads > 1 && !doorbellMode) ? &sqePtr[tid] : sqePtr;
+  cqeType* myCqe = (numThreads > 1 && !doorbellMode) ? &cqePtr[tid] : cqePtr;
   volatile cqeType* volatileCqe = myCqe;
 
   // Get per-thread timing arrays if provided
@@ -256,72 +346,172 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
   cqeType currentResponse = {};
   uint64_t lastCpuTime = 0;
 
-  // Encode thread index in iteration field (upper 32 bits) and iteration (lower
-  // 32 bits)
-  for (unsigned i = 0; i < iterations; ++i) {
-    // Record start time for this iteration
-    unsigned long long pollStartTime = wall_clock64();
-    if (myStartTimes != nullptr) {
-      myStartTimes[i] = pollStartTime;
+  if (doorbellMode) {
+    // Doorbell mode: write SQEs to circular queue and ring doorbell after all
+    // threads in an iteration have submitted their SQE
+    // Use a shared atomic counter for sequence numbers across all threads
+    __shared__ uint32_t globalSeq;
+    if (threadIdx.x == 0) {
+      globalSeq = 0;
     }
+    __syncthreads();
 
-    // Prepare message to CPU (matches simple-test)
-    // Encode thread index in upper 32 bits, iteration in lower 32 bits
-    sqeType msg = {};
-    msg.magic = TEST_EP_MAGIC_ID;
-    msg.iteration = ((uint64_t)tid << 32) | i;
-    msg.gpuTime = wall_clock64();
+    for (unsigned i = 0; i < iterations; ++i) {
+      // Record start time for this iteration (when SQE is posted)
+      unsigned long long pollStartTime = wall_clock64();
+      if (myStartTimes != nullptr) {
+        myStartTimes[i] = pollStartTime;
+      }
 
-    // Calculate delay based on delayNs parameter (per iteration, like
-    // simple-test) Negative: fixed delay of |delayNs| Positive: random delay
-    // between 0 and delayNs
-    uint64_t actualDelayNs = 0;
-    if (delayNs < 0) {
-      // Fixed delay: use absolute value
-      actualDelayNs = static_cast<uint64_t>(-delayNs);
-    } else if (delayNs > 0) {
-      // Random delay: generate value between 0 and delayNs
-      // Use thread ID, iteration, and GPU time as seed for pseudo-randomness
-      uint64_t seed = tid * 0x9e3779b9ULL + i * 0x6c6229e6ULL + wall_clock64();
-      // Simple LCG-based random number generator
-      seed = (seed * 1103515245ULL + 12345ULL) & 0x7FFFFFFFULL;
-      actualDelayNs = seed % (static_cast<uint64_t>(delayNs) + 1);
-    }
-    msg.data[0] = actualDelayNs;
+      // Prepare message to CPU
+      sqeType msg = {};
+      msg.magic = TEST_EP_MAGIC_ID;
+      msg.iteration = ((uint64_t)tid << 32) | i;
+      uint64_t sqeGpuTime = wall_clock64();
+      msg.gpuTime = sqeGpuTime;
 
-    // Fill remaining data payload
-    for (int j = 1; j < 5; ++j) {
-      msg.data[j] = 0x123456789ABCDEF0ULL + tid + i + j;
-    }
+      // Calculate delay
+      uint64_t actualDelayNs = 0;
+      if (delayNs < 0) {
+        actualDelayNs = static_cast<uint64_t>(-delayNs);
+      } else if (delayNs > 0) {
+        uint64_t seed = tid * 0x9e3779b9ULL + i * 0x6c6229e6ULL +
+                        wall_clock64();
+        seed = (seed * 1103515245ULL + 12345ULL) & 0x7FFFFFFFULL;
+        actualDelayNs = seed % (static_cast<uint64_t>(delayNs) + 1);
+      }
+      msg.data[0] = actualDelayNs;
 
-    // Write message to memory (matches simple-test)
-    *mySqe = msg;
-    __threadfence_system(); // Ensure write is visible
+      // Fill remaining data payload
+      for (int j = 1; j < 5; ++j) {
+        msg.data[j] = 0x123456789ABCDEF0ULL + tid + i + j;
+      }
 
-    // Poll for CPU response (matches simple-test exactly)
-    while (true) {
-      uint64_t magic = volatileCqe->magic;
-      uint64_t cpuTime = volatileCqe->cpuTime;
-      currentResponse.magic = magic;
-      currentResponse.cpuTime = cpuTime;
-      // Check if this is a new response
-      if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
-        if (currentResponse.cpuTime != 0) {
-          // Accept if this is a new response (cpuTime changed)
-          // Or if this is the first valid response (lastCpuTime was 0)
-          if (currentResponse.cpuTime != lastCpuTime || lastCpuTime == 0) {
-            break;
+      // Get next sequence number atomically (shared across all threads)
+      uint32_t seq = atomicAdd(&globalSeq, 1U);
+      unsigned sqeIndex = seq % queueSize;
+
+      // Write SQE
+      sqePtr[sqeIndex] = msg;
+      __threadfence_system(); // Ensure SQE write is visible
+
+      // Synchronize all threads before ringing doorbell
+      __syncthreads();
+
+      // Ring doorbell after all threads in this iteration have submitted their
+      // SQE (tail = (i + 1) * numThreads)
+      // Only thread 0 updates doorbell to avoid race conditions
+      if (doorbellAddr != nullptr && threadIdx.x == 0) {
+        uint32_t tail = (i + 1) * numThreads;
+        uint32_t* doorbellPtr = (uint32_t*)doorbellAddr;
+        __hip_atomic_store(doorbellPtr, tail, __ATOMIC_RELEASE,
+                           __HIP_MEMORY_SCOPE_SYSTEM);
+        __threadfence_system(); // Ensure doorbell update is visible
+      }
+      __syncthreads(); // Ensure doorbell update is visible to all threads
+
+      // Poll for CPU response in CQE queue (use same sequence number as SQE)
+      unsigned cqeIndex = seq % queueSize;
+      volatile cqeType* myCqe = &cqePtr[cqeIndex];
+      // Store expected sequence number for validation
+      uint32_t expectedSeq = seq;
+
+      while (true) {
+        uint64_t magic = myCqe->magic;
+        uint64_t cqeValue = myCqe->cpuTime;
+        currentResponse.magic = magic;
+        currentResponse.cpuTime = cqeValue;
+        if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
+          if (cqeValue != 0) {
+            // Verify CQE corresponds to our SQE by checking sequence number
+            // matches
+            uint32_t cqeSeq = (cqeValue >> 32) & 0xFFFFFFFFULL;
+            uint64_t cqeCpuTime = cqeValue & 0xFFFFFFFFULL;
+            if (cqeSeq == expectedSeq &&
+                (cqeCpuTime != (lastCpuTime & 0xFFFFFFFFULL) ||
+                 lastCpuTime == 0)) {
+              // Record GPU time immediately when valid CQE is detected
+              if (myEndTimes != nullptr) {
+                myEndTimes[i] = wall_clock64();
+              }
+              break;
+            }
           }
         }
       }
+      lastResponse = currentResponse;
+      lastCpuTime = currentResponse.cpuTime;
     }
-    lastResponse = currentResponse;
-    lastCpuTime = currentResponse.cpuTime;
+  } else {
+    // Normal polling mode
+    // Encode thread index in iteration field (upper 32 bits) and iteration
+    // (lower 32 bits)
+    for (unsigned i = 0; i < iterations; ++i) {
+      // Record start time for this iteration
+      unsigned long long pollStartTime = wall_clock64();
+      if (myStartTimes != nullptr) {
+        myStartTimes[i] = pollStartTime;
+      }
 
-    // Record GPU time when CPU response is received (use GPU time for both
-    // start and end)
-    if (myEndTimes != nullptr) {
-      myEndTimes[i] = wall_clock64();
+      // Prepare message to CPU (matches simple-test)
+      // Encode thread index in upper 32 bits, iteration in lower 32 bits
+      sqeType msg = {};
+      msg.magic = TEST_EP_MAGIC_ID;
+      msg.iteration = ((uint64_t)tid << 32) | i;
+      msg.gpuTime = wall_clock64();
+
+      // Calculate delay based on delayNs parameter (per iteration, like
+      // simple-test) Negative: fixed delay of |delayNs| Positive: random delay
+      // between 0 and delayNs
+      uint64_t actualDelayNs = 0;
+      if (delayNs < 0) {
+        // Fixed delay: use absolute value
+        actualDelayNs = static_cast<uint64_t>(-delayNs);
+      } else if (delayNs > 0) {
+        // Random delay: generate value between 0 and delayNs
+        // Use thread ID, iteration, and GPU time as seed for pseudo-randomness
+        uint64_t seed = tid * 0x9e3779b9ULL + i * 0x6c6229e6ULL +
+                        wall_clock64();
+        // Simple LCG-based random number generator
+        seed = (seed * 1103515245ULL + 12345ULL) & 0x7FFFFFFFULL;
+        actualDelayNs = seed % (static_cast<uint64_t>(delayNs) + 1);
+      }
+      msg.data[0] = actualDelayNs;
+
+      // Fill remaining data payload
+      for (int j = 1; j < 5; ++j) {
+        msg.data[j] = 0x123456789ABCDEF0ULL + tid + i + j;
+      }
+
+      // Write message to memory (matches simple-test)
+      *mySqe = msg;
+      __threadfence_system(); // Ensure write is visible
+
+      // Poll for CPU response (matches simple-test exactly)
+      while (true) {
+        uint64_t magic = volatileCqe->magic;
+        uint64_t cpuTime = volatileCqe->cpuTime;
+        currentResponse.magic = magic;
+        currentResponse.cpuTime = cpuTime;
+        // Check if this is a new response
+        if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
+          if (currentResponse.cpuTime != 0) {
+            // Accept if this is a new response (cpuTime changed)
+            // Or if this is the first valid response (lastCpuTime was 0)
+            if (currentResponse.cpuTime != lastCpuTime || lastCpuTime == 0) {
+              break;
+            }
+          }
+        }
+      }
+      lastResponse = currentResponse;
+      lastCpuTime = currentResponse.cpuTime;
+
+      // Record GPU time when CPU response is received (use GPU time for both
+      // start and end)
+      if (myEndTimes != nullptr) {
+        myEndTimes[i] = wall_clock64();
+      }
     }
   }
 
@@ -338,31 +528,69 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
 hipError_t test_ep_run(AxiioEndpointConfig* config) {
   std::vector<std::thread> cpuThreadHandles;
 
+  // Get test-ep specific config
+  test_ep::TestEpConfig* testEpConfig = static_cast<test_ep::TestEpConfig*>(
+    config->endpointConfig);
+  unsigned doorbell = (testEpConfig != nullptr) ? testEpConfig->doorbell : 0;
+
   // Cast void* to endpoint-specific types
   sqeType* sqePtr = static_cast<sqeType*>(config->submissionQueue);
   cqeType* cqePtr = static_cast<cqeType*>(config->completionQueue);
 
+  // Doorbell mode setup
+  void* doorbellAddr = nullptr;
+  unsigned queueSize = doorbell; // Use doorbell value as queue size
+  if (doorbell > 0) {
+    // Allocate doorbell (bit 2 of memoryMode: 0=host, 1=device)
+    bool doorbellOnDevice = (config->memoryMode & 0x4) != 0;
+    if (doorbellOnDevice) {
+      // Allocate device memory for doorbell
+      const size_t host_page_size = sysconf(_SC_PAGESIZE);
+      size_t alignedSize = ((sizeof(uint32_t) + host_page_size - 1) /
+                            host_page_size) *
+                           host_page_size;
+      hsa_status_t hsa_status = axiioAllocDeviceMemory(alignedSize,
+                                                       &doorbellAddr,
+                                                       "Doorbell");
+      if (hsa_status != HSA_STATUS_SUCCESS) {
+        std::cerr << "Error: Failed to allocate doorbell in device memory"
+                  << std::endl;
+        return hipErrorMemoryAllocation;
+      }
+      memset(doorbellAddr, 0, sizeof(uint32_t));
+    } else {
+      // Allocate host memory for doorbell
+      HIP_CHECK(
+        hipHostMalloc(&doorbellAddr, sizeof(uint32_t), hipHostMallocDefault));
+      memset(doorbellAddr, 0, sizeof(uint32_t));
+    }
+  }
+
   if (config->numThreads > 0) {
     // Check hardware concurrency for CPU threads
     unsigned hardwareThreads = std::thread::hardware_concurrency();
-    if (config->numThreads > hardwareThreads) {
-      // Warning: requested more CPU threads than available
+    if (config->numThreads > hardwareThreads && doorbell == 0) {
+      // Warning: requested more CPU threads than available (not applicable in
+      // doorbell mode)
     }
 
     // Launch CPU threads via launcher
     cpuThreadHandles = launchCpuThreads(config->submissionQueue,
                                         config->completionQueue,
                                         config->numThreads, config->iterations,
-                                        config->delayNs);
+                                        config->delayNs, doorbell, doorbellAddr,
+                                        queueSize);
 
     // Small delay to ensure CPU threads are ready
     std::this_thread::sleep_for(std::chrono::microseconds(100));
   }
 
   // Launch GPU kernel - pass pointers directly like simple-test
+  uint32_t* doorbellPtr = static_cast<uint32_t*>(doorbellAddr);
   hipLaunchKernelGGL(endpoint_kernel, dim3(1), dim3(config->numThreads), 0, 0,
                      sqePtr, cqePtr, config->startTimes, config->endTimes,
-                     config->iterations, config->numThreads, config->delayNs);
+                     config->iterations, config->numThreads, config->delayNs,
+                     doorbell, doorbellPtr, queueSize);
 
   // Check for kernel launch errors
   hipError_t err = hipGetLastError();
@@ -387,6 +615,16 @@ hipError_t test_ep_run(AxiioEndpointConfig* config) {
   // Join CPU threads if they were launched
   for (auto& thread : cpuThreadHandles) {
     thread.join();
+  }
+
+  // Free doorbell if allocated
+  if (doorbellAddr != nullptr) {
+    bool doorbellOnDevice = (config->memoryMode & 0x4) != 0;
+    if (doorbellOnDevice) {
+      hsa_memory_free(doorbellAddr);
+    } else {
+      HIP_CHECK(hipHostFree(doorbellAddr));
+    }
   }
 
   return hipSuccess;

--- a/src/include/axiio.h
+++ b/src/include/axiio.h
@@ -17,6 +17,11 @@
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
 
+// Forward declaration for CLI11
+namespace CLI {
+class App;
+}
+
 #include "axiio-endpoint-registry.h"
 // AUTO-GENERATED - DO NOT EDIT MANUALLY
 #include "axiio-endpoint-includes-gen.h"
@@ -46,9 +51,11 @@ struct AxiioEndpointConfig {
                              // Positive: random delay 0 to delayNs
                              // Zero: no delay
   unsigned memoryMode = 0;   // Memory mode bits:
-                             // Bit 0 (LSB): GPU write location
+                             // Bit 0 (LSB): GPU write location (SQE)
                              //   (0=host, 1=device)
-                             // Bit 1 (MSB): CPU write location
+                             // Bit 1: CPU write location (CQE)
+                             //   (0=host, 1=device)
+                             // Bit 2: Doorbell location (doorbell mode only)
                              //   (0=host, 1=device)
   bool verbose = false;      // Verbose output flag
 
@@ -92,9 +99,29 @@ public:
   __host__ virtual size_t getSubmissionQueueEntrySize() const = 0;
   __host__ virtual size_t getCompletionQueueEntrySize() const = 0;
 
+  // Get queue lengths (host-only) - number of entries needed
+  // Default implementation returns numThreads for multi-threaded, 1 for
+  // single-threaded Derived classes can override for custom queue sizing (e.g.,
+  // doorbell mode)
+  __host__ virtual size_t getSubmissionQueueLength(
+    const AxiioEndpointConfig* config) const;
+  __host__ virtual size_t getCompletionQueueLength(
+    const AxiioEndpointConfig* config) const;
+
   // Run endpoint test - launches GPU kernel and waits for completion
   // Each derived class implements this to call its specific run function
   __host__ virtual hipError_t run(AxiioEndpointConfig* config) = 0;
+
+  // Configure endpoint-specific CLI options
+  // Derived classes can override this to add their own CLI flags/options
+  // Default implementation does nothing (no endpoint-specific options)
+  __host__ virtual void configureCliOptions(CLI::App& app);
+
+  // Initialize endpoint-specific configuration
+  // Called after CLI parsing to set up endpointConfig pointer
+  // Returns pointer to endpoint-specific config object (or nullptr if none)
+  // Caller is responsible for managing the lifetime of the returned object
+  __host__ virtual void* initializeEndpointConfig();
 };
 
 // Factory function to create endpoint instances
@@ -106,12 +133,13 @@ __host__ std::unique_ptr<AxiioEndpoint> createEndpoint(
 // Helper functions
 void axiioPrintDeviceInfo();
 void axiioPrintStatistics(const std::vector<double>& durations,
-                          unsigned totalIterations = 0,
+                          unsigned totalIterations = 0, unsigned numThreads = 0,
                           unsigned readIterations = 0,
                           unsigned writeIterations = 0,
                           unsigned verifiedReadsCount = 0);
 void axiioPrintHistogram(const std::vector<double>& durations,
-                         unsigned nIterations, unsigned readIterations = 0,
+                         unsigned nIterations, unsigned numThreads = 0,
+                         unsigned readIterations = 0,
                          unsigned writeIterations = 0,
                          unsigned verifiedReadsCount = 0);
 
@@ -124,5 +152,14 @@ hipError_t axiioAllocateCompletionQueue(size_t size, unsigned memoryMode,
                                         void** ptr);
 void axiioFreeSubmissionQueue(void* ptr, unsigned memoryMode);
 void axiioFreeCompletionQueue(void* ptr, unsigned memoryMode);
+
+// HSA device memory allocation (for doorbell and other device memory needs)
+hsa_status_t axiioAllocDeviceMemory(size_t size, void** ptr,
+                                    const char* direction);
+
+// Extract endpoint name from command line arguments
+// This allows endpoints to add their CLI options before full parsing
+// Returns empty string if endpoint name not found in arguments
+std::string axiioExtractEndpointName(int argc, char** argv);
 
 #endif // AXIIO_H

--- a/src/tester/axiio-tester.cpp
+++ b/src/tester/axiio-tester.cpp
@@ -9,87 +9,132 @@
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <CLI/CLI.hpp>
 
 #include "axiio.h"
+#include "test-ep-config.h"
 
 int main(int argc, char** argv) {
   CLI::App app{"axiio-tester: A test harness for rocm-axiio."};
-  // Base configuration
-  AxiioEndpointConfig baseConfig;
+  app.fallthrough(true);
 
-  // CLI options - common testing parameters
-  app
-    .add_option("-n,--iterations", baseConfig.iterations,
-                "Number of I/O operations")
-    ->default_val(128);
-
-  app
-    .add_option("-t,--threads", baseConfig.numThreads,
-                "Number of GPU threads (default: 1, max: 32)")
-    ->default_val(1)
-    ->check(CLI::Range(1, 32));
-
-  app
-    .add_option("--delay", baseConfig.delayNs,
-                "Delay in nanoseconds for CPU response (default: 0). "
-                "Negative: fixed delay of |delay| ns. "
-                "Positive: random delay 0 to delay ns.")
-    ->default_val(0);
-
-  app
-    .add_option("-m,--memory-mode", baseConfig.memoryMode, "Memory mode (0-3)")
-    ->default_val(0)
-    ->check(CLI::Range(0, 3));
-
-  baseConfig.verbose = false;
-  app.add_flag("-v,--verbose", baseConfig.verbose, "Enable detailed output");
-
+  // Global flags (not endpoint-specific)
   bool printInfo = false;
   app.add_flag("-i,--info", printInfo, "Print GPU information");
-
-  bool printHistogram = false;
-  app.add_flag("--histogram", printHistogram, "Generate performance histogram");
-
-  std::string endpointName = "test-ep";
-  app.add_option("-e,--endpoint", endpointName, "Endpoint to use")
-    ->default_val("test-ep");
 
   bool listEndpoints = false;
   app.add_flag("-l,--list-endpoints", listEndpoints,
                "List all available endpoints");
 
+  // Common options (will be inherited by subcommands via fallthrough)
+  // We'll use a single config that gets copied to the selected endpoint
+  AxiioEndpointConfig commonConfig;
+  app
+    .add_option("-n,--iterations", commonConfig.iterations,
+                "Number of I/O operations")
+    ->default_val(128)
+    ->group("Common Options");
+
+  app
+    .add_option("-t,--threads", commonConfig.numThreads,
+                "Number of GPU threads (default: 1, max: 32)")
+    ->default_val(1)
+    ->check(CLI::Range(1, 32))
+    ->group("Common Options");
+
+  app
+    .add_option("--delay", commonConfig.delayNs,
+                "Delay in nanoseconds for CPU response (default: 0). "
+                "Negative: fixed delay of |delay| ns. "
+                "Positive: random delay 0 to delay ns.")
+    ->default_val(0)
+    ->group("Common Options");
+
+  app
+    .add_option("-m,--memory-mode", commonConfig.memoryMode,
+                "Memory mode (0-7)")
+    ->default_val(0)
+    ->check(CLI::Range(0, 7))
+    ->group("Common Options");
+
+  commonConfig.verbose = false;
+  app.add_flag("-v,--verbose", commonConfig.verbose, "Enable detailed output")
+    ->group("Common Options");
+
+  bool printHistogram = false;
+  app.add_flag("--histogram", printHistogram, "Generate performance histogram")
+    ->group("Common Options");
+
+  // Get all available endpoints
+  const auto& registry = getEndpointRegistry();
+
+  // Create subcommands for each endpoint
+  std::map<std::string, CLI::App*> endpointSubcommands;
+  std::map<std::string, std::unique_ptr<AxiioEndpoint>> endpoints;
+
+  for (const auto& endpointInfo : registry) {
+    // Create endpoint object
+    auto endpoint = createEndpoint(endpointInfo.name);
+    if (!endpoint) {
+      continue;
+    }
+
+    // Create subcommand for this endpoint
+    std::string description = endpointInfo.description;
+    CLI::App* subcmd = app.add_subcommand(endpointInfo.name, description);
+
+    // Enable fallthrough for the subcommand itself
+    // This allows options defined on the main app to be parsed
+    subcmd->fallthrough(true);
+
+    // Store endpoint and subcommand
+    endpoints[endpointInfo.name] = std::move(endpoint);
+    endpointSubcommands[endpointInfo.name] = subcmd;
+
+    // Let endpoint configure its own CLI options
+    endpoints[endpointInfo.name]->configureCliOptions(*subcmd);
+  }
+
+  // Parse command line
   CLI11_PARSE(app, argc, argv);
 
-  // List endpoints if requested
+  // Handle global flags
   if (listEndpoints) {
     listAvailableEndpoints();
     return EXIT_SUCCESS;
   }
 
-  // Print GPU info if requested
   if (printInfo) {
     axiioPrintDeviceInfo();
+    return EXIT_SUCCESS;
   }
 
-  // Validate endpoint
-  if (!isValidEndpoint(endpointName)) {
-    std::cerr << "Error: Unknown endpoint '" << endpointName << "'"
-              << std::endl;
-    std::cerr << "Use --list-endpoints to see available endpoints" << std::endl;
-    return EXIT_FAILURE;
+  // Find which subcommand was called
+  std::string selectedEndpoint;
+  for (const auto& [name, subcmd] : endpointSubcommands) {
+    if (subcmd->parsed()) {
+      selectedEndpoint = name;
+      break;
+    }
   }
 
-  // Create endpoint object using factory function
-  auto endpoint = createEndpoint(endpointName);
-  if (!endpoint) {
-    std::cerr << "Error: Failed to create endpoint '" << endpointName << "'"
-              << std::endl;
-    return EXIT_FAILURE;
+  // If no subcommand was called, show help
+  if (selectedEndpoint.empty()) {
+    std::cout << app.help() << std::endl;
+    return EXIT_SUCCESS;
   }
+
+  // Get the selected endpoint and copy common config
+  auto& endpoint = endpoints[selectedEndpoint];
+  AxiioEndpointConfig baseConfig = commonConfig;
+
+  // Initialize endpoint-specific configuration
+  baseConfig.endpointConfig = endpoint->initializeEndpointConfig();
 
   // Get GPU device information
   int deviceId = 0;
@@ -137,17 +182,35 @@ int main(int argc, char** argv) {
 
   // Extract memory mode bits and explain them
   bool gpuWriteToDevice = (baseConfig.memoryMode & 0x1) != 0; // LSB
-  bool cpuWriteToDevice = (baseConfig.memoryMode & 0x2) != 0; // MSB
+  bool cpuWriteToDevice = (baseConfig.memoryMode & 0x2) != 0; // Bit 1
+  bool doorbellOnDevice = (baseConfig.memoryMode & 0x4) != 0; // Bit 2
   std::cout << "Memory Mode: " << baseConfig.memoryMode
             << " (GPU write: " << (gpuWriteToDevice ? "device" : "host")
-            << ", CPU write: " << (cpuWriteToDevice ? "device" : "host") << ")"
+            << ", CPU write: " << (cpuWriteToDevice ? "device" : "host")
+            << ", Doorbell: " << (doorbellOnDevice ? "device" : "host") << ")"
             << std::endl;
 
-  // Get queue entry sizes from endpoint
+  // Get queue entry sizes and lengths from endpoint
   size_t sqeSize = endpoint->getSubmissionQueueEntrySize();
   size_t cqeSize = endpoint->getCompletionQueueEntrySize();
+  size_t sqeLength = endpoint->getSubmissionQueueLength(&baseConfig);
+  size_t cqeLength = endpoint->getCompletionQueueLength(&baseConfig);
+
+  // Validate doorbell mode: numThreads must not exceed doorbell queue length
+  test_ep::TestEpConfig* testEpConfig = static_cast<test_ep::TestEpConfig*>(
+    baseConfig.endpointConfig);
+  unsigned doorbell = (testEpConfig != nullptr) ? testEpConfig->doorbell : 0;
+  if (doorbell > 0 && baseConfig.numThreads > doorbell) {
+    std::cerr << "Error: Number of threads (" << baseConfig.numThreads
+              << ") exceeds doorbell queue length (" << doorbell << ")"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
   std::cout << "SQE size: " << sqeSize << " bytes" << std::endl;
   std::cout << "CQE size: " << cqeSize << " bytes" << std::endl;
+  std::cout << "SQE length: " << sqeLength << " entries" << std::endl;
+  std::cout << "CQE length: " << cqeLength << " entries" << std::endl;
 
   // Allocate queue memory
   void* hostSqeAddr = nullptr;
@@ -155,12 +218,8 @@ int main(int argc, char** argv) {
   unsigned long long int* hostStartTime = nullptr;
   unsigned long long int* hostEndTime = nullptr;
 
-  size_t totalSqeSize = (baseConfig.numThreads > 1)
-                          ? sqeSize * baseConfig.numThreads
-                          : sqeSize;
-  size_t totalCqeSize = (baseConfig.numThreads > 1)
-                          ? cqeSize * baseConfig.numThreads
-                          : cqeSize;
+  size_t totalSqeSize = sqeSize * sqeLength;
+  size_t totalCqeSize = cqeSize * cqeLength;
   size_t totalTimingSize = baseConfig.iterations * baseConfig.numThreads *
                            sizeof(unsigned long long int);
 
@@ -271,12 +330,15 @@ int main(int argc, char** argv) {
     }
   }
 
-  // Print statistics
+  // Print statistics (printHistogram is already set from common options)
+
   if (durations.size() > 0) {
     if (printHistogram) {
-      axiioPrintHistogram(durations, baseConfig.iterations);
+      axiioPrintHistogram(durations, baseConfig.iterations,
+                          baseConfig.numThreads);
     } else {
-      axiioPrintStatistics(durations, baseConfig.iterations);
+      axiioPrintStatistics(durations, baseConfig.iterations,
+                           baseConfig.numThreads);
     }
   } else {
     std::cout << "Warning: No valid timing data collected" << std::endl;


### PR DESCRIPTION
…ands

This commit implements doorbell mode for the test-ep endpoint and refactors the CLI interface to use subcommands for better organization and extensibility.

Doorbell Mode Features:
- Add --doorbell flag to test-ep subcommand to enable doorbell mode with specified queue length
- In doorbell mode, GPU threads write SQEs to a circular queue and ring a doorbell after all threads in an iteration have submitted their SQEs
- Single CPU thread polls the doorbell address instead of polling individual SQEs
- Doorbell location controlled by memory mode bit 2 (0=host, 1=device)
- GPU uses shared atomic counter (globalSeq) to assign unique sequence numbers to SQEs across all threads
- Doorbell increments by numThreads per iteration (e.g., with -t 4, doorbell jumps by 4 each iteration)
- Validation added to ensure numThreads <= doorbell queue length

CLI Refactoring:
- Refactor CLI to use subcommands for each endpoint (test-ep, nvme-ep, etc.)
- Global flags (-i, -l) remain on main app
- Common options (-n, -t, --delay, -m, -v, --histogram) inherited by subcommands via fallthrough()
- Endpoint-specific options only shown when help is requested for that subcommand
- Extract endpoint name from CLI args before parsing to allow endpoints to configure their options

Endpoint Architecture Improvements:
- Add virtual methods to AxiioEndpoint base class:
  * configureCliOptions() - allows endpoints to add their own CLI options
  * initializeEndpointConfig() - allows endpoints to initialize their config
  * getSubmissionQueueLength() - returns required SQE queue length
  * getCompletionQueueLength() - returns required CQE queue length
- TestEndpoint implements these methods to support doorbell mode queue sizing
- Other endpoints (nvme-ep, rdma-ep, sdma-ep) provide default empty implementations

Memory Mode Extension:
- Extend memory mode range from 0-3 to 0-7 (3 bits)
- Bit 0: GPU write location (SQE) - 0=host, 1=device
- Bit 1: CPU write location (CQE) - 0=host, 1=device
- Bit 2: Doorbell location (doorbell mode only) - 0=host, 1=device

Helper Functions:
- Make axiioAllocDeviceMemory() public (was static) for use by endpoints
- Add axiioExtractEndpointName() helper to manually parse endpoint name from CLI args before full parsing

Testing:
- All code passes clang-format linting
- All code compiles successfully
- Doorbell mode tested with various thread counts and queue lengths
