### PR TITLE
Add missing host-side DOCA compatibility surface for GIN and introduc…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,8 +312,11 @@ add_executable(doca-gin-doorbell-test
 add_executable(doca-gin-wqe-test
   ${UNIT_TESTS_DIR}/gin-ep/gin-ep-wqe-test.hip
 )
+add_executable(doca-gin-alloc-test
+  ${UNIT_TESTS_DIR}/gin-ep/gin-ep-alloc-test.hip
+)
 
-foreach(tgt doca-gin-atomic-test doca-gin-doorbell-test doca-gin-wqe-test)
+foreach(tgt doca-gin-atomic-test doca-gin-doorbell-test doca-gin-wqe-test doca-gin-alloc-test)
   target_compile_options(${tgt} PRIVATE
     -std=c++17
     -Wall

--- a/src/endpoints/gin-ep/doca_error.hip.h
+++ b/src/endpoints/gin-ep/doca_error.hip.h
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Modifications Copyright (c) 2025-2026 Advanced
+ * Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DOCA_ERROR_HIP_H
+#define DOCA_ERROR_HIP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum doca_error {
+  DOCA_SUCCESS = 0,
+  DOCA_ERROR_UNKNOWN = 1,
+  DOCA_ERROR_NOT_PERMITTED = 2,
+  DOCA_ERROR_IN_USE = 3,
+  DOCA_ERROR_NOT_SUPPORTED = 4,
+  DOCA_ERROR_AGAIN = 5,
+  DOCA_ERROR_INVALID_VALUE = 6,
+  DOCA_ERROR_NO_MEMORY = 7,
+  DOCA_ERROR_INITIALIZATION = 8,
+  DOCA_ERROR_TIME_OUT = 9,
+  DOCA_ERROR_SHUTDOWN = 10,
+  DOCA_ERROR_CONNECTION_RESET = 11,
+  DOCA_ERROR_CONNECTION_ABORTED = 12,
+  DOCA_ERROR_CONNECTION_INPROGRESS = 13,
+  DOCA_ERROR_NOT_CONNECTED = 14,
+  DOCA_ERROR_NO_LOCK = 15,
+  DOCA_ERROR_NOT_FOUND = 16,
+  DOCA_ERROR_IO_FAILED = 17,
+  DOCA_ERROR_BAD_STATE = 18,
+  DOCA_ERROR_UNSUPPORTED_VERSION = 19,
+  DOCA_ERROR_OPERATING_SYSTEM = 20,
+  DOCA_ERROR_DRIVER = 21,
+  DOCA_ERROR_UNEXPECTED = 22,
+  DOCA_ERROR_ALREADY_EXIST = 23,
+  DOCA_ERROR_FULL = 24,
+  DOCA_ERROR_EMPTY = 25,
+  DOCA_ERROR_IN_PROGRESS = 26,
+  DOCA_ERROR_TOO_BIG = 27,
+  DOCA_ERROR_AUTHENTICATION = 28,
+  DOCA_ERROR_BAD_CONFIG = 29,
+  DOCA_ERROR_SKIPPED = 30,
+  DOCA_ERROR_DEVICE_FATAL_ERROR = 31
+} doca_error_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/endpoints/gin-ep/doca_gpunetio_high_level.hip.h
+++ b/src/endpoints/gin-ep/doca_gpunetio_high_level.hip.h
@@ -1,0 +1,79 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef DOCA_GPUNETIO_HIGH_LEVEL_HIP_H
+#define DOCA_GPUNETIO_HIGH_LEVEL_HIP_H
+
+#include <cstdint>
+
+#include "doca_error.hip.h"
+#include "doca_gpunetio_verbs_def.hip.h"
+#include "doca_verbs.hip.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum doca_gpu_verbs_mem_reg_type {
+  DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT = 0,
+  DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_CUDA_DMABUF = 1,
+  DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_CUDA_PEERMEM = 2,
+  DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_MAX,
+};
+
+struct ibv_pd;
+struct doca_verbs_umem;
+struct doca_verbs_uar;
+struct doca_gpu_dev_verbs_qp;
+struct doca_gpu;
+struct doca_gpu_verbs_qp;
+
+struct doca_gpu_verbs_qp_init_attr_hl {
+  struct doca_gpu* gpu_dev;
+  struct ibv_pd* ibpd;
+  uint16_t sq_nwqe;
+  doca_gpu_dev_verbs_nic_handler nic_handler;
+  enum doca_gpu_verbs_mem_reg_type mreg_type;
+  enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext;
+};
+
+struct doca_gpu_verbs_qp_hl {
+  struct doca_gpu* gpu_dev;
+  struct doca_verbs_cq* cq_sq;
+  void* cq_sq_umem_gpu_ptr;
+  struct doca_verbs_umem* cq_sq_umem;
+  void* cq_sq_umem_dbr_gpu_ptr;
+  struct doca_verbs_umem* cq_sq_umem_dbr;
+  struct doca_verbs_qp* qp;
+  void* qp_umem_gpu_ptr;
+  struct doca_verbs_umem* qp_umem;
+  void* qp_umem_dbr_gpu_ptr;
+  struct doca_verbs_umem* qp_umem_dbr;
+  struct doca_verbs_uar* external_uar;
+  doca_gpu_dev_verbs_nic_handler nic_handler;
+  enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext;
+  struct doca_gpu_verbs_qp* qp_gverbs;
+};
+
+struct doca_gpu_verbs_qp_group_hl {
+  struct doca_gpu_verbs_qp_hl qp_main;
+  struct doca_gpu_verbs_qp_hl qp_companion;
+};
+
+doca_error_t doca_gpu_verbs_create_qp_hl(
+  struct doca_gpu_verbs_qp_init_attr_hl* qp_init_attr,
+  struct doca_gpu_verbs_qp_hl** qp);
+doca_error_t doca_gpu_verbs_destroy_qp_hl(struct doca_gpu_verbs_qp_hl* qp);
+doca_error_t doca_gpu_verbs_create_qp_group_hl(
+  struct doca_gpu_verbs_qp_init_attr_hl* qp_init_attr,
+  struct doca_gpu_verbs_qp_group_hl** qpg);
+doca_error_t doca_gpu_verbs_destroy_qp_group_hl(
+  struct doca_gpu_verbs_qp_group_hl* qpg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/endpoints/gin-ep/doca_gpunetio_host.hip
+++ b/src/endpoints/gin-ep/doca_gpunetio_host.hip
@@ -1,0 +1,583 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <new>
+#include <string>
+#include <unordered_map>
+
+#include "doca_gpunetio_high_level.hip.h"
+#include "doca_gpunetio_host.hip.h"
+#include "hip/hip_runtime.h"
+
+struct doca_gpu {
+  int device_ordinal;
+  std::string pci_bus_id;
+};
+
+namespace {
+
+struct AllocationRecord {
+  enum doca_gpu_mem_type type;
+  void* gpu_ptr;
+  void* cpu_ptr;
+};
+
+std::mutex g_alloc_mu;
+std::unordered_map<void*, AllocationRecord> g_allocs;
+
+bool isPowerOfTwo(size_t value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+doca_error_t fromHipError(hipError_t err) {
+  if (err == hipSuccess)
+    return DOCA_SUCCESS;
+  if (err == hipErrorOutOfMemory)
+    return DOCA_ERROR_NO_MEMORY;
+  return DOCA_ERROR_DRIVER;
+}
+
+doca_error_t setU16(uint16_t* out, uint32_t value) {
+  if (out == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  if (value > 0xffffU)
+    return DOCA_ERROR_INVALID_VALUE;
+  *out = static_cast<uint16_t>(value);
+  return DOCA_SUCCESS;
+}
+
+doca_error_t notSupported() {
+  return DOCA_ERROR_NOT_SUPPORTED;
+}
+
+} // namespace
+
+extern "C" {
+
+doca_error_t doca_gpu_create(const char* gpu_bus_id,
+                             struct doca_gpu** gpu_dev) {
+  if (gpu_dev == nullptr || gpu_bus_id == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *gpu_dev = nullptr;
+
+  int device_count = 0;
+  hipError_t err = hipGetDeviceCount(&device_count);
+  if (err != hipSuccess)
+    return fromHipError(err);
+
+  int selected = -1;
+  char bus_id[32] = {0};
+  for (int d = 0; d < device_count; ++d) {
+    if (hipDeviceGetPCIBusId(bus_id, sizeof(bus_id), d) != hipSuccess)
+      continue;
+    if (std::strcmp(bus_id, gpu_bus_id) == 0) {
+      selected = d;
+      break;
+    }
+  }
+  if (selected < 0)
+    return DOCA_ERROR_NOT_FOUND;
+
+  doca_gpu* gpu = new (std::nothrow) doca_gpu();
+  if (gpu == nullptr)
+    return DOCA_ERROR_NO_MEMORY;
+  gpu->device_ordinal = selected;
+  gpu->pci_bus_id = gpu_bus_id;
+  *gpu_dev = gpu;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_destroy(struct doca_gpu* gpu_dev) {
+  if (gpu_dev == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  delete gpu_dev;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_mem_alloc(struct doca_gpu* gpu_dev, size_t size,
+                                size_t alignment, enum doca_gpu_mem_type mtype,
+                                void** memptr_gpu, void** memptr_cpu) {
+  if (gpu_dev == nullptr || memptr_gpu == nullptr || size == 0)
+    return DOCA_ERROR_INVALID_VALUE;
+  if (alignment != 0 && !isPowerOfTwo(alignment))
+    return DOCA_ERROR_INVALID_VALUE;
+
+  *memptr_gpu = nullptr;
+  if (memptr_cpu != nullptr)
+    *memptr_cpu = nullptr;
+
+  int current_device = -1;
+  hipError_t err = hipGetDevice(&current_device);
+  if (err != hipSuccess)
+    return fromHipError(err);
+  err = hipSetDevice(gpu_dev->device_ordinal);
+  if (err != hipSuccess)
+    return fromHipError(err);
+
+  void* gpu_ptr = nullptr;
+  void* cpu_ptr = nullptr;
+  doca_error_t status = DOCA_SUCCESS;
+
+  switch (mtype) {
+    case DOCA_GPU_MEM_TYPE_GPU:
+      err = hipMalloc(&gpu_ptr, size);
+      status = fromHipError(err);
+      break;
+    case DOCA_GPU_MEM_TYPE_GPU_CPU:
+      err = hipMallocManaged(&gpu_ptr, size, hipMemAttachGlobal);
+      cpu_ptr = gpu_ptr;
+      status = fromHipError(err);
+      break;
+    case DOCA_GPU_MEM_TYPE_CPU_GPU:
+      err = hipHostMalloc(&cpu_ptr, size, hipHostMallocMapped);
+      if (err == hipSuccess)
+        err = hipHostGetDevicePointer(&gpu_ptr, cpu_ptr, 0);
+      status = fromHipError(err);
+      if (status != DOCA_SUCCESS && cpu_ptr != nullptr) {
+        static_cast<void>(hipHostFree(cpu_ptr));
+        cpu_ptr = nullptr;
+      }
+      break;
+    default:
+      status = DOCA_ERROR_INVALID_VALUE;
+      break;
+  }
+
+  static_cast<void>(hipSetDevice(current_device));
+  if (status != DOCA_SUCCESS)
+    return status;
+
+  {
+    std::lock_guard<std::mutex> lk(g_alloc_mu);
+    g_allocs[gpu_ptr] = AllocationRecord{mtype, gpu_ptr, cpu_ptr};
+  }
+
+  *memptr_gpu = gpu_ptr;
+  if (memptr_cpu != nullptr)
+    *memptr_cpu = cpu_ptr;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_mem_free(struct doca_gpu* gpu, void* memptr_gpu) {
+  if (gpu == nullptr || memptr_gpu == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+
+  AllocationRecord rec{};
+  {
+    std::lock_guard<std::mutex> lk(g_alloc_mu);
+    auto it = g_allocs.find(memptr_gpu);
+    if (it == g_allocs.end())
+      return DOCA_ERROR_NOT_FOUND;
+    rec = it->second;
+    g_allocs.erase(it);
+  }
+
+  int current_device = -1;
+  hipError_t err = hipGetDevice(&current_device);
+  if (err != hipSuccess)
+    return fromHipError(err);
+  err = hipSetDevice(gpu->device_ordinal);
+  if (err != hipSuccess)
+    return fromHipError(err);
+
+  if (rec.type == DOCA_GPU_MEM_TYPE_CPU_GPU) {
+    err = hipHostFree(rec.cpu_ptr);
+  } else {
+    err = hipFree(rec.gpu_ptr);
+  }
+
+  static_cast<void>(hipSetDevice(current_device));
+  return fromHipError(err);
+}
+
+doca_error_t doca_gpu_verbs_export_qp(
+  struct doca_gpu* gpu_dev, struct doca_verbs_qp* qp,
+  doca_gpu_dev_verbs_nic_handler nic_handler, void* gpu_qp_umem_dev_ptr,
+  struct doca_verbs_cq* cq_sq,
+  enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext,
+  struct doca_gpu_verbs_qp** qp_out) {
+  (void)gpu_dev;
+  (void)qp;
+  (void)nic_handler;
+  (void)gpu_qp_umem_dev_ptr;
+  (void)cq_sq;
+  (void)send_dbr_mode_ext;
+  if (qp_out == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *qp_out = nullptr;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_unexport_qp(struct doca_gpu* gpu_dev,
+                                        struct doca_gpu_verbs_qp* qp) {
+  (void)gpu_dev;
+  (void)qp;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_get_qp_dev(struct doca_gpu_verbs_qp* qp,
+                                       struct radaki_dev_qp** qp_gpu) {
+  if (qp == nullptr || qp_gpu == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *qp_gpu = qp->qp_gpu;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_dmabuf_fd(struct doca_gpu* gpu_dev, void* memptr_gpu,
+                                size_t size, int* dmabuf_fd) {
+  (void)gpu_dev;
+  (void)memptr_gpu;
+  (void)size;
+  if (dmabuf_fd == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *dmabuf_fd = -1;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_can_gpu_register_uar(void* db,
+                                                 bool* out_can_register) {
+  (void)db;
+  if (out_can_register == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *out_can_register = false;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_export_uar(uint64_t* sq_db,
+                                       uint64_t** uar_addr_gpu) {
+  if (sq_db == nullptr || uar_addr_gpu == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *uar_addr_gpu = nullptr;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_unexport_uar(uint64_t* uar_addr_gpu) {
+  (void)uar_addr_gpu;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_cpu_proxy_progress(
+  struct doca_gpu_verbs_qp* qp_cpu) {
+  if (qp_cpu == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  if (qp_cpu->sq_db == nullptr || qp_cpu->cpu_db == nullptr)
+    return DOCA_SUCCESS;
+  const uint64_t db = ((qp_cpu->sq_wqe_pi_last & 0x00ffffffULL) << 8) |
+                      static_cast<uint64_t>(
+                        __builtin_bswap32(qp_cpu->sq_num_shift8_be));
+  *qp_cpu->sq_db = db;
+  *qp_cpu->cpu_db = qp_cpu->sq_wqe_pi_last;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_create_service(
+  doca_gpu_verbs_service_t* out_service) {
+  if (out_service == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *out_service = nullptr;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_service_monitor_qp(doca_gpu_verbs_service_t service,
+                                               struct doca_gpu_verbs_qp* qp) {
+  (void)service;
+  (void)qp;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_destroy_service(doca_gpu_verbs_service_t service) {
+  (void)service;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_query_last_error(
+  struct doca_gpu_verbs_qp* qp,
+  struct doca_gpu_verbs_qp_error_info* error_info) {
+  if (qp == nullptr || error_info == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  std::memset(error_info, 0, sizeof(*error_info));
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_export_multi_qps_dev(
+  struct doca_gpu* gpu_dev, struct doca_gpu_verbs_qp** qps,
+  unsigned int num_qps, struct radaki_dev_qp** out_qp_gpus) {
+  (void)gpu_dev;
+  (void)qps;
+  (void)num_qps;
+  if (out_qp_gpus == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *out_qp_gpus = nullptr;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_unexport_multi_qps_dev(
+  struct doca_gpu* gpu_dev, struct doca_gpu_verbs_qp** qps,
+  unsigned int num_qps, struct radaki_dev_qp* qp_gpus) {
+  (void)gpu_dev;
+  (void)qps;
+  (void)num_qps;
+  (void)qp_gpus;
+  return notSupported();
+}
+
+doca_error_t doca_verbs_qp_attr_create(
+  struct doca_verbs_qp_attr** verbs_qp_attr) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *verbs_qp_attr = static_cast<doca_verbs_qp_attr*>(
+    std::calloc(1, sizeof(struct doca_verbs_qp_attr)));
+  if (*verbs_qp_attr == nullptr)
+    return DOCA_ERROR_NO_MEMORY;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_destroy(
+  struct doca_verbs_qp_attr* verbs_qp_attr) {
+  std::free(verbs_qp_attr);
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_next_state(
+  struct doca_verbs_qp_attr* verbs_qp_attr,
+  enum doca_verbs_qp_state next_state) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->next_state = next_state;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_path_mtu(
+  struct doca_verbs_qp_attr* verbs_qp_attr, enum doca_verbs_mtu_size path_mtu) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->path_mtu = path_mtu;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_rq_psn(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint32_t rq_psn) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->rq_psn = rq_psn;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_sq_psn(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint32_t sq_psn) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->sq_psn = sq_psn;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_port_num(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t port_num) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  return setU16(&verbs_qp_attr->port_num, port_num);
+}
+
+doca_error_t doca_verbs_qp_attr_set_ack_timeout(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t ack_timeout) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  return setU16(&verbs_qp_attr->ack_timeout, ack_timeout);
+}
+
+doca_error_t doca_verbs_qp_attr_set_retry_cnt(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t retry_cnt) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  return setU16(&verbs_qp_attr->retry_cnt, retry_cnt);
+}
+
+doca_error_t doca_verbs_qp_attr_set_rnr_retry(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t rnr_retry) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  return setU16(&verbs_qp_attr->rnr_retry, rnr_retry);
+}
+
+doca_error_t doca_verbs_qp_attr_set_min_rnr_timer(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t min_rnr_timer) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  return setU16(&verbs_qp_attr->min_rnr_timer, min_rnr_timer);
+}
+
+doca_error_t doca_verbs_qp_attr_set_allow_remote_write(
+  struct doca_verbs_qp_attr* verbs_qp_attr, int allow_remote_write) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->allow_remote_write = allow_remote_write ? 1 : 0;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_allow_remote_read(
+  struct doca_verbs_qp_attr* verbs_qp_attr, int allow_remote_read) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->allow_remote_read = allow_remote_read ? 1 : 0;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_allow_remote_atomic(
+  struct doca_verbs_qp_attr* verbs_qp_attr,
+  enum doca_verbs_qp_atomic_type allow_remote_atomic) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->allow_remote_atomic = allow_remote_atomic;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_ah_attr(
+  struct doca_verbs_qp_attr* verbs_qp_attr,
+  struct doca_verbs_ah_attr* verbs_ah) {
+  if (verbs_qp_attr == nullptr || verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->ah_attr = verbs_ah;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_dest_qp_num(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint32_t dest_qp_num) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_qp_attr->dest_qp_num = dest_qp_num;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_qp_attr_set_pkey_index(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t pkey_index) {
+  if (verbs_qp_attr == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  return setU16(&verbs_qp_attr->pkey_index, pkey_index);
+}
+
+doca_error_t doca_verbs_qp_modify(struct doca_verbs_qp* qp,
+                                  struct doca_verbs_qp_attr* verbs_qp_attr,
+                                  uint64_t attr_mask) {
+  (void)qp;
+  (void)verbs_qp_attr;
+  (void)attr_mask;
+  return notSupported();
+}
+
+uint32_t doca_verbs_qp_get_qpn(struct doca_verbs_qp* qp) {
+  if (qp == nullptr)
+    return 0;
+  return qp->qpn;
+}
+
+doca_error_t doca_verbs_ah_attr_create(struct ibv_context* context,
+                                       struct doca_verbs_ah_attr** verbs_ah) {
+  if (verbs_ah == nullptr || context == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *verbs_ah = static_cast<doca_verbs_ah_attr*>(
+    std::calloc(1, sizeof(struct doca_verbs_ah_attr)));
+  if (*verbs_ah == nullptr)
+    return DOCA_ERROR_NO_MEMORY;
+  (*verbs_ah)->context = context;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_destroy(struct doca_verbs_ah_attr* verbs_ah) {
+  std::free(verbs_ah);
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_gid(struct doca_verbs_ah_attr* verbs_ah,
+                                        struct doca_verbs_gid gid) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  std::memcpy(verbs_ah->gid.raw, gid.raw, sizeof(gid.raw));
+  verbs_ah->has_gid = true;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_addr_type(
+  struct doca_verbs_ah_attr* verbs_ah, enum doca_verbs_addr_type addr_type) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_ah->addr_type = addr_type;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_dlid(struct doca_verbs_ah_attr* verbs_ah,
+                                         uint32_t dlid) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_ah->dlid = dlid;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_sl(struct doca_verbs_ah_attr* verbs_ah,
+                                       uint8_t sl) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_ah->sl = sl;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_sgid_index(
+  struct doca_verbs_ah_attr* verbs_ah, uint8_t sgid_index) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_ah->sgid_index = sgid_index;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_hop_limit(
+  struct doca_verbs_ah_attr* verbs_ah, uint8_t hop_limit) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_ah->hop_limit = hop_limit;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_verbs_ah_attr_set_traffic_class(
+  struct doca_verbs_ah_attr* verbs_ah, uint8_t traffic_class) {
+  if (verbs_ah == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  verbs_ah->traffic_class = traffic_class;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_create_qp_hl(
+  struct doca_gpu_verbs_qp_init_attr_hl* qp_init_attr,
+  struct doca_gpu_verbs_qp_hl** qp) {
+  (void)qp_init_attr;
+  if (qp == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *qp = nullptr;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_destroy_qp_hl(struct doca_gpu_verbs_qp_hl* qp) {
+  (void)qp;
+  return DOCA_SUCCESS;
+}
+
+doca_error_t doca_gpu_verbs_create_qp_group_hl(
+  struct doca_gpu_verbs_qp_init_attr_hl* qp_init_attr,
+  struct doca_gpu_verbs_qp_group_hl** qpg) {
+  (void)qp_init_attr;
+  if (qpg == nullptr)
+    return DOCA_ERROR_INVALID_VALUE;
+  *qpg = nullptr;
+  return notSupported();
+}
+
+doca_error_t doca_gpu_verbs_destroy_qp_group_hl(
+  struct doca_gpu_verbs_qp_group_hl* qpg) {
+  (void)qpg;
+  return DOCA_SUCCESS;
+}
+
+} // extern "C"

--- a/src/endpoints/gin-ep/doca_gpunetio_host.hip.h
+++ b/src/endpoints/gin-ep/doca_gpunetio_host.hip.h
@@ -39,9 +39,9 @@
 #ifndef DOCA_GPUNETIO_H
 #define DOCA_GPUNETIO_H
 
-#include "common/doca_gpunetio_verbs_def.h"
-#include "doca_gpunetio_config.h"
-#include "host/doca_error.h"
+#include "doca_error.hip.h"
+#include "doca_gpunetio_verbs_def.hip.h"
+#include "doca_verbs.hip.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,10 +88,13 @@ struct doca_gpu_verbs_qp {
   __be32* sq_dbrec;
   bool cpu_proxy;
   uint32_t sq_num_shift8_be;
+  enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext;
   /* CPU handler */
   struct radaki_dev_qp* qp_cpu;
   /* GPU handler */
   struct radaki_dev_qp* qp_gpu;
+  /* CPU-accessible GPU handler */
+  struct radaki_dev_qp* qp_gpu_h;
 };
 
 /**
@@ -213,12 +216,12 @@ doca_error_t doca_gpu_mem_free(struct doca_gpu* gpu, void* memptr_gpu);
  * doca_error code - in case of failure:
  * - DOCA_ERROR_INVALID_VALUE - if an invalid input had been received.
  */
-doca_error_t doca_gpu_verbs_export_qp(struct doca_gpu* gpu_dev,
-                                      struct doca_verbs_qp* qp,
-                                      enum radaki_dev_nic_handler nic_handler,
-                                      void* gpu_qp_umem_dev_ptr,
-                                      struct doca_verbs_cq* cq_sq,
-                                      struct doca_gpu_verbs_qp** qp_out);
+doca_error_t doca_gpu_verbs_export_qp(
+  struct doca_gpu* gpu_dev, struct doca_verbs_qp* qp,
+  doca_gpu_dev_verbs_nic_handler nic_handler, void* gpu_qp_umem_dev_ptr,
+  struct doca_verbs_cq* cq_sq,
+  enum doca_gpu_verbs_send_dbr_mode_ext send_dbr_mode_ext,
+  struct doca_gpu_verbs_qp** qp_out);
 
 /**
  * Destroy a GPU handler for a Verbs QP object
@@ -393,6 +396,14 @@ doca_error_t doca_gpu_verbs_destroy_service(doca_gpu_verbs_service_t service);
 doca_error_t doca_gpu_verbs_query_last_error(
   struct doca_gpu_verbs_qp* qp,
   struct doca_gpu_verbs_qp_error_info* error_info);
+
+doca_error_t doca_gpu_verbs_export_multi_qps_dev(
+  struct doca_gpu* gpu_dev, struct doca_gpu_verbs_qp** qps,
+  unsigned int num_qps, struct radaki_dev_qp** out_qp_gpus);
+
+doca_error_t doca_gpu_verbs_unexport_multi_qps_dev(
+  struct doca_gpu* gpu_dev, struct doca_gpu_verbs_qp** qps,
+  unsigned int num_qps, struct radaki_dev_qp* qp_gpus);
 
 #ifdef __cplusplus
 }

--- a/src/endpoints/gin-ep/doca_gpunetio_verbs_def.hip.h
+++ b/src/endpoints/gin-ep/doca_gpunetio_verbs_def.hip.h
@@ -227,6 +227,16 @@ enum radaki_dev_mem_type {
 };
 
 /**
+ * @enum doca_gpu_verbs_send_dbr_mode_ext
+ * @brief Send DBR mode.
+ */
+enum doca_gpu_verbs_send_dbr_mode_ext {
+  DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR = 0,
+  DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW = 1,
+  DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED = 2,
+};
+
+/**
  * @enum radaki_dev_mem_type
  * @brief Memory type of the buffer.
  */
@@ -267,6 +277,13 @@ enum radaki_dev_resource_sharing_mode {
   DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_MAX = INT_MAX ///< Sentinel value
 };
 
+enum {
+  DOCA_GPUNETIO_VERBS_NIC_HANDLER_FLAG_CPU_PROXY = 1 << 0,
+  DOCA_GPUNETIO_VERBS_NIC_HANDLER_FLAG_GPU_SM = 1 << 1,
+  DOCA_GPUNETIO_VERBS_NIC_HANDLER_FLAG_BF = 1 << 2,
+  DOCA_GPUNETIO_VERBS_NIC_HANDLER_FLAG_NO_DBR = 1 << 3,
+};
+
 /**
  * @enum radaki_dev_nic_handler
  * @brief The processor that handles the NIC.
@@ -279,6 +296,15 @@ enum radaki_dev_nic_handler {
   DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_BF = 3, ///< GPU SM, BlueFlame DB
   DOCA_GPUNETIO_VERBS_NIC_HANDLER_TYPE_MAX,      ///< Sentinel value
 };
+
+/* Host API compatibility aliases used by NCCL GIN host path. */
+typedef enum radaki_dev_mem_type doca_gpu_dev_verbs_mem_type;
+typedef enum radaki_dev_qp_type doca_gpu_dev_verbs_qp_type;
+typedef enum radaki_dev_exec_scope doca_gpu_dev_verbs_exec_scope;
+typedef enum radaki_dev_sync_scope doca_gpu_dev_verbs_sync_scope;
+typedef enum radaki_dev_resource_sharing_mode
+  doca_gpu_dev_verbs_resource_sharing_mode;
+typedef enum radaki_dev_nic_handler doca_gpu_dev_verbs_nic_handler;
 
 /**
  * @enum radaki_dev_gpu_code_opt

--- a/src/endpoints/gin-ep/doca_verbs.hip.h
+++ b/src/endpoints/gin-ep/doca_verbs.hip.h
@@ -1,0 +1,174 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef DOCA_VERBS_HIP_H
+#define DOCA_VERBS_HIP_H
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "doca_error.hip.h"
+#include "doca_gpunetio_verbs_def.hip.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ibv_context;
+
+enum doca_verbs_qp_state {
+  DOCA_VERBS_QP_STATE_RST = 0x0,
+  DOCA_VERBS_QP_STATE_INIT = 0x1,
+  DOCA_VERBS_QP_STATE_RTR = 0x2,
+  DOCA_VERBS_QP_STATE_RTS = 0x3,
+  DOCA_VERBS_QP_STATE_ERR = 0x4,
+};
+
+enum doca_verbs_addr_type {
+  DOCA_VERBS_ADDR_TYPE_IPv4,
+  DOCA_VERBS_ADDR_TYPE_IPv6,
+  DOCA_VERBS_ADDR_TYPE_IB_GRH,
+  DOCA_VERBS_ADDR_TYPE_IB_NO_GRH,
+};
+
+enum doca_verbs_mtu_size {
+  DOCA_VERBS_MTU_SIZE_256_BYTES = 0x0,
+  DOCA_VERBS_MTU_SIZE_512_BYTES = 0x1,
+  DOCA_VERBS_MTU_SIZE_1K_BYTES = 0x2,
+  DOCA_VERBS_MTU_SIZE_2K_BYTES = 0x3,
+  DOCA_VERBS_MTU_SIZE_4K_BYTES = 0x4,
+  DOCA_VERBS_MTU_SIZE_RAW_ETHERNET = 0x5,
+};
+
+enum doca_verbs_qp_atomic_type {
+  DOCA_VERBS_QP_ATOMIC_MODE_NONE = 0x0,
+  DOCA_VERBS_QP_ATOMIC_MODE_IB_SPEC = 0x1,
+  DOCA_VERBS_QP_ATOMIC_MODE_UP_TO_8BYTES = 0x3
+};
+
+enum {
+  DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE = (1 << 0),
+  DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ = (1 << 1),
+  DOCA_VERBS_QP_ATTR_PKEY_INDEX = (1 << 2),
+  DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER = (1 << 3),
+  DOCA_VERBS_QP_ATTR_PORT_NUM = (1 << 4),
+  DOCA_VERBS_QP_ATTR_NEXT_STATE = (1 << 5),
+  DOCA_VERBS_QP_ATTR_PATH_MTU = (1 << 7),
+  DOCA_VERBS_QP_ATTR_RQ_PSN = (1 << 8),
+  DOCA_VERBS_QP_ATTR_SQ_PSN = (1 << 9),
+  DOCA_VERBS_QP_ATTR_DEST_QP_NUM = (1 << 10),
+  DOCA_VERBS_QP_ATTR_AH_ATTR = (1 << 11),
+  DOCA_VERBS_QP_ATTR_ACK_TIMEOUT = (1 << 13),
+  DOCA_VERBS_QP_ATTR_RETRY_CNT = (1 << 14),
+  DOCA_VERBS_QP_ATTR_RNR_RETRY = (1 << 15),
+};
+
+struct doca_verbs_gid {
+  uint8_t raw[16];
+};
+
+struct doca_verbs_qp {
+  uint32_t qpn;
+};
+
+struct doca_verbs_cq {
+  int unused;
+};
+
+struct doca_verbs_ah_attr {
+  struct ibv_context* context;
+  struct doca_verbs_gid gid;
+  enum doca_verbs_addr_type addr_type;
+  uint32_t dlid;
+  uint8_t sl;
+  uint8_t sgid_index;
+  uint8_t hop_limit;
+  uint8_t traffic_class;
+  bool has_gid;
+};
+
+struct doca_verbs_qp_attr {
+  enum doca_verbs_qp_state next_state;
+  enum doca_verbs_mtu_size path_mtu;
+  uint32_t rq_psn;
+  uint32_t sq_psn;
+  uint32_t dest_qp_num;
+  int allow_remote_write;
+  int allow_remote_read;
+  enum doca_verbs_qp_atomic_type allow_remote_atomic;
+  struct doca_verbs_ah_attr* ah_attr;
+  uint16_t pkey_index;
+  uint16_t port_num;
+  uint16_t ack_timeout;
+  uint16_t retry_cnt;
+  uint16_t rnr_retry;
+  uint16_t min_rnr_timer;
+};
+
+doca_error_t doca_verbs_qp_attr_create(
+  struct doca_verbs_qp_attr** verbs_qp_attr);
+doca_error_t doca_verbs_qp_attr_destroy(
+  struct doca_verbs_qp_attr* verbs_qp_attr);
+doca_error_t doca_verbs_qp_attr_set_next_state(
+  struct doca_verbs_qp_attr* verbs_qp_attr,
+  enum doca_verbs_qp_state next_state);
+doca_error_t doca_verbs_qp_attr_set_path_mtu(
+  struct doca_verbs_qp_attr* verbs_qp_attr, enum doca_verbs_mtu_size path_mtu);
+doca_error_t doca_verbs_qp_attr_set_rq_psn(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint32_t rq_psn);
+doca_error_t doca_verbs_qp_attr_set_sq_psn(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint32_t sq_psn);
+doca_error_t doca_verbs_qp_attr_set_port_num(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t port_num);
+doca_error_t doca_verbs_qp_attr_set_ack_timeout(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t ack_timeout);
+doca_error_t doca_verbs_qp_attr_set_retry_cnt(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t retry_cnt);
+doca_error_t doca_verbs_qp_attr_set_rnr_retry(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t rnr_retry);
+doca_error_t doca_verbs_qp_attr_set_min_rnr_timer(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t min_rnr_timer);
+doca_error_t doca_verbs_qp_attr_set_allow_remote_write(
+  struct doca_verbs_qp_attr* verbs_qp_attr, int allow_remote_write);
+doca_error_t doca_verbs_qp_attr_set_allow_remote_read(
+  struct doca_verbs_qp_attr* verbs_qp_attr, int allow_remote_read);
+doca_error_t doca_verbs_qp_attr_set_allow_remote_atomic(
+  struct doca_verbs_qp_attr* verbs_qp_attr,
+  enum doca_verbs_qp_atomic_type allow_remote_atomic);
+doca_error_t doca_verbs_qp_attr_set_ah_attr(
+  struct doca_verbs_qp_attr* verbs_qp_attr,
+  struct doca_verbs_ah_attr* verbs_ah);
+doca_error_t doca_verbs_qp_attr_set_dest_qp_num(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint32_t dest_qp_num);
+doca_error_t doca_verbs_qp_attr_set_pkey_index(
+  struct doca_verbs_qp_attr* verbs_qp_attr, uint16_t pkey_index);
+doca_error_t doca_verbs_qp_modify(struct doca_verbs_qp* qp,
+                                  struct doca_verbs_qp_attr* verbs_qp_attr,
+                                  uint64_t attr_mask);
+uint32_t doca_verbs_qp_get_qpn(struct doca_verbs_qp* qp);
+
+doca_error_t doca_verbs_ah_attr_create(struct ibv_context* context,
+                                       struct doca_verbs_ah_attr** verbs_ah);
+doca_error_t doca_verbs_ah_attr_destroy(struct doca_verbs_ah_attr* verbs_ah);
+doca_error_t doca_verbs_ah_attr_set_gid(struct doca_verbs_ah_attr* verbs_ah,
+                                        struct doca_verbs_gid gid);
+doca_error_t doca_verbs_ah_attr_set_addr_type(
+  struct doca_verbs_ah_attr* verbs_ah, enum doca_verbs_addr_type addr_type);
+doca_error_t doca_verbs_ah_attr_set_dlid(struct doca_verbs_ah_attr* verbs_ah,
+                                         uint32_t dlid);
+doca_error_t doca_verbs_ah_attr_set_sl(struct doca_verbs_ah_attr* verbs_ah,
+                                       uint8_t sl);
+doca_error_t doca_verbs_ah_attr_set_sgid_index(
+  struct doca_verbs_ah_attr* verbs_ah, uint8_t sgid_index);
+doca_error_t doca_verbs_ah_attr_set_hop_limit(
+  struct doca_verbs_ah_attr* verbs_ah, uint8_t hop_limit);
+doca_error_t doca_verbs_ah_attr_set_traffic_class(
+  struct doca_verbs_ah_attr* verbs_ah, uint8_t traffic_class);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/unit-tests/gin-ep/gin-ep-alloc-test.hip
+++ b/src/unit-tests/gin-ep/gin-ep-alloc-test.hip
@@ -1,0 +1,334 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <cerrno>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include "gin-ep/doca_gpunetio_host.hip.h"
+#include "hip/hip_runtime.h"
+
+/*
+ * Test scope: doca_gpu_mem_alloc()/doca_gpu_mem_free() semantics for the
+ * DOCA-compatible gin-ep host API.
+ *
+ * Host-side hipified DOCA APIs explicitly exercised by this test:
+ * - doca_gpu_create()
+ * - doca_gpu_mem_alloc() with DOCA_GPU_MEM_TYPE_GPU
+ * - doca_gpu_mem_alloc() with DOCA_GPU_MEM_TYPE_GPU_CPU
+ * - doca_gpu_mem_alloc() with DOCA_GPU_MEM_TYPE_CPU_GPU
+ * - doca_gpu_mem_free()
+ * - doca_gpu_destroy()
+ *
+ * Device-side validation in this test (not DOCA device API calls):
+ * - fill_u32_kernel(): writes deterministic data into GPU-only allocation.
+ * - sum_u32_kernel(): validates GPU read visibility by reducing test buffers.
+ * - host_visible_write_kernel(): validates GPU->host visibility with
+ *   __threadfence_system().
+ *
+ * What this test validates:
+ * 1) DOCA_GPU_MEM_TYPE_GPU:
+ *    - API contract for pointer visibility (GPU pointer valid, CPU alias null).
+ *    - Device-side usability by writing and reducing on GPU, then checking an
+ *      independently computed expected sum on host.
+ * 2) DOCA_GPU_MEM_TYPE_GPU_CPU:
+ *    - Host writes are visible to GPU reads.
+ *    - Validation is done by host initializing a pattern, GPU reducing it, and
+ *      host checking exact expected sum.
+ * 3) DOCA_GPU_MEM_TYPE_CPU_GPU:
+ *    - GPU writes become visible to host after system-scope fence +
+ *      synchronization.
+ *    - Validation is done by GPU writing a marker value that host reads back.
+ *
+ * What this test does NOT validate:
+ * - NIC-backed verbs behavior (WQE posting, CQE completion, doorbell/UAR MMIO).
+ * - End-to-end network transport correctness.
+ * - Performance characteristics or latency/throughput benchmarking.
+ */
+
+static int hip_to_errno(hipError_t err) {
+  switch (err) {
+    case hipErrorInvalidValue:
+      return EINVAL;
+    case hipErrorOutOfMemory:
+      return ENOMEM;
+    case hipErrorNoDevice:
+      return ENODEV;
+    default:
+      return EIO;
+  }
+}
+
+static int doca_to_errno(doca_error_t err) {
+  switch (err) {
+    case DOCA_SUCCESS:
+      return 0;
+    case DOCA_ERROR_INVALID_VALUE:
+      return EINVAL;
+    case DOCA_ERROR_NO_MEMORY:
+      return ENOMEM;
+    case DOCA_ERROR_NOT_SUPPORTED:
+      return ENOTSUP;
+    case DOCA_ERROR_NOT_FOUND:
+      return ENOENT;
+    case DOCA_ERROR_TIME_OUT:
+      return ETIMEDOUT;
+    default:
+      return EIO;
+  }
+}
+
+#define HIP_CHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t _err = (cmd);                                                   \
+    if (_err != hipSuccess) {                                                  \
+      errno = hip_to_errno(_err);                                              \
+      std::fprintf(stderr, "HIP error %s errno=%d (%s) at %s:%d\n",            \
+                   hipGetErrorString(_err), errno, std::strerror(errno),       \
+                   __FILE__, __LINE__);                                        \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+#define TEST_DOCA_CHECK(cmd)                                                   \
+  do {                                                                         \
+    doca_error_t _err = (cmd);                                                 \
+    if (_err != DOCA_SUCCESS) {                                                \
+      errno = doca_to_errno(_err);                                             \
+      std::fprintf(stderr, "DOCA error %d errno=%d (%s) at %s:%d\n",           \
+                   static_cast<int>(_err), errno, std::strerror(errno),        \
+                   __FILE__, __LINE__);                                        \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+__global__ void fill_u32_kernel(uint32_t* ptr, uint32_t value, size_t n) {
+  const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid >= n)
+    return;
+  ptr[tid] = value + static_cast<uint32_t>(tid);
+}
+
+__global__ void sum_u32_kernel(const uint32_t* ptr, uint64_t* out_sum,
+                               size_t n) {
+  __shared__ uint64_t partial[256];
+  const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  uint64_t v = 0;
+  if (tid < n)
+    v = ptr[tid];
+  partial[threadIdx.x] = v;
+  __syncthreads();
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < static_cast<unsigned>(stride)) {
+      partial[threadIdx.x] += partial[threadIdx.x + stride];
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x == 0)
+    atomicAdd(reinterpret_cast<unsigned long long*>(out_sum), partial[0]);
+}
+
+__global__ void host_visible_write_kernel(uint32_t* mapped_ptr,
+                                          uint32_t marker) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    mapped_ptr[0] = marker;
+    __threadfence_system();
+  }
+}
+
+static uint64_t expected_sum(uint32_t base, size_t n) {
+  return static_cast<uint64_t>(n) * static_cast<uint64_t>(base) +
+         (static_cast<uint64_t>(n) * (n - 1)) / 2;
+}
+
+int main(int argc, char** argv) {
+  bool run_device = true;
+  bool run_host = true;
+  bool saw_mode_flag = false;
+
+  for (int i = 1; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--device") == 0) {
+      run_device = true;
+      if (!saw_mode_flag)
+        run_host = false;
+      saw_mode_flag = true;
+    } else if (std::strcmp(argv[i], "--host") == 0) {
+      run_host = true;
+      if (!saw_mode_flag)
+        run_device = false;
+      saw_mode_flag = true;
+    } else {
+      errno = EINVAL;
+      std::fprintf(stderr, "Usage: %s [--host] [--device] errno=%d (%s)\n",
+                   argv[0], errno, std::strerror(errno));
+      return 64;
+    }
+  }
+
+  if (!run_device && !run_host) {
+    errno = EINVAL;
+    std::fprintf(stderr, "At least one mode must be enabled errno=%d (%s)\n",
+                 errno, std::strerror(errno));
+    return 64;
+  }
+
+  int rc = 0;
+  int device_count = 0;
+  HIP_CHECK(hipGetDeviceCount(&device_count));
+  if (device_count == 0) {
+    errno = ENODEV;
+    std::fprintf(stderr, "No HIP device found errno=%d (%s)\n", errno,
+                 std::strerror(errno));
+    return 1;
+  }
+
+  int dev = 0;
+  HIP_CHECK(hipGetDevice(&dev));
+  char pci_bus_id[32] = {0};
+  HIP_CHECK(hipDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), dev));
+
+  doca_gpu* gpu = nullptr;
+  TEST_DOCA_CHECK(doca_gpu_create(pci_bus_id, &gpu));
+
+  constexpr size_t kCount = 1024;
+  constexpr size_t kBytes = kCount * sizeof(uint32_t);
+  constexpr uint32_t kBase = 0x1234U;
+
+  uint64_t* d_sum = nullptr;
+  HIP_CHECK(hipMalloc(&d_sum, sizeof(uint64_t)));
+  uint64_t got_sum = 0;
+  uint32_t* gpu_only = nullptr;
+  uint32_t* gpu_cpu_gpu = nullptr;
+  uint32_t* gpu_cpu_host = nullptr;
+  uint32_t* cpu_gpu_gpu = nullptr;
+  uint32_t* cpu_gpu_host = nullptr;
+
+  if (run_device) {
+    void* cpu_alias = nullptr;
+    TEST_DOCA_CHECK(doca_gpu_mem_alloc(gpu, kBytes, 0, DOCA_GPU_MEM_TYPE_GPU,
+                                       reinterpret_cast<void**>(&gpu_only),
+                                       &cpu_alias));
+    if (cpu_alias != nullptr) {
+      errno = EINVAL;
+      std::fprintf(stderr,
+                   "Expected null CPU pointer for GPU-only allocation errno=%d "
+                   "(%s) cpu_alias=%p\n",
+                   errno, std::strerror(errno), cpu_alias);
+      rc = 2;
+      goto cleanup;
+    }
+    HIP_CHECK(hipMemset(d_sum, 0, sizeof(uint64_t)));
+    hipLaunchKernelGGL(fill_u32_kernel, dim3((kCount + 255) / 256), dim3(256),
+                       0, 0, gpu_only, kBase, kCount);
+    HIP_CHECK(hipGetLastError());
+    hipLaunchKernelGGL(sum_u32_kernel, dim3((kCount + 255) / 256), dim3(256), 0,
+                       0, gpu_only, d_sum, kCount);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+
+    HIP_CHECK(
+      hipMemcpy(&got_sum, d_sum, sizeof(got_sum), hipMemcpyDeviceToHost));
+    const uint64_t exp_sum = expected_sum(kBase, kCount);
+    if (got_sum != exp_sum) {
+      errno = EIO;
+      std::fprintf(stderr,
+                   "GPU-only alloc mismatch got=%" PRIu64 " expected=%" PRIu64
+                   " errno=%d (%s)\n",
+                   got_sum, exp_sum, errno, std::strerror(errno));
+      rc = 3;
+      goto cleanup;
+    }
+  }
+
+  if (run_host) {
+    TEST_DOCA_CHECK(
+      doca_gpu_mem_alloc(gpu, kBytes, 0, DOCA_GPU_MEM_TYPE_GPU_CPU,
+                         reinterpret_cast<void**>(&gpu_cpu_gpu),
+                         reinterpret_cast<void**>(&gpu_cpu_host)));
+    if (gpu_cpu_gpu == nullptr || gpu_cpu_host == nullptr) {
+      errno = (gpu_cpu_gpu == nullptr && gpu_cpu_host == nullptr) ? ENOMEM
+                                                                  : EFAULT;
+      std::fprintf(stderr,
+                   "GPU_CPU alloc returned null pointers errno=%d (%s) "
+                   "gpu_ptr=%p host_ptr=%p\n",
+                   errno, std::strerror(errno), static_cast<void*>(gpu_cpu_gpu),
+                   static_cast<void*>(gpu_cpu_host));
+      rc = 4;
+      goto cleanup;
+    }
+    for (size_t i = 0; i < kCount; ++i)
+      gpu_cpu_host[i] = static_cast<uint32_t>(i ^ 0x55aaU);
+    HIP_CHECK(hipMemset(d_sum, 0, sizeof(uint64_t)));
+    hipLaunchKernelGGL(sum_u32_kernel, dim3((kCount + 255) / 256), dim3(256), 0,
+                       0, gpu_cpu_gpu, d_sum, kCount);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(
+      hipMemcpy(&got_sum, d_sum, sizeof(got_sum), hipMemcpyDeviceToHost));
+    uint64_t exp_host_sum = 0;
+    for (size_t i = 0; i < kCount; ++i)
+      exp_host_sum += static_cast<uint64_t>(i ^ 0x55aaU);
+    if (got_sum != exp_host_sum) {
+      errno = EIO;
+      std::fprintf(stderr,
+                   "GPU_CPU visibility mismatch got=%" PRIu64
+                   " expected=%" PRIu64 " errno=%d (%s)\n",
+                   got_sum, exp_host_sum, errno, std::strerror(errno));
+      rc = 5;
+      goto cleanup;
+    }
+
+    TEST_DOCA_CHECK(
+      doca_gpu_mem_alloc(gpu, kBytes, 0, DOCA_GPU_MEM_TYPE_CPU_GPU,
+                         reinterpret_cast<void**>(&cpu_gpu_gpu),
+                         reinterpret_cast<void**>(&cpu_gpu_host)));
+    if (cpu_gpu_gpu == nullptr || cpu_gpu_host == nullptr) {
+      errno = (cpu_gpu_gpu == nullptr && cpu_gpu_host == nullptr) ? ENOMEM
+                                                                  : EFAULT;
+      std::fprintf(stderr,
+                   "CPU_GPU alloc returned null pointers errno=%d (%s) "
+                   "gpu_ptr=%p host_ptr=%p\n",
+                   errno, std::strerror(errno), static_cast<void*>(cpu_gpu_gpu),
+                   static_cast<void*>(cpu_gpu_host));
+      rc = 6;
+      goto cleanup;
+    }
+    std::memset(cpu_gpu_host, 0, kBytes);
+    const uint32_t marker = 0xdec0deU;
+    hipLaunchKernelGGL(host_visible_write_kernel, dim3(1), dim3(1), 0, 0,
+                       cpu_gpu_gpu, marker);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    if (cpu_gpu_host[0] != marker) {
+      errno = EIO;
+      std::fprintf(stderr,
+                   "CPU_GPU host visibility mismatch got=0x%x expected=0x%x "
+                   "errno=%d (%s)\n",
+                   cpu_gpu_host[0], marker, errno, std::strerror(errno));
+      rc = 7;
+      goto cleanup;
+    }
+  }
+
+cleanup:
+  if (cpu_gpu_gpu != nullptr)
+    TEST_DOCA_CHECK(doca_gpu_mem_free(gpu, cpu_gpu_gpu));
+  if (gpu_cpu_gpu != nullptr)
+    TEST_DOCA_CHECK(doca_gpu_mem_free(gpu, gpu_cpu_gpu));
+  if (gpu_only != nullptr)
+    TEST_DOCA_CHECK(doca_gpu_mem_free(gpu, gpu_only));
+  if (d_sum != nullptr)
+    HIP_CHECK(hipFree(d_sum));
+  if (gpu != nullptr)
+    TEST_DOCA_CHECK(doca_gpu_destroy(gpu));
+
+  if (rc == 0) {
+    std::printf("PASS: alloc/mapped-memory semantics test mode=%s%s%s\n",
+                run_device ? "device" : "", (run_device && run_host) ? "+" : "",
+                run_host ? "host" : "");
+  }
+  return rc;
+}


### PR DESCRIPTION
…e alloc semantics test

This change closes a critical host-path gap in the hipified GIN foundations by adding the host-side DOCA APIs that NCCL’s GDAKI/GPU-initiated host flow expects to call, while keeping scope intentionally limited to what is semantically valid in rocm-xio today.

What this commit adds:
- New host-side DOCA compatibility headers and implementation for missing symbols used by the NCCL GIN host path:
  - doca_error compatibility definitions
  - doca_verbs host attribute/container APIs and minimal QP/AH surface
  - high-level GPUNetIO host compatibility types
  - host implementation file wiring for DOCA-compatible entry points
- Explicit semantic boundaries for unsupported NIC-backed paths:
  - Functions that require full provider/NIC/verbs integration return DOCA_ERROR_NOT_SUPPORTED instead of pretending parity.
  - This preserves API discoverability while preventing false-positive behavior.
- New low-level allocation/visibility test:
  - doca-gin-alloc-test validates host/device memory allocation semantics and mapped memory visibility relevant to GIN foundations.
  - Covers GPU-only, GPU+CPU-accessible, and CPU+GPU-accessible allocation modes with deterministic value checks.

Build/test integration:
- Adds a dedicated doca-gin-alloc-test CMake executable target.
- Reuses existing low-level gin-ep build conventions (compile flags/includes/linking) with minimal disruption to existing structure.

Validation performed:
- Built and ran:
  - doca-gin-wqe-test
  - doca-gin-doorbell-test
  - doca-gin-alloc-test
- All passed on MI300X environment after dependency preflight.

Why this is important:
- Unblocks host-side semantic bring-up work for hipified GIN without requiring full RCCL+GIN integration.
- Aligns rocm-xio API surface with the subset NCCL host flow actually consumes.
- Improves reviewability by clearly separating implemented semantics from intentional out-of-scope gaps.

Closes AICOMXIO-13 and AICOMXIO-18

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
