### PR TITLE
Replace PVRDMA vendor with rocm-ernic vendor

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -6,6 +6,7 @@
 xio
 XIO
 rocm
+ernic
 
 # ===== NVMe and Storage =====
 CQE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ setup_code_generation(
     ${ENDPOINTS_DIR}/rdma-ep/mlx/mlx5-rdma.h
     ${ENDPOINTS_DIR}/rdma-ep/bnxt/bnxt-rdma.h
     ${ENDPOINTS_DIR}/rdma-ep/ionic/ionic-rdma.h
-    ${ENDPOINTS_DIR}/rdma-ep/pvrdma/pvrdma-rdma.h
+    ${ENDPOINTS_DIR}/rdma-ep/rocm-ernic/rocm-ernic-rdma.h
 )
 
 # Discover source files
@@ -252,7 +252,7 @@ set(RDMA_VENDOR_HEADER_DEPS
   ${ENDPOINTS_DIR}/rdma-ep/mlx/mlx5-rdma.h
   ${ENDPOINTS_DIR}/rdma-ep/bnxt/bnxt-rdma.h
   ${ENDPOINTS_DIR}/rdma-ep/ionic/ionic-rdma.h
-  ${ENDPOINTS_DIR}/rdma-ep/pvrdma/pvrdma-rdma.h
+  ${ENDPOINTS_DIR}/rdma-ep/rocm-ernic/rocm-ernic-rdma.h
 )
 set_source_files_properties(
   ${ENDPOINTS_DIR}/rdma-ep/rdma-ep.hip

--- a/src/endpoints/rdma-ep/README.md
+++ b/src/endpoints/rdma-ep/README.md
@@ -7,7 +7,7 @@ GPU-Direct RDMA endpoint supporting 4 major vendors.
 1. **MLX5** - Mellanox/NVIDIA ConnectX (InfiniBand/RoCE)
 2. **BNXT_RE** - Broadcom NetXtreme RDMA Engine
 3. **IONIC** - Pensando Ionic RDMA (SmartNIC)
-4. **PVRDMA** - VMware Paravirtualized RDMA
+4. **rocm-ernic** - AMD Emulated RDMA NIC
 
 ## Directory Structure
 
@@ -21,8 +21,8 @@ rdma-ep/
 │   └── bnxt-rdma.h     # BNXT_RE doorbell + vendor specifics
 ├── ionic/
 │   └── ionic-rdma.h    # IONIC doorbell + vendor specifics
-├── pvrdma/
-│   └── pvrdma-rdma.h   # PVRDMA doorbell + vendor specifics
+├── rocm-ernic/
+│   └── rocm-ernic-rdma.h # rocm-ernic doorbell + vendor specifics
 └── README.md           # This file
 ```
 

--- a/src/endpoints/rdma-ep/rdma-ep.h
+++ b/src/endpoints/rdma-ep/rdma-ep.h
@@ -19,7 +19,7 @@
  * - MLX5 (Mellanox/NVIDIA ConnectX-5 and later)
  * - BNXT_RE (Broadcom NetXtreme RDMA)
  * - IONIC (Pensando Ionic RDMA)
- * - PVRDMA (VMware Paravirtualized RDMA)
+ * - rocm-ernic (AMD Emulated RDMA NIC)
  *
  * Reference: Based on linux-rdma/rdma-core repository
  * Downloaded headers in include/external/rdma/ for reference
@@ -38,10 +38,10 @@
 // RDMA Vendor Types
 //
 enum class RDMAVendor : uint8_t {
-  MLX5 = 0,    // Mellanox/NVIDIA ConnectX
-  BNXT_RE = 1, // Broadcom NetXtreme
-  IONIC = 2,   // Pensando Ionic RDMA
-  PVRDMA = 3,  // VMware Paravirtualized RDMA
+  MLX5 = 0,       // Mellanox/NVIDIA ConnectX
+  BNXT_RE = 1,    // Broadcom NetXtreme
+  IONIC = 2,      // Pensando Ionic RDMA
+  ROCM_ERNIC = 3, // AMD Emulated RDMA NIC
   UNKNOWN = 0xFF
 };
 
@@ -125,9 +125,9 @@ struct rdma_cqe {
       uint32_t reserved;
     } ionic;
     struct {
-      uint32_t qpn; // Queue pair number (for PVRDMA)
+      uint32_t qpn; // Queue pair number (for rocm-ernic)
       uint32_t reserved;
-    } pvrdma;
+    } rocm_ernic;
     uint64_t vendor_data;
   };
 
@@ -240,8 +240,8 @@ __host__ __device__ static inline const char* rdma_vendor_name(
       return "BNXT_RE";
     case RDMAVendor::IONIC:
       return "IONIC";
-    case RDMAVendor::PVRDMA:
-      return "PVRDMA";
+    case RDMAVendor::ROCM_ERNIC:
+      return "rocm-ernic";
     default:
       return "UNKNOWN";
   }

--- a/src/endpoints/rdma-ep/rdma-ep.hip
+++ b/src/endpoints/rdma-ep/rdma-ep.hip
@@ -19,7 +19,7 @@
 #include "bnxt/bnxt-rdma.h"
 #include "ionic/ionic-rdma.h"
 #include "mlx/mlx5-rdma.h"
-#include "pvrdma/pvrdma-rdma.h"
+#include "rocm-ernic/rocm-ernic-rdma.h"
 
 /*
  * RDMA Endpoint Implementation
@@ -28,7 +28,7 @@
  * - MLX5 (Mellanox/NVIDIA ConnectX)
  * - BNXT_RE (Broadcom NetXtreme)
  * - IONIC (Pensando Ionic RDMA)
- * - PVRDMA (VMware Paravirtualized RDMA)
+ * - rocm-ernic (AMD Emulated RDMA NIC)
  *
  * Reference headers downloaded from linux-rdma/rdma-core:
  *   Run 'make fetch-rdma-headers' to download reference headers
@@ -173,10 +173,10 @@ __host__ __device__ cqeType cqeGenFromSqe(const sqeType* sqeData,
       cqe->ionic.qpn = static_cast<uint32_t>(wqe->vendor_specific >> 32);
       cqe->ionic.reserved = 0;
       break;
-    case RDMAVendor::PVRDMA:
+    case RDMAVendor::ROCM_ERNIC:
       // Extract QP number
-      cqe->pvrdma.qpn = static_cast<uint32_t>(wqe->vendor_specific >> 32);
-      cqe->pvrdma.reserved = 0;
+      cqe->rocm_ernic.qpn = static_cast<uint32_t>(wqe->vendor_specific >> 32);
+      cqe->rocm_ernic.reserved = 0;
       break;
     default:
       cqe->vendor_data = 0;
@@ -269,7 +269,7 @@ __device__ void rdma_ep_driveEndpoint(const XioEndpointConfig& config,
 
   // Vendor selection: if UNKNOWN, cycle through all vendors
   RDMAVendor vendors[] = {RDMAVendor::MLX5, RDMAVendor::BNXT_RE,
-                          RDMAVendor::IONIC, RDMAVendor::PVRDMA};
+                          RDMAVendor::IONIC, RDMAVendor::ROCM_ERNIC};
   int num_vendors = sizeof(vendors) / sizeof(vendors[0]);
   bool use_all_vendors = (vendor == RDMAVendor::UNKNOWN);
 
@@ -315,8 +315,8 @@ __device__ void rdma_ep_driveEndpoint(const XioEndpointConfig& config,
       case RDMAVendor::IONIC:
         ionic_wqe_set_vendor_specific(wqe, 2000 + i, true, false);
         break;
-      case RDMAVendor::PVRDMA:
-        pvrdma_wqe_set_vendor_specific(wqe, 3000 + i, true, false);
+      case RDMAVendor::ROCM_ERNIC:
+        rocm_ernic_wqe_set_vendor_specific(wqe, 3000 + i, true, false);
         break;
       default:
         break;
@@ -371,14 +371,15 @@ __host__ void registerCliOptions(CLI::App& app, RdmaEpConfig* config) {
     ->check(CLI::PositiveNumber)
     ->group(rdma_group);
 
-  // Vendor selection: support "mlx5", "bnxt", "ionic", "pvrdma", or "all"
+  // Vendor selection: support "mlx5", "bnxt", "ionic", "rocm-ernic", or "all"
   app
     .add_option("--vendor", config->vendorStr,
-                "RDMA vendor to use: mlx5, bnxt, ionic, pvrdma, or all "
+                "RDMA vendor to use: mlx5, bnxt, ionic, rocm-ernic, or all "
                 "(round-robin)")
     ->default_val("mlx5")
-    ->check(CLI::IsMember({"mlx5", "bnxt", "bnxt_re", "ionic", "pvrdma", "all"},
-                          CLI::ignore_case))
+    ->check(
+      CLI::IsMember({"mlx5", "bnxt", "bnxt_re", "ionic", "rocm-ernic", "all"},
+                    CLI::ignore_case))
     ->group(rdma_group);
 
   app
@@ -430,12 +431,12 @@ __host__ std::string validateConfig(RdmaEpConfig* config) {
     config->vendor = RDMAVendor::BNXT_RE;
   } else if (config->vendorStr == "ionic") {
     config->vendor = RDMAVendor::IONIC;
-  } else if (config->vendorStr == "pvrdma") {
-    config->vendor = RDMAVendor::PVRDMA;
+  } else if (config->vendorStr == "rocm-ernic") {
+    config->vendor = RDMAVendor::ROCM_ERNIC;
   } else if (config->vendorStr == "all") {
     config->vendor = RDMAVendor::UNKNOWN; // Use UNKNOWN to indicate "all"
   } else {
-    return "Invalid vendor. Must be: mlx5, bnxt, ionic, pvrdma, or all";
+    return "Invalid vendor. Must be: mlx5, bnxt, ionic, rocm-ernic, or all";
   }
 
   // Validate queue length is power of 2

--- a/src/endpoints/rdma-ep/rocm-ernic/rocm-ernic-rdma.h
+++ b/src/endpoints/rdma-ep/rocm-ernic/rocm-ernic-rdma.h
@@ -1,0 +1,71 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ROCM_ERNIC_RDMA_H
+#define ROCM_ERNIC_RDMA_H
+
+#include "../rdma-ep.h"
+
+/*
+ * rocm-ernic (AMD Emulated RDMA NIC) Provider
+ *
+ * Reference: ../rocm-ernic/driver/rocm_ernic-abi.h
+ * Driver headers located at ../rocm-ernic/driver/ relative to rocm-xio root
+ */
+
+// rocm-ernic-specific constants from rocm_ernic-abi.h
+#define ROCM_ERNIC_MAX_SEND_WR 4096
+#define ROCM_ERNIC_MAX_RECV_WR 4096
+#define ROCM_ERNIC_MAX_SEND_SGE 4
+#define ROCM_ERNIC_MAX_RECV_SGE 4
+
+// rocm-ernic-specific WQE opcodes (from rocm_ernic_wr_opcode enum)
+#define ROCM_ERNIC_WR_SEND 0x02
+#define ROCM_ERNIC_WR_SEND_WITH_IMM 0x03
+#define ROCM_ERNIC_WR_RDMA_WRITE 0x00
+#define ROCM_ERNIC_WR_RDMA_WRITE_WITH_IMM 0x01
+#define ROCM_ERNIC_WR_RDMA_READ 0x04
+
+// rocm-ernic-specific completion status (from rocm_ernic_wc_status enum)
+#define ROCM_ERNIC_WC_SUCCESS 0x00
+#define ROCM_ERNIC_WC_LOC_LEN_ERR 0x01
+#define ROCM_ERNIC_WC_LOC_QP_OP_ERR 0x02
+#define ROCM_ERNIC_WC_LOC_PROT_ERR 0x04
+#define ROCM_ERNIC_WC_REM_ACCESS_ERR 0x0C
+
+// rocm-ernic WQE flags (send_flags field in rocm_ernic_sq_wqe_hdr)
+// Based on IB verbs send flags, similar to PVRDMA
+#define ROCM_ERNIC_SEND_SIGNALED (1 << 0)
+#define ROCM_ERNIC_SEND_SOLICITED (1 << 1)
+#define ROCM_ERNIC_SEND_INLINE (1 << 2)
+#define ROCM_ERNIC_SEND_FENCE (1 << 3)
+
+// Doorbell constants (from rocm_ernic-abi.h)
+#define ROCM_ERNIC_UAR_QP_OFFSET 0
+#define ROCM_ERNIC_UAR_QP_SEND (1 << 30)
+#define ROCM_ERNIC_UAR_QP_RECV (1 << 31)
+#define ROCM_ERNIC_UAR_CQ_OFFSET 4
+#define ROCM_ERNIC_UAR_CQ_ARM (1 << 30)
+#define ROCM_ERNIC_UAR_CQ_POLL (1 << 31)
+
+// Helper function to set rocm-ernic-specific WQE fields
+// Similar to PVRDMA: encode QP num in upper 32 bits, flags in lower 32 bits
+__host__ __device__ static inline void rocm_ernic_wqe_set_vendor_specific(
+  struct rdma_wqe* wqe, uint32_t qp_num, bool signaled, bool fence) {
+  uint64_t flags = 0;
+  if (signaled)
+    flags |= ROCM_ERNIC_SEND_SIGNALED;
+  if (fence)
+    flags |= ROCM_ERNIC_SEND_FENCE;
+  wqe->vendor_specific = (static_cast<uint64_t>(qp_num) << 32) | flags;
+}
+
+// Helper function to extract rocm-ernic-specific CQE fields
+__host__ __device__ static inline uint32_t rocm_ernic_cqe_get_qpn(
+  const struct rdma_cqe* cqe) {
+  return cqe->rocm_ernic.qpn;
+}
+
+#endif // ROCM_ERNIC_RDMA_H

--- a/tests/unit/rdma-ep/CMakeLists.txt
+++ b/tests/unit/rdma-ep/CMakeLists.txt
@@ -35,7 +35,7 @@ function(setup_rdma_test TEST_NAME SOURCE_FILE NEEDS_VENDOR_DIRS)
       ${ENDPOINTS_DIR}/rdma-ep/mlx
       ${ENDPOINTS_DIR}/rdma-ep/bnxt
       ${ENDPOINTS_DIR}/rdma-ep/ionic
-      ${ENDPOINTS_DIR}/rdma-ep/pvrdma
+      ${ENDPOINTS_DIR}/rdma-ep/rocm-ernic
     )
   endif()
 

--- a/tests/unit/rdma-ep/test-rdma-config.hip
+++ b/tests/unit/rdma-ep/test-rdma-config.hip
@@ -38,7 +38,7 @@ __global__ void test_config_structure_kernel(
   test_passed &= (device_config->vendor == RDMAVendor::MLX5 ||
                   device_config->vendor == RDMAVendor::BNXT_RE ||
                   device_config->vendor == RDMAVendor::IONIC ||
-                  device_config->vendor == RDMAVendor::PVRDMA ||
+                  device_config->vendor == RDMAVendor::ROCM_ERNIC ||
                   device_config->vendor == RDMAVendor::UNKNOWN);
 
   results[0] = test_passed;
@@ -217,11 +217,11 @@ int test_vendor_string_ionic() {
   return 0;
 }
 
-// Test vendor string conversion: "pvrdma" -> PVRDMA
-int test_vendor_string_pvrdma() {
+// Test vendor string conversion: "rocm-ernic" -> ROCM_ERNIC
+int test_vendor_string_rocm_ernic() {
   rdma_ep::RdmaEpConfig config = {};
   config.iterations = 100;
-  config.vendorStr = "pvrdma";
+  config.vendorStr = "rocm-ernic";
   config.emulate = false;
   config.queueLength = 256;
   config.transferSize = 4096;
@@ -229,7 +229,7 @@ int test_vendor_string_pvrdma() {
   std::string result = rdma_ep::validateConfig(&config);
 
   ASSERT_STREQ(result.c_str(), "");
-  ASSERT_EQ(config.vendor, RDMAVendor::PVRDMA);
+  ASSERT_EQ(config.vendor, RDMAVendor::ROCM_ERNIC);
 
   return 0;
 }
@@ -457,7 +457,7 @@ int main() {
   failures += test_vendor_string_bnxt();
   failures += test_vendor_string_bnxt_re();
   failures += test_vendor_string_ionic();
-  failures += test_vendor_string_pvrdma();
+  failures += test_vendor_string_rocm_ernic();
   failures += test_vendor_string_all();
   failures += test_invalid_vendor_string();
   failures += test_vendor_string_case_insensitive();

--- a/tests/unit/rdma-ep/test-rdma-cqe-generation.hip
+++ b/tests/unit/rdma-ep/test-rdma-cqe-generation.hip
@@ -10,10 +10,10 @@
 #include "bnxt/bnxt-rdma.h"
 #include "ionic/ionic-rdma.h"
 #include "mlx/mlx5-rdma.h"
-#include "pvrdma/pvrdma-rdma.h"
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
-#include "xio.h"       // For HIP_CHECK macro
+#include "rocm-ernic/rocm-ernic-rdma.h"
+#include "xio.h" // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -65,17 +65,18 @@ __global__ void test_cqe_generation_kernel(bool* results) {
   test_passed &= (ionic_cqe.byte_len == 16384);
   test_passed &= (ionic_cqe.ionic.qpn == ionic_qp);
 
-  // Test PVRDMA CQE generation
-  struct rdma_wqe pvrdma_wqe = {};
-  rdma_wqe_setup_send(&pvrdma_wqe, 321, RDMAVendor::PVRDMA, 0x6000, 32768,
-                      0x1111);
-  uint32_t pvrdma_qp = 3003;
-  pvrdma_wqe_set_vendor_specific(&pvrdma_wqe, pvrdma_qp, false, true);
-  rdma_ep::cqeType pvrdma_cqe = rdma_ep::cqeGenFromSqe(&pvrdma_wqe,
-                                                       0x1122334455667788ULL);
-  test_passed &= (pvrdma_cqe.wqe_id == 321);
-  test_passed &= (pvrdma_cqe.byte_len == 32768);
-  test_passed &= (pvrdma_cqe.pvrdma.qpn == pvrdma_qp);
+  // Test rocm-ernic CQE generation
+  struct rdma_wqe rocm_ernic_wqe = {};
+  rdma_wqe_setup_send(&rocm_ernic_wqe, 321, RDMAVendor::ROCM_ERNIC, 0x6000,
+                      32768, 0x1111);
+  uint32_t rocm_ernic_qp = 3003;
+  rocm_ernic_wqe_set_vendor_specific(&rocm_ernic_wqe, rocm_ernic_qp, false,
+                                     true);
+  rdma_ep::cqeType rocm_ernic_cqe =
+    rdma_ep::cqeGenFromSqe(&rocm_ernic_wqe, 0x1122334455667788ULL);
+  test_passed &= (rocm_ernic_cqe.wqe_id == 321);
+  test_passed &= (rocm_ernic_cqe.byte_len == 32768);
+  test_passed &= (rocm_ernic_cqe.rocm_ernic.qpn == rocm_ernic_qp);
 
   // Test error handling for invalid opcode
   struct rdma_wqe invalid_wqe = {};
@@ -165,26 +166,26 @@ int test_cqe_generation_ionic() {
   return 0;
 }
 
-// Test CQE generation from PVRDMA WQE
-int test_cqe_generation_pvrdma() {
+// Test CQE generation from rocm-ernic WQE
+int test_cqe_generation_rocm_ernic() {
   struct rdma_wqe wqe = {};
-  rdma_wqe_setup_send(&wqe, 321, RDMAVendor::PVRDMA, 0x6000, 32768, 0x1111);
+  rdma_wqe_setup_send(&wqe, 321, RDMAVendor::ROCM_ERNIC, 0x6000, 32768, 0x1111);
   uint32_t qp_num = 3003;
-  pvrdma_wqe_set_vendor_specific(&wqe, qp_num, false, true);
+  rocm_ernic_wqe_set_vendor_specific(&wqe, qp_num, false, true);
 
   uint64_t timestamp = 0x1122334455667788ULL;
   rdma_ep::cqeType cqe = rdma_ep::cqeGenFromSqe(&wqe, timestamp);
 
   // Verify basic fields
   ASSERT_EQ(cqe.wqe_id, 321);
-  ASSERT_EQ(cqe.vendor, static_cast<uint8_t>(RDMAVendor::PVRDMA));
+  ASSERT_EQ(cqe.vendor, static_cast<uint8_t>(RDMAVendor::ROCM_ERNIC));
   ASSERT_EQ(cqe.status, RDMA_WC_SUCCESS);
   ASSERT_EQ(cqe.byte_len, 32768);
   ASSERT_EQ(cqe.timestamp, timestamp);
 
-  // Verify PVRDMA-specific fields
-  ASSERT_EQ(cqe.pvrdma.qpn, qp_num);
-  ASSERT_EQ(cqe.pvrdma.reserved, 0);
+  // Verify rocm-ernic-specific fields
+  ASSERT_EQ(cqe.rocm_ernic.qpn, qp_num);
+  ASSERT_EQ(cqe.rocm_ernic.reserved, 0);
 
   return 0;
 }
@@ -332,7 +333,7 @@ int main() {
   failures += test_cqe_generation_mlx5();
   failures += test_cqe_generation_bnxt();
   failures += test_cqe_generation_ionic();
-  failures += test_cqe_generation_pvrdma();
+  failures += test_cqe_generation_rocm_ernic();
   failures += test_cqe_generation_invalid_opcode();
   failures += test_cqe_generation_stop_command();
   failures += test_wqe_id_matching();

--- a/tests/unit/rdma-ep/test-rdma-queue-ops.hip
+++ b/tests/unit/rdma-ep/test-rdma-queue-ops.hip
@@ -308,7 +308,7 @@ int test_cqe_equal() {
   struct rdma_cqe cqe3 = {};
 
   rdma_cqe_setup_success(&cqe1, 100, RDMAVendor::IONIC, 4096, 0x1111);
-  rdma_cqe_setup_success(&cqe2, 100, RDMAVendor::PVRDMA, 8192, 0x2222);
+  rdma_cqe_setup_success(&cqe2, 100, RDMAVendor::ROCM_ERNIC, 8192, 0x2222);
   rdma_cqe_setup_error(&cqe3, 200, RDMAVendor::IONIC, RDMA_WC_LOC_LEN_ERR,
                        0x3333);
 
@@ -341,11 +341,11 @@ int test_byte_by_byte_preservation() {
 
   // Create CQE with all fields set
   struct rdma_cqe original_cqe = {};
-  rdma_cqe_setup_success(&original_cqe, 888, RDMAVendor::PVRDMA, 0xFFFF,
+  rdma_cqe_setup_success(&original_cqe, 888, RDMAVendor::ROCM_ERNIC, 0xFFFF,
                          0xAAAAAAAA);
   original_cqe.imm_data = 0x87654321;
-  original_cqe.pvrdma.qpn = 5000;
-  original_cqe.pvrdma.reserved = 0x1234;
+  original_cqe.rocm_ernic.qpn = 5000;
+  original_cqe.rocm_ernic.reserved = 0x1234;
 
   // Write and read back
   alignas(64) uint8_t cqe_buffer[RDMA_EP_CQE_SIZE] = {};

--- a/tests/unit/rdma-ep/test-rdma-vendors.hip
+++ b/tests/unit/rdma-ep/test-rdma-vendors.hip
@@ -11,10 +11,10 @@
 #include "bnxt/bnxt-rdma.h"
 #include "ionic/ionic-rdma.h"
 #include "mlx/mlx5-rdma.h"
-#include "pvrdma/pvrdma-rdma.h"
 #include "rdma-ep.h"
 #include "rdma-ep.hip" // Include implementation for __device__ functions
-#include "xio.h"       // For HIP_CHECK macro
+#include "rocm-ernic/rocm-ernic-rdma.h"
+#include "xio.h" // For HIP_CHECK macro
 
 // Simple assertion macros
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -64,16 +64,17 @@ __global__ void test_vendor_specific_kernel(bool* results) {
   rdma_ep::cqeType ionic_cqe = rdma_ep::cqeGenFromSqe(&ionic_wqe, 0);
   test_passed &= (ionic_cqe.ionic.qpn == ionic_qp);
 
-  // Test PVRDMA
-  struct rdma_wqe pvrdma_wqe = {};
-  uint32_t pvrdma_qp = 3000;
-  pvrdma_wqe_set_vendor_specific(&pvrdma_wqe, pvrdma_qp, false, true);
-  uint32_t pvrdma_extracted_qp = static_cast<uint32_t>(
-    pvrdma_wqe.vendor_specific >> 32);
-  test_passed &= (pvrdma_extracted_qp == pvrdma_qp);
+  // Test rocm-ernic
+  struct rdma_wqe rocm_ernic_wqe = {};
+  uint32_t rocm_ernic_qp = 3000;
+  rocm_ernic_wqe_set_vendor_specific(&rocm_ernic_wqe, rocm_ernic_qp, false,
+                                     true);
+  uint32_t rocm_ernic_extracted_qp = static_cast<uint32_t>(
+    rocm_ernic_wqe.vendor_specific >> 32);
+  test_passed &= (rocm_ernic_extracted_qp == rocm_ernic_qp);
 
-  rdma_ep::cqeType pvrdma_cqe = rdma_ep::cqeGenFromSqe(&pvrdma_wqe, 0);
-  test_passed &= (pvrdma_cqe.pvrdma.qpn == pvrdma_qp);
+  rdma_ep::cqeType rocm_ernic_cqe = rdma_ep::cqeGenFromSqe(&rocm_ernic_wqe, 0);
+  test_passed &= (rocm_ernic_cqe.rocm_ernic.qpn == rocm_ernic_qp);
 
   results[0] = test_passed;
 }
@@ -172,14 +173,14 @@ int test_ionic_vendor_specific() {
   return 0;
 }
 
-// Test PVRDMA vendor-specific functions
-int test_pvrdma_vendor_specific() {
+// Test rocm-ernic vendor-specific functions
+int test_rocm_ernic_vendor_specific() {
   struct rdma_wqe wqe = {};
   uint32_t qp_num = 3000;
   bool signaled = false;
   bool fence = true;
 
-  pvrdma_wqe_set_vendor_specific(&wqe, qp_num, signaled, fence);
+  rocm_ernic_wqe_set_vendor_specific(&wqe, qp_num, signaled, fence);
 
   // Verify encoding: QP number in upper 32 bits, flags in lower 32 bits
   uint32_t extracted_qp = static_cast<uint32_t>(wqe.vendor_specific >> 32);
@@ -187,20 +188,20 @@ int test_pvrdma_vendor_specific() {
                                                    0xFFFFFFFF);
 
   ASSERT_EQ(extracted_qp, qp_num);
-  ASSERT_FALSE(extracted_flags & PVRDMA_SEND_SIGNALED);
-  ASSERT_TRUE(extracted_flags & PVRDMA_SEND_FENCE);
+  ASSERT_FALSE(extracted_flags & ROCM_ERNIC_SEND_SIGNALED);
+  ASSERT_TRUE(extracted_flags & ROCM_ERNIC_SEND_FENCE);
 
   // Test with signaled flag
-  pvrdma_wqe_set_vendor_specific(&wqe, qp_num, true, false);
+  rocm_ernic_wqe_set_vendor_specific(&wqe, qp_num, true, false);
   extracted_flags = static_cast<uint32_t>(wqe.vendor_specific & 0xFFFFFFFF);
-  ASSERT_TRUE(extracted_flags & PVRDMA_SEND_SIGNALED);
-  ASSERT_FALSE(extracted_flags & PVRDMA_SEND_FENCE);
+  ASSERT_TRUE(extracted_flags & ROCM_ERNIC_SEND_SIGNALED);
+  ASSERT_FALSE(extracted_flags & ROCM_ERNIC_SEND_FENCE);
 
   // Generate CQE and verify extraction
   rdma_ep::cqeType cqe = rdma_ep::cqeGenFromSqe(&wqe, 0);
   struct rdma_cqe* cqe_ptr = &cqe;
 
-  ASSERT_EQ(pvrdma_cqe_get_qpn(cqe_ptr), qp_num);
+  ASSERT_EQ(rocm_ernic_cqe_get_qpn(cqe_ptr), qp_num);
 
   return 0;
 }
@@ -237,15 +238,16 @@ int test_vendor_cqe_extraction() {
   ASSERT_EQ(ionic_cqe.ionic.qpn, 2002);
   ASSERT_EQ(ionic_cqe.ionic.reserved, 0);
 
-  // PVRDMA
-  struct rdma_wqe pvrdma_wqe = {};
-  pvrdma_wqe.vendor = static_cast<uint8_t>(RDMAVendor::PVRDMA);
-  pvrdma_wqe.wqe_id = 4;
-  pvrdma_wqe.length = 32768;
-  pvrdma_wqe_set_vendor_specific(&pvrdma_wqe, 3003, false, true);
-  rdma_ep::cqeType pvrdma_cqe = rdma_ep::cqeGenFromSqe(&pvrdma_wqe, 0x4444);
-  ASSERT_EQ(pvrdma_cqe.pvrdma.qpn, 3003);
-  ASSERT_EQ(pvrdma_cqe.pvrdma.reserved, 0);
+  // rocm-ernic
+  struct rdma_wqe rocm_ernic_wqe = {};
+  rocm_ernic_wqe.vendor = static_cast<uint8_t>(RDMAVendor::ROCM_ERNIC);
+  rocm_ernic_wqe.wqe_id = 4;
+  rocm_ernic_wqe.length = 32768;
+  rocm_ernic_wqe_set_vendor_specific(&rocm_ernic_wqe, 3003, false, true);
+  rdma_ep::cqeType rocm_ernic_cqe = rdma_ep::cqeGenFromSqe(&rocm_ernic_wqe,
+                                                           0x4444);
+  ASSERT_EQ(rocm_ernic_cqe.rocm_ernic.qpn, 3003);
+  ASSERT_EQ(rocm_ernic_cqe.rocm_ernic.reserved, 0);
 
   return 0;
 }
@@ -321,7 +323,7 @@ int main() {
   failures += test_mlx5_vendor_specific();
   failures += test_bnxt_vendor_specific();
   failures += test_ionic_vendor_specific();
-  failures += test_pvrdma_vendor_specific();
+  failures += test_rocm_ernic_vendor_specific();
   failures += test_vendor_cqe_extraction();
 
   if (failures == 0) {

--- a/tests/unit/rdma-ep/test-rdma-wqe-cqe.hip
+++ b/tests/unit/rdma-ep/test-rdma-wqe-cqe.hip
@@ -50,7 +50,7 @@ __global__ void test_wqe_cqe_setup_kernel(bool* results) {
 
   // Test CQE setup functions
   struct rdma_cqe cqe_success = {};
-  rdma_cqe_setup_success(&cqe_success, 123, RDMAVendor::PVRDMA, 4096,
+  rdma_cqe_setup_success(&cqe_success, 123, RDMAVendor::ROCM_ERNIC, 4096,
                          0x12345678);
   test_passed &= (cqe_success.status == RDMA_WC_SUCCESS);
   test_passed &= (cqe_success.byte_len == 4096);
@@ -130,10 +130,10 @@ int test_wqe_setup_read() {
 // Test CQE setup functions
 int test_cqe_setup_success() {
   struct rdma_cqe cqe = {};
-  rdma_cqe_setup_success(&cqe, 123, RDMAVendor::PVRDMA, 4096, 0x12345678);
+  rdma_cqe_setup_success(&cqe, 123, RDMAVendor::ROCM_ERNIC, 4096, 0x12345678);
 
   ASSERT_EQ(cqe.wqe_id, 123);
-  ASSERT_EQ(cqe.vendor, static_cast<uint8_t>(RDMAVendor::PVRDMA));
+  ASSERT_EQ(cqe.vendor, static_cast<uint8_t>(RDMAVendor::ROCM_ERNIC));
   ASSERT_EQ(cqe.status, RDMA_WC_SUCCESS);
   ASSERT_EQ(cqe.byte_len, 4096);
   ASSERT_EQ(cqe.imm_data, 0);
@@ -197,7 +197,7 @@ int test_vendor_name() {
   ASSERT_STREQ(rdma_vendor_name(RDMAVendor::MLX5), "MLX5");
   ASSERT_STREQ(rdma_vendor_name(RDMAVendor::BNXT_RE), "BNXT_RE");
   ASSERT_STREQ(rdma_vendor_name(RDMAVendor::IONIC), "IONIC");
-  ASSERT_STREQ(rdma_vendor_name(RDMAVendor::PVRDMA), "PVRDMA");
+  ASSERT_STREQ(rdma_vendor_name(RDMAVendor::ROCM_ERNIC), "rocm-ernic");
   ASSERT_STREQ(rdma_vendor_name(RDMAVendor::UNKNOWN), "UNKNOWN");
 
   return 0;


### PR DESCRIPTION
Replace PVRDMA (VMware Paravirtualized RDMA) vendor support with rocm-ernic (AMD Emulated RDMA NIC) vendor support. rocm-ernic is AMD's emulated RDMA NIC driver located at ../rocm-ernic/driver.

Changes:
- Update RDMAVendor enum: PVRDMA = 3 → ROCM_ERNIC = 3
- Rename CQE union member: pvrdma → rocm_ernic
- Create new vendor header: rocm-ernic/rocm-ernic-rdma.h
- Remove PVRDMA directory and all references
- Update all test files to use ROCM_ERNIC instead of PVRDMA
- Update CLI vendor strings: "pvrdma" → "rocm-ernic"
- Update build system (CMakeLists.txt) to reference rocm-ernic
- Update documentation (README.md) to reflect new vendor

Naming convention:
- User-facing strings: "rocm-ernic" (lowercase with hyphen)
- Enum values: ROCM_ERNIC (uppercase with underscore)
- C/C++ identifiers: rocm_ernic (lowercase with underscore)

The rocm-ernic vendor header is based on the driver headers in ../rocm-ernic/driver/rocm_ernic-abi.h and follows the same pattern as other vendor headers (MLX5, BNXT_RE, IONIC).
