### PR TITLE
Add GPU-based unit tests for rdma-ep endpoint

### DIFF
--- a/tests/unit/rdma-ep/test-rdma-config.hip
+++ b/tests/unit/rdma-ep/test-rdma-config.hip
@@ -10,6 +10,7 @@
 
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
+#include "xio.h"       // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -376,7 +377,7 @@ int test_config_structure_gpu() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy config to device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_config);
+    HIP_CHECK(hipFree(device_config));
     return 1;
   }
 
@@ -385,7 +386,7 @@ int test_config_structure_gpu() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to allocate device memory for results: %s\n",
             hipGetErrorString(err));
-    hipFree(device_config);
+    HIP_CHECK(hipFree(device_config));
     return 1;
   }
 
@@ -394,8 +395,8 @@ int test_config_structure_gpu() {
                   hipMemcpyHostToDevice);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy to device: %s\n", hipGetErrorString(err));
-    hipFree(device_config);
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_config));
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -406,16 +407,16 @@ int test_config_structure_gpu() {
   err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to launch kernel: %s\n", hipGetErrorString(err));
-    hipFree(device_config);
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_config));
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to synchronize: %s\n", hipGetErrorString(err));
-    hipFree(device_config);
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_config));
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -423,13 +424,13 @@ int test_config_structure_gpu() {
                   hipMemcpyDeviceToHost);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy from device: %s\n", hipGetErrorString(err));
