### PR TITLE
nvme-ep: Fix kernel stall by updating CQ doorbell after consuming com…

### DIFF
--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -665,11 +665,15 @@ __host__ __device__ static inline bool dataPattern(bool isVerify,
  * Ring NVMe doorbell with support for both PCI MMIO bridge and direct BAR0
  * modes
  *
- * @param sq_tail Submission queue tail value
+ * @param value Doorbell value to write (sq_tail for SQ, cq_head for CQ)
  * @param doorbellParams Doorbell configuration parameters
+ * @param offset_override Optional offset override (defaults to
+ *                        doorbellParams.doorbellOffset). Use this for CQ
+ *                        doorbell which is at SQ offset + doorBellStride.
  */
-__host__ __device__ void ringDoorbell(uint16_t sq_tail,
-                                      const nvmeDoorbellParams& doorbellParams);
+__host__ __device__ void ringDoorbell(uint16_t value,
+                                      const nvmeDoorbellParams& doorbellParams,
+                                      uint32_t offset_override = UINT32_MAX);
 
 /**
  * GPU kernel entry point for NVMe endpoint operations

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -107,17 +107,19 @@ __host__ __device__ cqeType cqePoll(cqeType cqeLast,
   }
 }
 
-__host__ __device__ void ringDoorbell(
-  uint16_t sq_tail, const nvmeDoorbellParams& doorbellParams) {
+__host__ __device__ void ringDoorbell(uint16_t value,
+                                      const nvmeDoorbellParams& doorbellParams,
+                                      uint32_t offset_override) {
+  uint32_t offset = (offset_override != UINT32_MAX)
+                      ? offset_override
+                      : doorbellParams.doorbellOffset;
   if (doorbellParams.usePciMmioBridge &&
       doorbellParams.shadowBufferVirt != nullptr) {
     genPciMmioBridgeCmd(doorbellParams.shadowBufferVirt,
-                        doorbellParams.nvmeTargetBdf, 0,
-                        doorbellParams.doorbellOffset, sq_tail,
+                        doorbellParams.nvmeTargetBdf, 0, offset, value,
                         PCI_MMIO_BRIDGE_CMD_WRITE, 4);
   } else {
-    xio_ep::ringDoorbell(doorbellParams.nvmeBar0Gpu,
-                         doorbellParams.doorbellOffset, sq_tail);
+    xio_ep::ringDoorbell(doorbellParams.nvmeBar0Gpu, offset, value);
   }
 }
 
@@ -304,6 +306,11 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
         config.endTimes[idx] = wall_clock64();
       }
       cq_head = (cq_head + 1) % ioParams.queueSize;
+      // Update CQ doorbell to notify controller we consumed the completion
+      // CQ doorbell is at SQ doorbell offset + doorBellStride (4 bytes)
+      nvme_ep::ringDoorbell(cq_head, doorbellParams,
+                            doorbellParams.doorbellOffset +
+                              nvme_ep::doorBellStride);
       uint8_t phase = NVME_CQE_STATUS_PHASE(cqe_new.status);
       expected_phase = phase ^ 1;
       last_sq_head = new_sq_head;
@@ -415,6 +422,11 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
         completed_count += new_completions;
         last_sq_head = new_sq_head;
         cq_head = (cq_head + 1) % ioParams.queueSize;
+        // Update CQ doorbell to notify controller we consumed the completion
+        // CQ doorbell is at SQ doorbell offset + doorBellStride (4 bytes)
+        nvme_ep::ringDoorbell(cq_head, doorbellParams,
+                              doorbellParams.doorbellOffset +
+                                nvme_ep::doorBellStride);
         uint8_t phase = NVME_CQE_STATUS_PHASE(cqe_new.status);
         expected_phase = phase ^ 1;
         cqe_last = cqe_new;


### PR DESCRIPTION
…pletions

The kernel was stalling because it updated the completion queue head (cq_head) after reading completions but never notified QEMU via the completion queue doorbell. This caused QEMU to think the completion queue was full and stop writing new completions, leading to an infinite wait in cqePoll().

Changes:
- Refactored ringDoorbell() to accept an optional offset_override parameter, allowing it to be used for both SQ and CQ doorbells
- Added CQ doorbell updates after consuming completions in both sequential and batch modes
- CQ doorbell is located at SQ doorbell offset + doorBellStride (4 bytes)

The fix ensures that after each completion is consumed, the kernel notifies QEMU via the CQ doorbell, allowing QEMU to continue writing completions even when the queue wraps around (cq_head goes from 63 to 0).

Files changed: 2
Lines added: 24
Lines removed: 8
