### PR TITLE
Add device functions to sdma-ep for GIN backend

### DIFF
--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -41,7 +41,7 @@ for MEMORY_MODE in 1 2 3 4 5 6 7; do
 done
 # Subcommand must come first; run sdma-ep only when GPU is whitelisted
 if $sdma_ep_allowed; then
-  ./build/xio-tester sdma-ep --to-host --verify -n 100
+  ./build/xio-tester sdma-ep p2p --to-host --verify -n 100
 else
   echo "INFO: Skipping sdma-ep tests (${ROCM_GPU_ARCH} not in SDMA whitelist)."
 fi

--- a/.alola/rocm-xio-tests.two-gpu.sbatch
+++ b/.alola/rocm-xio-tests.two-gpu.sbatch
@@ -51,7 +51,7 @@ run_p2p_test() {
 
   echo "Running sdma-ep P2P (GPU 0 -> GPU 1)..."
   p2p_rc=0
-  ./build/xio-tester sdma-ep -n "${n}" -s "${size_bytes}" --verify -v || p2p_rc=$?
+  ./build/xio-tester sdma-ep p2p -n "${n}" -s "${size_bytes}" --verify -v || p2p_rc=$?
 
   echo "Capturing XGMI metrics (after)..."
   amd-smi xgmi -m -g all --json > "${xgmi_after}" 2>/dev/null || true

--- a/src/endpoints/common/xio-endpoint.hip
+++ b/src/endpoints/common/xio-endpoint.hip
@@ -305,10 +305,13 @@ class SdmaEndpoint : public XioEndpoint {
   unsigned iterations_ = 128;
   bool useHostDst_ = false;
   bool verifyData_ = false;
+  bool useCounter_ = false;
+  bool useFlush_ = false;
   int srcDeviceId_ = -1;
   int dstDeviceId_ = -1;
   size_t transferSize_ = 4096;
   sdma_ep::SdmaEpConfig sdmaEpConfig_;
+  std::map<std::string, CLI::App*> testSubcommands;
 
 public:
   __host__ EndpointType getType() const override {
@@ -339,15 +342,7 @@ public:
     app.add_option("-n,--iterations", iterations_, "Number of SDMA transfers")
       ->default_val(128)
       ->group("Endpoint Options");
-    app
-      .add_flag("--to-host", useHostDst_,
-                "Use pinned host memory as destination (single GPU only)")
-      ->group("Endpoint Options");
-    app
-      .add_flag("--verify", verifyData_,
-                "Verify destination buffer contains expected pattern after "
-                "transfer (host-dst or P2P)")
-      ->group("Endpoint Options");
+
     app
       .add_option("--src-gpu", srcDeviceId_,
                   "Source HIP device ID (default: 0)")
@@ -367,11 +362,61 @@ public:
       ->transform(CLI::Validator(transferSizeTransform,
                                  "4k/1M/2G (binary) or bytes", "SIZE"))
       ->group("Endpoint Options");
+
+    // Register p2p subcommand
+    CLI::App* p2p =
+      app.add_subcommand("p2p", "Simple P2P between GPU -> GPU or GPU -> Host");
+    p2p
+      ->add_flag("--to-host", useHostDst_,
+                 "Use pinned host memory as destination (single GPU only)")
+      ->group("Endpoint Options");
+    p2p
+      ->add_flag("--verify", verifyData_,
+                 "Verify destination buffer contains expected pattern after "
+                 "transfer (host-dst or P2P)")
+      ->group("Endpoint Options");
+    testSubcommands["p2p"] = p2p;
+
+    // Register ping-pong subcommand
+    CLI::App* pingPong = app.add_subcommand(
+      "ping-pong", "Bidirectional ping-pong transfer between two GPUs");
+    pingPong
+      ->add_flag("--use-counter", useCounter_,
+                 "Use counter-based approach for buffer reuse")
+      ->group("Endpoint Options");
+    pingPong
+      ->add_flag("--use-flush", useFlush_,
+                 "Use flush-based approach for buffer reuse")
+      ->group("Endpoint Options");
+    testSubcommands["ping-pong"] = pingPong;
+
+    // Register buffer-reuse subcommand
+    CLI::App* bufferReuse = app.add_subcommand("buffer-reuse",
+                                               "Test buffer reuse patterns");
+    bufferReuse
+      ->add_flag("--use-counter", useCounter_,
+                 "Use counter-based approach for buffer reuse")
+      ->group("Endpoint Options");
+    bufferReuse
+      ->add_flag("--use-flush", useFlush_,
+                 "Use flush-based approach for buffer reuse")
+      ->group("Endpoint Options");
+    testSubcommands["buffer-reuse"] = bufferReuse;
   }
 
   __host__ void* initializeEndpointConfig() override {
+    // Determine which test subcommand was selected
+    for (const auto& [name, subcmd] : testSubcommands) {
+      if (subcmd && subcmd->parsed()) {
+        sdmaEpConfig_.testType = name;
+        break;
+      }
+    }
+
     sdmaEpConfig_.useHostDst = useHostDst_;
     sdmaEpConfig_.verifyData = verifyData_;
+    sdmaEpConfig_.useCounter = useCounter_;
+    sdmaEpConfig_.useFlush = useFlush_;
     sdmaEpConfig_.srcDeviceId = srcDeviceId_;
     sdmaEpConfig_.dstDeviceId = dstDeviceId_;
     sdmaEpConfig_.transferSize = transferSize_;
@@ -382,6 +427,13 @@ public:
     if (endpointConfig) {
       const auto* ep = static_cast<const sdma_ep::SdmaEpConfig*>(
         endpointConfig);
+      if (ep->testType.empty()) {
+        return "Missing test subcommand. Available: p2p, ping-pong, "
+               "buffer-reuse";
+      }
+      if (ep->useCounter && ep->useFlush) {
+        return "Cannot use both --use-counter and --use-flush at the same time";
+      }
       if (ep->transferSize == 0)
         return "transfer-size must be > 0";
       if (ep->transferSize % 4 != 0)

--- a/src/endpoints/sdma-ep/anvil.hip
+++ b/src/endpoints/sdma-ep/anvil.hip
@@ -178,8 +178,10 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId,
                                         sizeof(uint64_t),
                                         hipDeviceMallocUncached));
 
-  uint64_t cachedWptr = (uint64_t) * (queue_.Queue_write_ptr_aql);
-  uint64_t committedWptr = (uint64_t) * (queue_.Queue_write_ptr_aql);
+  uint64_t cachedWptr = *reinterpret_cast<uint64_t*>(
+    queue_.Queue_write_ptr_aql);
+  uint64_t committedWptr = *reinterpret_cast<uint64_t*>(
+    queue_.Queue_write_ptr_aql);
   SdmaQueueDeviceHandle handle = {
     .queueBuf = static_cast<uint32_t*>(queueBuffer_),
     .rptr = queue_.Queue_read_ptr_aql,
@@ -187,7 +189,9 @@ SdmaQueue::SdmaQueue(int localDeviceId, int remoteDeviceId,
     .doorbell = queue_.Queue_DoorBell_aql,
     .cachedWptr = cachedWptr_,
     .committedWptr = committedWptr_,
-    .cachedHwReadIndex = (uint64_t) * (queue_.Queue_read_ptr_aql),
+    .cachedHwReadIndex = *reinterpret_cast<uint64_t*>(
+      queue_.Queue_read_ptr_aql),
+    .maxWritePtr = *reinterpret_cast<uint64_t*>(queue_.Queue_read_ptr_aql),
   };
 
   CHECK_HIP_ERROR(hipMemcpy(deviceHandle_, &handle,

--- a/src/endpoints/sdma-ep/anvil_device.hpp
+++ b/src/endpoints/sdma-ep/anvil_device.hpp
@@ -69,24 +69,33 @@ __device__ __forceinline__ SDMA_PKT_FENCE CreateFencePacket(HSAuint64* address,
   return packet;
 }
 
-// Assumes signal is allocated in device memory
-__device__ __forceinline__ bool waitForSignal(HSAuint64* addr,
+template <int64_t MAX_SPIN_COUNT = -1>
+__device__ __forceinline__ void poll_until_lt(uint64_t* addr,
                                               uint64_t expected) {
-  int retries = 0;
-
-  while (true) {
-    uint64_t value = __hip_atomic_load(addr, __ATOMIC_RELAXED,
-                                       __HIP_MEMORY_SCOPE_AGENT);
-    if (value == expected) {
-      return true;
-    }
-    if constexpr (BREAK_ON_RETRIES) {
-      if (retries++ == MAX_RETRIES) {
-        break;
-      }
-    }
+  [[maybe_unused]] int64_t spin_count = 0;
+  while (__hip_atomic_load(addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) <
+         expected) {
+    spin_count++;
+    assert(MAX_SPIN_COUNT < 0 || spin_count != MAX_SPIN_COUNT);
   }
-  return false;
+}
+
+// Assumes signal is allocated in device memory
+__device__ __forceinline__ void waitSignal(uint64_t* addr, uint64_t expected) {
+  if constexpr (BREAK_ON_RETRIES) {
+    poll_until_lt<MAX_RETRIES>(addr, expected);
+  } else {
+    poll_until_lt<-1>(addr, expected);
+  }
+}
+
+// Assumes counter is allocated in device memory
+__device__ __forceinline__ void waitCounter(uint64_t* addr, uint64_t expected) {
+  if constexpr (BREAK_ON_RETRIES) {
+    poll_until_lt<MAX_RETRIES>(addr, expected);
+  } else {
+    poll_until_lt<-1>(addr, expected);
+  }
 }
 
 struct SdmaQueueDeviceHandle {
@@ -219,6 +228,23 @@ struct SdmaQueueDeviceHandle {
     __builtin_amdgcn_s_waitcnt(0);
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
     __builtin_nontemporal_store(pendingWptr, committedWptr);
+    maxWritePtr = pendingWptr;
+  }
+
+  __device__ __forceinline__ void flush(uint64_t upToIndex) {
+    uint64_t hw_read_index;
+    do {
+      hw_read_index = __hip_atomic_load(rptr, __ATOMIC_RELAXED,
+                                        __HIP_MEMORY_SCOPE_AGENT);
+    } while (hw_read_index < upToIndex);
+  }
+
+  __device__ __forceinline__ void quiet() {
+    uint64_t hw_read_index;
+    do {
+      hw_read_index = __hip_atomic_load(rptr, __ATOMIC_RELAXED,
+                                        __HIP_MEMORY_SCOPE_AGENT);
+    } while (hw_read_index < maxWritePtr);
   }
 
   // Queue resources
@@ -232,6 +258,7 @@ struct SdmaQueueDeviceHandle {
   uint64_t* committedWptr;
   // local variables
   uint64_t cachedHwReadIndex;
+  uint64_t maxWritePtr;
 
 private:
   __device__ __forceinline__ bool nontemporal_compare_exchange(
@@ -312,36 +339,88 @@ struct SdmaQueueSingleProducerDeviceHandle : SdmaQueueDeviceHandle {
 static_assert(sizeof(SdmaQueueSingleProducerDeviceHandle) ==
               sizeof(SdmaQueueDeviceHandle));
 
+template <bool PUT_EN, bool SIGNAL_EN, bool COUNTER_EN>
+__device__ __forceinline__ void put_signal_counter_impl(
+  SdmaQueueDeviceHandle& handle, void* dst, void* src, size_t size,
+  uint64_t* signal, uint64_t* counter, uint64_t* put_index = nullptr) {
+  constexpr size_t space_required =
+    ((PUT_EN) ? sizeof(SDMA_PKT_COPY_LINEAR) : 0) +
+    ((SIGNAL_EN) ? sizeof(SDMA_PKT_ATOMIC) : 0) +
+    ((COUNTER_EN) ? sizeof(SDMA_PKT_ATOMIC) : 0);
+  auto base = handle.ReserveQueueSpace(space_required);
+  uint64_t pendingWptr = base;
+
+  if constexpr (PUT_EN) {
+    auto copy_packet = CreateCopyPacket(src, dst, size);
+    handle.placePacket(copy_packet, pendingWptr);
+    if (put_index != nullptr) {
+      *put_index = pendingWptr;
+    }
+  }
+  if constexpr (SIGNAL_EN) {
+    auto signal_packet = CreateAtomicIncPacket(
+      reinterpret_cast<HSAuint64*>(signal));
+    handle.placePacket(signal_packet, pendingWptr);
+  }
+  if constexpr (COUNTER_EN) {
+    auto counter_packet = CreateAtomicIncPacket(
+      reinterpret_cast<HSAuint64*>(counter));
+    handle.placePacket(counter_packet, pendingWptr);
+  }
+  handle.submitPacket(base, pendingWptr);
+}
+
 __device__ __forceinline__ void put(SdmaQueueDeviceHandle& handle, void* dst,
                                     void* src, size_t size) {
-  auto base = handle.ReserveQueueSpace(sizeof(SDMA_PKT_COPY_LINEAR));
-  auto packet = CreateCopyPacket(src, dst, size);
-  uint64_t pendingWptr = base;
-  handle.placePacket(packet, pendingWptr);
-  handle.submitPacket(base, pendingWptr);
+  put_signal_counter_impl<true, false, false>(handle, dst, src, size, nullptr,
+                                              nullptr);
 }
 
+// TODO should increment value be a parameter?
 __device__ __forceinline__ void signal(SdmaQueueDeviceHandle& handle,
-                                       void* signal) {
-  auto base = handle.ReserveQueueSpace(sizeof(SDMA_PKT_ATOMIC));
-  auto packet = CreateAtomicIncPacket(reinterpret_cast<HSAuint64*>(signal));
-  uint64_t pendingWptr = base;
-  handle.placePacket(packet, pendingWptr);
-  handle.submitPacket(base, pendingWptr);
+                                       uint64_t* signal) {
+  put_signal_counter_impl<false, true, false>(handle, nullptr, nullptr, 0,
+                                              signal, nullptr);
 }
 
-__device__ __forceinline__ void putWithSignal(SdmaQueueDeviceHandle& handle,
-                                              void* dst, void* src, size_t size,
-                                              void* signal) {
-  auto base = handle.ReserveQueueSpace(sizeof(SDMA_PKT_COPY_LINEAR) +
-                                       sizeof(SDMA_PKT_ATOMIC));
-  auto copy_packet = CreateCopyPacket(src, dst, size);
-  auto signal_packet = CreateAtomicIncPacket(
-    reinterpret_cast<HSAuint64*>(signal));
-  uint64_t pendingWptr = base;
-  handle.placePacket(copy_packet, pendingWptr);
-  handle.placePacket(signal_packet, pendingWptr);
-  handle.submitPacket(base, pendingWptr);
+__device__ __forceinline__ void put_signal(SdmaQueueDeviceHandle& handle,
+                                           void* dst, void* src, size_t size,
+                                           uint64_t* signal) {
+  put_signal_counter_impl<true, true, false>(handle, dst, src, size, signal,
+                                             nullptr);
+}
+
+__device__ __forceinline__ void put_signal_counter(
+  SdmaQueueDeviceHandle& handle, void* dst, void* src, size_t size,
+  uint64_t* signal, uint64_t* counter) {
+  put_signal_counter_impl<true, true, true>(handle, dst, src, size, signal,
+                                            counter);
+}
+
+__device__ __forceinline__ void put_counter(SdmaQueueDeviceHandle& handle,
+                                            void* dst, void* src, size_t size,
+                                            uint64_t* counter) {
+  put_signal_counter_impl<true, false, true>(handle, dst, src, size, nullptr,
+                                             counter);
+}
+
+__device__ __forceinline__ void signal_counter(SdmaQueueDeviceHandle& handle,
+                                               uint64_t* signal,
+                                               uint64_t* counter) {
+  put_signal_counter_impl<false, true, true>(handle, nullptr, nullptr, 0,
+                                             signal, counter);
+}
+
+// Allows application to track certain operations, usually put operations
+// and only flush up to the most recent put operation,
+// ignoring other operations such as signal
+__device__ __forceinline__ void flush(SdmaQueueDeviceHandle& handle,
+                                      uint64_t up_to_index) {
+  handle.flush(up_to_index);
+}
+
+__device__ __forceinline__ void quiet(SdmaQueueDeviceHandle& handle) {
+  handle.quiet();
 }
 
 } // namespace anvil

--- a/src/endpoints/sdma-ep/sdma-ep.h
+++ b/src/endpoints/sdma-ep/sdma-ep.h
@@ -9,10 +9,15 @@
 namespace sdma_ep {
 
 struct SdmaEpConfig {
-  bool useHostDst = false; // If true, use pinned host memory as destination
-                           // (single GPU, no P2P required)
-  bool verifyData = false; // If true, validate destination contains 0xAB
-                           // after transfer (host-dst or P2P).
+  std::string testType = ""; // Which test subcommand: "p2p", "ping-pong", or
+                             // "buffer-reuse"
+  bool useHostDst = false;   // If true, use pinned host memory as destination
+                             // (single GPU, no P2P required)
+  bool verifyData = false;   // If true, validate destination contains 0xAB
+                             // after transfer (host-dst or P2P).
+  bool useCounter = false;   // For buffer-reuse/ping-pong: use counter-based
+                             // approach
+  bool useFlush = false; // For buffer-reuse/ping-pong: use flush-based approach
   // HIP device IDs. Use -1 for default (src=0, dst=1 for P2P; both 0 for
   // --to-host).
   int srcDeviceId = -1;

--- a/src/endpoints/sdma-ep/sdma-ep.hip
+++ b/src/endpoints/sdma-ep/sdma-ep.hip
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <map>
 #include <vector>
 
 #include <hip/hip_ext.h>
@@ -64,12 +65,11 @@ void ensureAnvilInit() {
 
 // Single-thread kernel: one thread does all transfers to avoid queue
 // contention (multi-thread submit can stall on anvil's committedWptr ordering).
-__global__ void sdma_transfer_kernel(anvil::SdmaQueueDeviceHandle* handle,
-                                     void* dstBuf, void* srcBuf,
-                                     size_t transferSize, unsigned iterations,
-                                     HSAuint64* signal,
-                                     unsigned long long* startTimes,
-                                     unsigned long long* endTimes) {
+__global__ void sdma_p2p_kernel(anvil::SdmaQueueDeviceHandle* handle,
+                                void* dstBuf, void* srcBuf, size_t transferSize,
+                                unsigned iterations, uint64_t* signal,
+                                unsigned long long* startTimes,
+                                unsigned long long* endTimes) {
   for (unsigned i = 0; i < iterations; i++) {
     size_t offset = i * transferSize;
     void* src = static_cast<char*>(srcBuf) + offset;
@@ -80,7 +80,7 @@ __global__ void sdma_transfer_kernel(anvil::SdmaQueueDeviceHandle* handle,
     }
 
     if (i == iterations - 1) {
-      anvil::putWithSignal(*handle, dst, src, transferSize, signal);
+      anvil::put_signal(*handle, dst, src, transferSize, signal);
     } else {
       anvil::put(*handle, dst, src, transferSize);
     }
@@ -91,7 +91,273 @@ __global__ void sdma_transfer_kernel(anvil::SdmaQueueDeviceHandle* handle,
   }
   // Kernel waits for SDMA completion so host can rely on hipDeviceSynchronize
   if (iterations > 0) {
-    anvil::waitForSignal(signal, 1);
+    anvil::waitSignal(signal, 1);
+  }
+}
+
+// Ping-pong kernel to test latency of put, signal, quiet
+// quiet can be substituted by local counter or flush
+__global__ void sdma_ping_pong_kernel(anvil::SdmaQueueDeviceHandle* handle,
+                                      void* dstBuf, void* srcBuf, size_t nElem,
+                                      unsigned iterations, uint64_t** signals,
+                                      int rank, uint64_t* counter,
+                                      bool use_counter, bool use_flush,
+                                      unsigned long long* startTimes,
+                                      unsigned long long* endTimes) {
+  if (rank > 1)
+    return;
+
+  // Maintain local copy of SDMA handle
+  // This is required if the handle is shared across multiple waves or
+  // threadblocks
+  anvil::SdmaQueueDeviceHandle sdma_handle = *handle;
+
+  int rank1_offset = 1000000;
+
+  int* src = static_cast<int*>(srcBuf);
+  int* dst = static_cast<int*>(dstBuf);
+
+  uint64_t* local_signal = signals[rank];
+  uint64_t* remote_signal = signals[1 - rank];
+  // Use value to track index of put operation
+  // This is an advanced optimization
+  uint64_t put_index = 0;
+
+  for (unsigned i = 0; i < iterations; i++) {
+    // Initiator
+    if (rank == 0) {
+      if (threadIdx.x == 0) {
+        if (startTimes != nullptr) {
+          startTimes[i] = wall_clock64();
+        }
+      }
+      // Populate src buffer
+      for (size_t j = threadIdx.x; j < nElem; j += blockDim.x) {
+        src[j] = i + j + 42;
+      }
+      __syncthreads();
+      __threadfence_system();
+      // Have thread 0 trigger the SDMA
+      if (threadIdx.x == 0) {
+        if (use_counter) {
+          anvil::put_signal_counter(sdma_handle, dst, src, nElem * sizeof(int),
+                                    remote_signal, counter);
+        } else if (use_flush) {
+          anvil::put_signal_counter_impl<true, true, false>(
+            sdma_handle, dst, src, nElem * sizeof(int), remote_signal,
+            /* counter*/ nullptr, &put_index);
+        } else {
+          anvil::put_signal(sdma_handle, dst, src, nElem * sizeof(int),
+                            remote_signal);
+        }
+      }
+
+      // Flush for benchmarking purpose
+      if (threadIdx.x == 0) {
+        if (use_counter) {
+          anvil::waitCounter(counter, i + 1);
+        } else if (use_flush) {
+          anvil::flush(sdma_handle, put_index);
+        } else {
+          anvil::quiet(sdma_handle);
+        }
+      }
+
+      // Wait for signal
+      if (threadIdx.x == 0) {
+        anvil::waitSignal(local_signal, (i + 1));
+      }
+      __syncthreads();
+
+      if (endTimes != nullptr) {
+        endTimes[i] = wall_clock64();
+      }
+
+      // Check if received values are correct
+      for (size_t j = threadIdx.x; j < nElem; j += blockDim.x) {
+        int expected_value = static_cast<int>(rank1_offset + i + j + 42);
+        if (src[j] != expected_value) {
+          printf("[SDMA-EP] rank 1 Error: buffer[%zu] = %d, expected %d\n", j,
+                 src[j], expected_value);
+        }
+      }
+    }
+
+    // Responder
+    if (rank == 1) {
+      // Have thread 0 wait for signal
+      if (threadIdx.x == 0) {
+        anvil::waitSignal(local_signal, (i + 1));
+      }
+      __syncthreads();
+
+      // Check if received values are correct
+      for (size_t j = threadIdx.x; j < nElem; j += blockDim.x) {
+        int expected_value = static_cast<int>(i + j + 42);
+        if (src[j] != expected_value) {
+          printf("[SDMA-EP] rank 1 Error: buffer[%zu] = %d, expected %d\n", j,
+                 src[j], expected_value);
+        }
+        // Update values to send them back
+        src[j] += rank1_offset;
+      }
+      __syncthreads();
+      __threadfence_system();
+
+      // Signal that rank1 is ready for next iteration
+      if (threadIdx.x == 0) {
+        if (use_counter) {
+          anvil::put_signal_counter(sdma_handle, dst, src, nElem * sizeof(int),
+                                    remote_signal, counter);
+        } else if (use_flush) {
+          anvil::put_signal_counter_impl<true, true, false>(
+            sdma_handle, dst, src, nElem * sizeof(int), remote_signal,
+            /* counter */ nullptr, &put_index);
+
+        } else {
+          anvil::put_signal(sdma_handle, dst, src, nElem * sizeof(int),
+                            remote_signal);
+        }
+      }
+
+      // Flush for benchmarking purpose
+      if (threadIdx.x == 0) {
+        if (use_counter) {
+          anvil::waitCounter(counter, i + 1);
+        } else if (use_flush) {
+          anvil::flush(sdma_handle, put_index);
+        } else {
+          anvil::quiet(sdma_handle);
+        }
+      }
+    }
+
+  } // iteration
+}
+
+// Kernel that sends data from rank0 to rank1
+// rank0 is re-using the same buffer for `transfers_per_iteration` iterations
+// This kernel tests the different variations to determine that the source
+// buffer can be re-used
+__global__ void sdma_buffer_reuse_kernel(
+  anvil::SdmaQueueDeviceHandle* handle, void* dstBuf, void* srcBuf,
+  size_t nElem, unsigned iterations, uint64_t** signals, int rank,
+  uint64_t* counter, bool use_counter, bool use_flush,
+  unsigned long long* startTimes, unsigned long long* endTimes) {
+  if (rank > 1)
+    return;
+
+  // Maintain local copy of SDMA handle
+  // This is required if the handle is shared across multiple waves or
+  // threadblocks
+  anvil::SdmaQueueDeviceHandle sdma_handle = *handle;
+
+  unsigned transfers_per_iteration = 10;
+
+  int* src = static_cast<int*>(srcBuf);
+  int* dst = static_cast<int*>(dstBuf);
+
+  uint64_t* local_signal = signals[rank];
+  uint64_t* remote_signal = signals[1 - rank];
+
+  // Use value to track index of put operation
+  // This is an advanced optimization
+  uint64_t put_index = 0;
+
+  for (unsigned i = 0; i < iterations; i++) {
+    // if (startTimes != nullptr) {
+    //   startTimes[i] = wall_clock64();
+    // }
+
+    int offset = 0;
+
+    // Initiator
+    if (rank == 0) {
+      for (unsigned t = 0; t < transfers_per_iteration; t++) {
+        // Populate src buffer
+        for (size_t j = threadIdx.x; j < nElem; j += blockDim.x) {
+          src[j] = i + (t * nElem) + j + 42;
+        }
+        __syncthreads();
+        __threadfence_system();
+        // Have thread 0 trigger the SDMA
+        if (threadIdx.x == 0) {
+          if (t == (transfers_per_iteration - 1)) {
+            if (use_counter) {
+              anvil::put_signal_counter(sdma_handle, dst + offset, src,
+                                        nElem * sizeof(int), remote_signal,
+                                        counter);
+
+            } else if (use_flush) {
+              anvil::put_signal_counter_impl<true, true, false>(
+                sdma_handle, dst + offset, src, nElem * sizeof(int),
+                remote_signal, /*counter*/ nullptr, &put_index);
+            } else {
+              anvil::put_signal(sdma_handle, dst + offset, src,
+                                nElem * sizeof(int), remote_signal);
+            }
+          } else {
+            if (use_counter) {
+              anvil::put_counter(sdma_handle, dst + offset, src,
+                                 nElem * sizeof(int), counter);
+            } else if (use_flush) {
+              anvil::put_signal_counter_impl<true, false, false>(
+                sdma_handle, dst + offset, src, nElem * sizeof(int),
+                /* signal*/ nullptr, /*counter*/ nullptr, &put_index);
+            } else {
+              anvil::put(sdma_handle, dst + offset, src, nElem * sizeof(int));
+            }
+          }
+        }
+        // Wait for buffer re-use
+        if (threadIdx.x == 0) {
+          if (use_counter) {
+            anvil::waitCounter(counter, (i * transfers_per_iteration) + t + 1);
+          } else if (use_flush) {
+            anvil::flush(sdma_handle, put_index);
+          } else {
+            anvil::quiet(sdma_handle);
+          }
+        }
+        __syncthreads();
+        offset += nElem;
+      }
+
+      // Wait for signal
+      if (threadIdx.x == 0) {
+        anvil::waitSignal(local_signal, (i + 1));
+      }
+    }
+
+    // Responder
+    if (rank == 1) {
+      // Have thread 0 wait for padding
+      if (threadIdx.x == 0) {
+        anvil::waitSignal(local_signal, (i + 1));
+      }
+      __syncthreads();
+
+      // Check if received values are correct
+      for (unsigned t = 0; t < transfers_per_iteration; t++) {
+        for (size_t j = threadIdx.x; j < nElem; j += blockDim.x) {
+          int expected_value = static_cast<int>(i + (t * nElem) + j + 42);
+          if (src[j + offset] != expected_value) {
+            printf("[SDMA-EP] rank 1 Error: buffer[%zu] = %d, expected %d\n",
+                   j + offset, src[j + offset], expected_value);
+          }
+        }
+        offset += nElem;
+      }
+
+      // Signal that rank1 is ready for next iteration
+      __syncthreads();
+      if (threadIdx.x == 0) {
+        anvil::signal(sdma_handle, remote_signal);
+      }
+    }
+    // if (endTimes != nullptr) {
+    //   endTimes[i] = wall_clock64();
+    // }
   }
 }
 
@@ -113,14 +379,20 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
   int cfgSrc = -1;
   int cfgDst = -1;
   size_t transferSize = 4096;
+  std::string testType = "";
+  bool useCounter = false;
+  bool useFlush = false;
   if (config->endpointConfig) {
     const auto* epConfig = static_cast<const sdma_ep::SdmaEpConfig*>(
       config->endpointConfig);
+    testType = epConfig->testType;
     useHostDst = epConfig->useHostDst;
     verifyData = epConfig->verifyData;
     cfgSrc = epConfig->srcDeviceId;
     cfgDst = epConfig->dstDeviceId;
     transferSize = epConfig->transferSize;
+    useCounter = epConfig->useCounter;
+    useFlush = epConfig->useFlush;
   }
 
   int numGpus = 0;
@@ -186,8 +458,27 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
       return hipErrorInvalidDevice;
     }
     anvil::EnablePeerAccess(srcGpu, dstGpu);
+
+    // For buffer-reuse and ping-pong, enable bidirectional peer access
+    if (testType == "buffer-reuse" || testType == "ping-pong") {
+      int canAccessReverse = 0;
+      err = hipDeviceCanAccessPeer(&canAccessReverse, dstGpu, srcGpu);
+      if (err != hipSuccess) {
+        std::cerr << "hipDeviceCanAccessPeer (reverse) failed: "
+                  << hipGetErrorString(err) << std::endl;
+        return err;
+      }
+      if (canAccessReverse == 0) {
+        std::cerr << "P2P not available: GPU " << dstGpu
+                  << " cannot access GPU " << srcGpu
+                  << " (hipDeviceCanAccessPeer returned 0)" << std::endl;
+        return hipErrorInvalidDevice;
+      }
+      anvil::EnablePeerAccess(dstGpu, srcGpu);
+    }
   }
 
+  // Create bidirectional SDMA connections and queues
   try {
     bool success = anvil::AnvilLib::getInstance().connect(srcGpu, dstGpu, 1);
     if (!success) {
@@ -195,18 +486,39 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
                 << ", dst=" << dstGpu << ")" << std::endl;
       return hipErrorInvalidDevice;
     }
+
+    success = anvil::AnvilLib::getInstance().connect(dstGpu, srcGpu, 1);
+    if (!success) {
+      std::cerr << "Failed to connect SDMA (src=" << dstGpu
+                << ", dst=" << srcGpu << ")" << std::endl;
+      return hipErrorInvalidDevice;
+    }
   } catch (const std::exception& e) {
     std::cerr << "SDMA connect error: " << e.what() << std::endl;
     return hipErrorInvalidDevice;
   }
 
-  anvil::SdmaQueue* queue = nullptr;
+  // Store SDMA queue handles in a map indexed by rank
+  std::map<int, anvil::SdmaQueueDeviceHandle*> sdmaHandles;
+
   try {
-    queue = anvil::AnvilLib::getInstance().getSdmaQueue(srcGpu, dstGpu, 0);
-    if (queue == nullptr) {
-      std::cerr << "Failed to get SDMA queue" << std::endl;
+    anvil::SdmaQueue* queue0 =
+      anvil::AnvilLib::getInstance().getSdmaQueue(srcGpu, dstGpu, 0);
+    if (queue0 == nullptr) {
+      std::cerr << "Failed to get SDMA queue (rank 0: " << srcGpu << " -> "
+                << dstGpu << ")" << std::endl;
       return hipErrorInvalidValue;
     }
+    sdmaHandles[0] = queue0->deviceHandle();
+
+    anvil::SdmaQueue* queue1 =
+      anvil::AnvilLib::getInstance().getSdmaQueue(dstGpu, srcGpu, 0);
+    if (queue1 == nullptr) {
+      std::cerr << "Failed to get SDMA queue (rank 1: " << dstGpu << " -> "
+                << srcGpu << ")" << std::endl;
+      return hipErrorInvalidValue;
+    }
+    sdmaHandles[1] = queue1->deviceHandle();
   } catch (const std::exception& e) {
     std::cerr << "SDMA queue error: " << e.what() << std::endl;
     return hipErrorInvalidValue;
@@ -218,7 +530,10 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
     return err;
 
   // Calculate buffer sizes (transferSize from config, validated by endpoint)
-  size_t totalSize = transferSize * config->iterations;
+  size_t totalSize = transferSize * config->iterations * 10;
+  // if (testType == "buffer-reuse") {
+  //   totalSize = transferSize * 10;
+  // }
 
   // Allocate source buffer on source GPU (uncached for P2P to match RAD)
   void* srcBuf = nullptr;
@@ -276,8 +591,49 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
     }
   }
 
-  // Ensure current device is srcGpu so signal is allocated on source (SDMA
-  // on src writes completion there).
+  // Helper lambda for cleanup (defined early so it can be used in error paths)
+  auto cleanupBuffers = [&]() {
+    if (useHostDst) {
+      ignoreHip(hipHostFree(dstBuf));
+    } else {
+      ignoreHip(hipSetDevice(dstGpu));
+      ignoreHip(hipFree(dstBuf));
+    }
+    ignoreHip(hipSetDevice(srcGpu));
+    ignoreHip(hipFree(srcBuf));
+  };
+
+  // Allocate completion signals - use uncached memory for P2P access
+  // For buffer-reuse, signals map stores pointers to device arrays of signal
+  // pointers For p2p, signals map stores individual signal pointers
+  std::map<int, uint64_t**> signals;
+
+  // Allocate individual signal memory on each GPU
+  uint64_t* signal0 = nullptr;
+  uint64_t* signal1 = nullptr;
+
+  auto cleanupSignals = [&]() {
+    // Free device signal arrays
+    if (signals.count(0)) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(signals[0]));
+    }
+    if (signals.count(1)) {
+      ignoreHip(hipSetDevice(dstGpu));
+      ignoreHip(hipFree(signals[1]));
+    }
+    // Free individual signal memory
+    if (signal1 != nullptr) {
+      ignoreHip(hipSetDevice(dstGpu));
+      ignoreHip(hipFree(signal1));
+    }
+    if (signal0 != nullptr) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(signal0));
+    }
+  };
+
+  // Allocate signal on source GPU (rank 0)
   err = hipSetDevice(srcGpu);
   if (err != hipSuccess) {
     if (useHostDst) {
@@ -290,9 +646,8 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
     return err;
   }
 
-  // Completion signal on source GPU (device memory) so SDMA can update it
-  HSAuint64* signal = nullptr;
-  err = hipMalloc(&signal, sizeof(HSAuint64));
+  err = hipExtMallocWithFlags((void**)&signal0, sizeof(uint64_t),
+                              hipDeviceMallocUncached);
   if (err != hipSuccess) {
     if (useHostDst) {
       ignoreHip(hipFree(dstBuf));
@@ -304,68 +659,300 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
     return err;
   }
 
-  HSAuint64 signalInit = 0;
-  err = hipMemcpy(signal, &signalInit, sizeof(HSAuint64),
+  err = hipMemset(signal0, 0, sizeof(uint64_t));
+  if (err != hipSuccess) {
+    ignoreHip(hipFree(signal0));
+    cleanupBuffers();
+    return err;
+  }
+
+  // Allocate signal on destination GPU (rank 1)
+  if (!useHostDst) {
+    err = hipSetDevice(dstGpu);
+    if (err != hipSuccess) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(signal0));
+      cleanupBuffers();
+
+      return err;
+    }
+
+    err = hipExtMallocWithFlags((void**)&signal1, sizeof(uint64_t),
+                                hipDeviceMallocUncached);
+    if (err != hipSuccess) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(signal0));
+      cleanupBuffers();
+      return err;
+    }
+
+    err = hipMemset(signal1, 0, sizeof(uint64_t));
+    if (err != hipSuccess) {
+      ignoreHip(hipFree(signal1));
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(signal0));
+      cleanupBuffers();
+      return err;
+    }
+  }
+
+  // Create host array with signal pointers
+  uint64_t* signalsHost[2] = {signal0, signal1};
+
+  // Allocate device array on srcGpu and copy signal pointers
+  err = hipSetDevice(srcGpu);
+  if (err != hipSuccess) {
+    ignoreHip(hipSetDevice(dstGpu));
+    ignoreHip(hipFree(signal1));
+    ignoreHip(hipSetDevice(srcGpu));
+    ignoreHip(hipFree(signal0));
+    cleanupBuffers();
+    return err;
+  }
+
+  err = hipMalloc(&signals[0], 2 * sizeof(uint64_t*));
+  if (err != hipSuccess) {
+    ignoreHip(hipSetDevice(dstGpu));
+    ignoreHip(hipFree(signal1));
+    ignoreHip(hipSetDevice(srcGpu));
+    ignoreHip(hipFree(signal0));
+    cleanupBuffers();
+    return err;
+  }
+
+  err = hipMemcpy(signals[0], signalsHost, 2 * sizeof(uint64_t*),
                   hipMemcpyHostToDevice);
   if (err != hipSuccess) {
-    ignoreHip(hipFree(signal));
-    if (useHostDst) {
-      ignoreHip(hipFree(dstBuf));
-    } else {
-      ignoreHip(hipSetDevice(dstGpu));
-      ignoreHip(hipFree(dstBuf));
-    }
-    ignoreHip(hipFree(srcBuf));
+    cleanupSignals();
+    cleanupBuffers();
     return err;
   }
 
-  // Get SDMA queue device handle
-  anvil::SdmaQueueDeviceHandle* devHandle = queue->deviceHandle();
+  // Allocate device array on dstGpu and copy signal pointers
+  if (!useHostDst) {
+    err = hipSetDevice(dstGpu);
+    if (err != hipSuccess) {
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
 
-  // Launch kernel: one thread runs the loop over all iterations to avoid
-  // anvil queue contention (multi-thread submit can stall).
+    err = hipMalloc(&signals[1], 2 * sizeof(uint64_t*));
+    if (err != hipSuccess) {
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+
+    err = hipMemcpy(signals[1], signalsHost, 2 * sizeof(uint64_t*),
+                    hipMemcpyHostToDevice);
+    if (err != hipSuccess) {
+      ignoreHip(hipFree(signals[1]));
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+  }
+
+  // Allocate counters for buffer-reuse test (one per GPU)
+  uint64_t* counter0 = nullptr;
+  uint64_t* counter1 = nullptr;
+
+  if (useCounter) {
+    // Allocate counter on source GPU (rank 0)
+    err = hipSetDevice(srcGpu);
+    if (err != hipSuccess) {
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+
+    err = hipExtMallocWithFlags((void**)&counter0, sizeof(uint64_t),
+                                hipDeviceMallocUncached);
+    if (err != hipSuccess) {
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+
+    err = hipMemset(counter0, 0, sizeof(uint64_t));
+    if (err != hipSuccess) {
+      ignoreHip(hipFree(counter0));
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+
+    // Allocate counter on destination GPU (rank 1)
+    err = hipSetDevice(dstGpu);
+    if (err != hipSuccess) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(counter0));
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+
+    err = hipExtMallocWithFlags((void**)&counter1, sizeof(uint64_t),
+                                hipDeviceMallocUncached);
+    if (err != hipSuccess) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(counter0));
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+
+    err = hipMemset(counter1, 0, sizeof(uint64_t));
+    if (err != hipSuccess) {
+      ignoreHip(hipFree(counter1));
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(counter0));
+      cleanupSignals();
+      cleanupBuffers();
+      return err;
+    }
+  }
+
+  // Helper lambdas for cleanup
+  auto cleanupCounters = [&]() {
+    if (useCounter) {
+      ignoreHip(hipSetDevice(srcGpu));
+      ignoreHip(hipFree(counter0));
+      ignoreHip(hipSetDevice(dstGpu));
+      ignoreHip(hipFree(counter1));
+    }
+  };
+  auto cleanupAll = [&]() {
+    cleanupCounters();
+    cleanupSignals();
+    cleanupBuffers();
+  };
+
+  // Launch kernel based on test type
   const unsigned numBlocks = 1;
-  const unsigned threadsPerBlock = 1;
+  const unsigned threadsPerBlock = (testType == "p2p") ? 1 : 256;
 
-  std::cout << "Launching " << config->iterations
-            << " SDMA transfers (grid: " << numBlocks << " blocks x "
-            << threadsPerBlock << " threads)" << std::endl;
+  std::cout << "Launching " << config->iterations << " SDMA (test: " << testType
+            << ", grid: " << numBlocks << " blocks x " << threadsPerBlock
+            << " threads)" << std::endl;
 
-  hipLaunchKernelGGL(sdma_transfer_kernel, dim3(numBlocks),
-                     dim3(threadsPerBlock), 0, 0, devHandle, dstBuf, srcBuf,
-                     transferSize, config->iterations, signal,
-                     config->startTimes, config->endTimes);
+  if (testType == "p2p") {
+    err = hipSetDevice(srcGpu);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
+    hipLaunchKernelGGL(sdma_p2p_kernel, dim3(numBlocks), dim3(threadsPerBlock),
+                       0, 0, sdmaHandles[0], dstBuf, srcBuf, transferSize,
+                       config->iterations, signals[0][0], config->startTimes,
+                       config->endTimes);
+  } else if (testType == "buffer-reuse") {
+    // For buffer-reuse kernel, launch on both GPUs with different ranks
+    // signals[0] and signals[1] are device arrays containing signal pointers
+    size_t nElem = transferSize / sizeof(int);
+
+    // Launch rank 0 (initiator) on source GPU with srcGpu->dstGpu handle
+    err = hipSetDevice(srcGpu);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
+    hipLaunchKernelGGL(sdma_buffer_reuse_kernel, dim3(numBlocks),
+                       dim3(threadsPerBlock), 0, 0, sdmaHandles[0], dstBuf,
+                       srcBuf, nElem, config->iterations, signals[0],
+                       /*rank*/ 0, counter0, useCounter, useFlush,
+                       config->startTimes, config->endTimes);
+
+    // Launch rank 1 (responder) on destination GPU with dstGpu->srcGpu handle
+    // Swap buffer arguments: rank 1's src should point to where rank 0 wrote
+    // (dstBuf)
+    err = hipSetDevice(dstGpu);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
+    hipLaunchKernelGGL(sdma_buffer_reuse_kernel, dim3(numBlocks),
+                       dim3(threadsPerBlock), 0, 0, sdmaHandles[1], srcBuf,
+                       dstBuf, nElem, config->iterations, signals[1],
+                       /*rank*/ 1, counter1, useCounter, useFlush,
+                       config->startTimes, config->endTimes);
+  } else if (testType == "ping-pong") {
+    // For ping-pong kernel, launch on both GPUs with different ranks
+    // signals[0] and signals[1] are device arrays containing signal pointers
+    size_t nElem = transferSize / sizeof(int);
+
+    // Launch rank 0 (initiator) on source GPU with srcGpu->dstGpu handle
+    err = hipSetDevice(srcGpu);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
+    hipLaunchKernelGGL(sdma_ping_pong_kernel, dim3(numBlocks),
+                       dim3(threadsPerBlock), 0, 0, sdmaHandles[0], dstBuf,
+                       srcBuf, nElem, config->iterations, signals[0],
+                       /*rank*/ 0, counter0, useCounter, useFlush,
+                       config->startTimes, config->endTimes);
+
+    // Launch rank 1 (responder) on destination GPU with dstGpu->srcGpu handle
+    // Swap buffer arguments: rank 1's src should point to where rank 0 wrote
+    // (dstBuf)
+    err = hipSetDevice(dstGpu);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
+    hipLaunchKernelGGL(sdma_ping_pong_kernel, dim3(numBlocks),
+                       dim3(threadsPerBlock), 0, 0, sdmaHandles[1], srcBuf,
+                       dstBuf, nElem, config->iterations, signals[1],
+                       /*rank*/ 1, counter1, useCounter, useFlush,
+                       config->startTimes, config->endTimes);
+  } else {
+    std::cerr << "Unknown test type: " << testType << std::endl;
+    cleanupAll();
+    return hipErrorInvalidValue;
+  }
 
   err = hipGetLastError();
   if (err != hipSuccess) {
     std::cerr << "Kernel launch failed: " << hipGetErrorString(err)
               << std::endl;
-    ignoreHip(hipFree(signal));
-    if (useHostDst) {
-      ignoreHip(hipFree(dstBuf));
-    } else {
-      ignoreHip(hipSetDevice(dstGpu));
-      ignoreHip(hipFree(dstBuf));
-    }
-    ignoreHip(hipFree(srcBuf));
+    cleanupAll();
     return err;
   }
 
-  // Wait for kernel to complete; kernel waits for SDMA completion signal
-  // (no host-side signal polling).
+  // Wait for kernel to complete
+  err = hipSetDevice(srcGpu);
+  if (err != hipSuccess) {
+    std::cerr << "Failed to set device to srcGpu for sync: "
+              << hipGetErrorString(err) << std::endl;
+    cleanupAll();
+    return err;
+  }
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
-    std::cerr << "Device sync after kernel failed: " << hipGetErrorString(err)
+    std::cerr << "Device sync on srcGpu failed: " << hipGetErrorString(err)
               << std::endl;
-    ignoreHip(hipFree(signal));
-    if (useHostDst) {
-      ignoreHip(hipFree(dstBuf));
-    } else {
-      ignoreHip(hipSetDevice(dstGpu));
-      ignoreHip(hipFree(dstBuf));
-    }
-    ignoreHip(hipFree(srcBuf));
+    cleanupAll();
     return err;
+  }
+
+  // For buffer-reuse and ping-pong, synchronize both GPUs
+  if (testType == "buffer-reuse" || testType == "ping-pong") {
+    err = hipSetDevice(dstGpu);
+    if (err != hipSuccess) {
+      std::cerr << "Failed to set device to dstGpu for sync: "
+                << hipGetErrorString(err) << std::endl;
+      cleanupAll();
+      return err;
+    }
+    err = hipDeviceSynchronize();
+    if (err != hipSuccess) {
+      std::cerr << "Device sync on dstGpu failed: " << hipGetErrorString(err)
+                << std::endl;
+      cleanupAll();
+      return err;
+    }
   }
 
   std::cout << "SDMA transfers completed successfully" << std::endl;
@@ -426,22 +1013,13 @@ hipError_t sdma_ep_run(XioEndpointConfig* config) {
     } else {
       std::cerr << "Data verification: FAILED at iteration " << failIter
                 << " offset " << failOffset << std::endl;
-      ignoreHip(hipSetDevice(dstGpu));
-      ignoreHip(hipFree(dstBuf));
-      ignoreHip(hipSetDevice(srcGpu));
-      ignoreHip(hipFree(signal));
-      ignoreHip(hipFree(srcBuf));
+      cleanupAll();
       return hipErrorUnknown;
     }
   }
 
-  // Cleanup (free on correct device: signal and srcBuf on srcGpu, dstBuf on
-  // dstGpu)
-  ignoreHip(hipSetDevice(dstGpu));
-  ignoreHip(hipFree(dstBuf));
-  ignoreHip(hipSetDevice(srcGpu));
-  ignoreHip(hipFree(signal));
-  ignoreHip(hipFree(srcBuf));
+  // Cleanup all resources
+  cleanupAll();
 
   return hipSuccess;
 }


### PR DESCRIPTION
- adding device functions to support determinig completions of SDMA commands. This can be determined with a local counter, as in GIN, or by querying the read_ptr of the SDMA queue. The read_ptr is updated by the SDMA engine when the command completed. For this approach there are two variations: `quiet()` which is more conservative ensuring all previous ops have completed and `flush()` which allows the application to specify the "index" of a previous operation.
- Adding two kernels to exercise this functionality: ping-pong and buffer-reuse
They can be run with: `./xio-tester sdma-ep ping-pong` and `./xio-tester sdma-ep buffer-reuse`. By default it uses `quiet()`, the counter implementation is used by setting flag `--use-counter` and the `flush()` implementation by setting `--use-flush`