-    hipFree(device_config);
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_config));
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
-  hipFree(device_config);
-  hipFree(device_results);
+  HIP_CHECK(hipFree(device_config));
+  HIP_CHECK(hipFree(device_results));
 
   if (!host_result) {
     fprintf(stderr, "GPU kernel test failed\n");

--- a/tests/unit/rdma-ep/test-rdma-cqe-generation.hip
+++ b/tests/unit/rdma-ep/test-rdma-cqe-generation.hip
@@ -13,6 +13,7 @@
 #include "pvrdma/pvrdma-rdma.h"
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
+#include "xio.h"       // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -78,7 +79,7 @@ __global__ void test_cqe_generation_kernel(bool* results) {
 
   // Test error handling for invalid opcode
   struct rdma_wqe invalid_wqe = {};
-  invalid_wqe.opcode = 0xFF + 1; // Invalid opcode
+  invalid_wqe.opcode = static_cast<uint8_t>(0xFF + 1); // Invalid opcode
   invalid_wqe.vendor = static_cast<uint8_t>(RDMAVendor::MLX5);
   invalid_wqe.wqe_id = 999;
   invalid_wqe.length = 4096;
@@ -191,7 +192,8 @@ int test_cqe_generation_pvrdma() {
 // Test error handling for invalid opcode
 int test_cqe_generation_invalid_opcode() {
   struct rdma_wqe wqe = {};
-  wqe.opcode = 0xFF + 1; // Invalid opcode (greater than max)
+  wqe.opcode = static_cast<uint8_t>(0xFF + 1); // Invalid opcode (greater than
+                                               // max)
   wqe.vendor = static_cast<uint8_t>(RDMAVendor::MLX5);
   wqe.wqe_id = 999;
   wqe.length = 4096;
@@ -280,7 +282,7 @@ int test_cqe_generation_gpu() {
                   hipMemcpyHostToDevice);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy to device: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -291,14 +293,14 @@ int test_cqe_generation_gpu() {
   err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to launch kernel: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to synchronize: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -306,11 +308,11 @@ int test_cqe_generation_gpu() {
                   hipMemcpyDeviceToHost);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy from device: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
-  hipFree(device_results);
+  HIP_CHECK(hipFree(device_results));
 
   if (!host_result) {
     fprintf(stderr, "GPU kernel test failed\n");

--- a/tests/unit/rdma-ep/test-rdma-queue-ops.hip
+++ b/tests/unit/rdma-ep/test-rdma-queue-ops.hip
@@ -10,6 +10,7 @@
 
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
+#include "xio.h"       // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -114,7 +115,7 @@ int test_sqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to allocate device memory for success flag: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
+    HIP_CHECK(hipFree(device_buffer));
     return 1;
   }
 
@@ -123,8 +124,8 @@ int test_sqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to memset device buffer: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -134,8 +135,8 @@ int test_sqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy success flag to device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -146,8 +147,8 @@ int test_sqe_read_write() {
   err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to launch kernel: %s\n", hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -156,8 +157,8 @@ int test_sqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to synchronize device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -167,14 +168,14 @@ int test_sqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy result from device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
   // Cleanup
-  hipFree(device_buffer);
-  hipFree(device_success);
+  HIP_CHECK(hipFree(device_buffer));
+  HIP_CHECK(hipFree(device_success));
 
   if (!host_success) {
     fprintf(stderr,
@@ -204,7 +205,7 @@ int test_cqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to allocate device memory for success flag: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
+    HIP_CHECK(hipFree(device_buffer));
     return 1;
   }
 
@@ -213,8 +214,8 @@ int test_cqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to memset device buffer: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -224,8 +225,8 @@ int test_cqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy success flag to device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -236,8 +237,8 @@ int test_cqe_read_write() {
   err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to launch kernel: %s\n", hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -246,8 +247,8 @@ int test_cqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to synchronize device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
@@ -257,14 +258,14 @@ int test_cqe_read_write() {
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy result from device: %s\n",
             hipGetErrorString(err));
-    hipFree(device_buffer);
-    hipFree(device_success);
+    HIP_CHECK(hipFree(device_buffer));
+    HIP_CHECK(hipFree(device_success));
     return 1;
   }
 
   // Cleanup
-  hipFree(device_buffer);
-  hipFree(device_success);
+  HIP_CHECK(hipFree(device_buffer));
+  HIP_CHECK(hipFree(device_success));
 
   if (!host_success) {
     fprintf(stderr,

--- a/tests/unit/rdma-ep/test-rdma-vendors.hip
+++ b/tests/unit/rdma-ep/test-rdma-vendors.hip
@@ -14,6 +14,7 @@
 #include "pvrdma/pvrdma-rdma.h"
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
+#include "xio.h"       // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -270,7 +271,7 @@ int test_vendor_specific_gpu() {
                   hipMemcpyHostToDevice);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy to device: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -281,14 +282,14 @@ int test_vendor_specific_gpu() {
   err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to launch kernel: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to synchronize: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -296,11 +297,11 @@ int test_vendor_specific_gpu() {
                   hipMemcpyDeviceToHost);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy from device: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
-  hipFree(device_results);
+  HIP_CHECK(hipFree(device_results));
 
   if (!host_result) {
     fprintf(stderr, "GPU kernel test failed\n");

--- a/tests/unit/rdma-ep/test-rdma-wqe-cqe.hip
+++ b/tests/unit/rdma-ep/test-rdma-wqe-cqe.hip
@@ -10,6 +10,7 @@
 
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
+#include "xio.h"       // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -223,7 +224,7 @@ int test_wqe_cqe_setup_gpu() {
                   hipMemcpyHostToDevice);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy to device: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -234,14 +235,14 @@ int test_wqe_cqe_setup_gpu() {
   err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to launch kernel: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to synchronize: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
@@ -249,11 +250,11 @@ int test_wqe_cqe_setup_gpu() {
                   hipMemcpyDeviceToHost);
   if (err != hipSuccess) {
     fprintf(stderr, "Failed to copy from device: %s\n", hipGetErrorString(err));
-    hipFree(device_results);
+    HIP_CHECK(hipFree(device_results));
     return 1;
   }
 
-  hipFree(device_results);
+  HIP_CHECK(hipFree(device_results));
 
   if (!host_result) {
     fprintf(stderr, "GPU kernel test failed\n");


### PR DESCRIPTION
Convert rdma-ep unit tests from host-only C++ tests to GPU-based HIP tests that perform actual RDMA operations on the GPU. This ensures the tests validate RDMA functionality in the intended GPU execution environment.

Changes:
- Convert all test files from .cpp to .hip extensions
- Add GPU kernels to each test file that perform RDMA operations:
  * test-rdma-wqe-cqe.hip: test_wqe_cqe_setup_kernel for WQE/CQE setup
  * test-rdma-vendors.hip: test_vendor_specific_kernel for all 4 vendors
  * test-rdma-queue-ops.hip: test_sqe_read_write_kernel and test_cqe_read_write_kernel for queue operations
  * test-rdma-cqe-generation.hip: test_cqe_generation_kernel for CQE generation from WQE
  * test-rdma-config.hip: test_config_structure_kernel for config structure validation
- Update CMakeLists.txt to compile tests as HIP instead of C++
  * Set LANGUAGE HIP for all test targets
  * Link against hip::host and hip::device libraries
  * Remove workaround scripts for HIP flags (no longer needed)
- Add HIP runtime includes and rdma-ep.hip implementation includes
- Retain host-based tests for detailed verification alongside GPU tests

Each test now:
- Allocates GPU memory for test data
- Launches GPU kernels that perform RDMA operations
- Synchronizes and copies results back to host
- Verifies results on both GPU and host

This provides comprehensive GPU-based testing for all RDMA vendors (MLX5, BNXT_RE, IONIC, PVRDMA) and ensures RDMA operations work correctly in the GPU execution environment.