### PR TITLE
fix: create endpoint-registry target before post-build formatting

### DIFF
--- a/cmake/CodeGeneration.cmake
+++ b/cmake/CodeGeneration.cmake
@@ -27,6 +27,9 @@ function(setup_code_generation)
     COMMENT "Generating endpoint files from: ${VALID_ENDPOINTS}"
   )
 
+  add_custom_target(endpoint-registry-generated
+    DEPENDS ${GEN_GENERATED_REGISTRY} ${GEN_GENERATED_INCLUDES})
+
   # Format generated files if clang-format is available
   find_program(CLANG_FORMAT clang-format PATHS /usr/bin ENV PATH)
   if(CLANG_FORMAT)
@@ -38,9 +41,6 @@ function(setup_code_generation)
       COMMENT "Formatting generated endpoint registry"
     )
   endif()
-
-  add_custom_target(endpoint-registry-generated
-    DEPENDS ${GEN_GENERATED_REGISTRY} ${GEN_GENERATED_INCLUDES})
 
   # NVMe header fetching
   set(NVME_FETCH_SCRIPT


### PR DESCRIPTION
Ensure CMake defines endpoint-registry-generated before attaching clang-format POST_BUILD commands so configure succeeds when clang-format is available.

## Motivation

Fix a CMake configure regression on `main` where configuration fails when `clang-format` is installed.  
This PR restores configure behavior so developers and CI can generate build files reliably.

## Technical Details

This PR makes a minimal ordering fix in `cmake/CodeGeneration.cmake`:

- Define `endpoint-registry-generated` via `add_custom_target(...)` **before** attaching:
  - `add_custom_command(TARGET endpoint-registry-generated POST_BUILD ...)`

No runtime logic or API behavior is changed; this is strictly a CMake target-definition ordering correction.

## Test Plan

- Reproduced failure on clean `origin/main`:
  - `cmake -S <main> -B <main>/build`
  - Expected/observed error:
    - `No TARGET 'endpoint-registry-generated' has been created in this directory.`
- Validated fix branch (`dev/thohuber/cmake-fix`):
  - `cmake -S ~/PR-review-sdma-48/rocm-xio-cmake-fix -B ~/PR-review-sdma-48/rocm-xio-cmake-fix/build`
  - `cmake --build ~/PR-review-sdma-48/rocm-xio-cmake-fix/build --target endpoint-registry-generated`

## Test Result

- **`origin/main`: FAIL (expected regression reproduced)**
  - Configure fails with target-order error in `cmake/CodeGeneration.cmake`.
- **`dev/thohuber/cmake-fix`: PASS**
  - Configure succeeds.
  - `endpoint-registry-generated` target builds successfully.

## Submission Checklist


- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
