### PR TITLE
nvme-ep/cli: add --infinite and --less-timing options and SIGINT handler

### DIFF
--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -70,6 +70,7 @@ struct nvmeIoParams {
   uint16_t queueSize;    // Queue size in entries
   uint32_t nsid;         // Namespace ID (must be > 0)
   uint32_t lbasPerIo;    // Number of LBAs per I/O operation (default: 1)
+  bool infiniteMode;     // Infinite mode: run forever
 };
 
 /**
@@ -724,6 +725,7 @@ struct nvmeEpConfig {
     int writeIo;   // Number of write I/O operations (negative for sequential)
     uint32_t nsid; // Namespace ID (default: 1, must be > 0)
     uint32_t lbasPerIo; // Number of LBAs per I/O operation (default: 1)
+    bool infiniteMode;  // Infinite mode: run forever.
   } ioParams;
 
   // Data buffer configuration (mirrors nvmeBufferParams POD struct)
@@ -748,7 +750,8 @@ struct nvmeEpConfig {
   nvmeEpConfig()
     : controller(""), queueId(63), queueLength(64), doorbellAddr(0),
       sqBaseAddr(0), cqBaseAddr(0), sqSize(0), cqSize(0),
-      ioParams{"random", 512, 0, 0, 0, 0, 0, 1, 1}, bufferParams{1024 * 1024},
+      ioParams{"random", 512, 0, 0, 0, 0, 0, 1, 1, false},
+      bufferParams{1024 * 1024},
       doorbellParams{false, 0x0020, 0x0030, nullptr, nullptr} {
   }
 };

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -49,8 +49,21 @@ __host__ __device__ cqeType cqeRead(volatile cqeType* cqeAddress) {
   return result;
 }
 
-__host__ __device__ void sqeWrite(sqeType sqeData, sqeType* sqeAddress) {
-  *sqeAddress = sqeData;
+__host__ __device__ void sqeWrite(sqeType sqeData,
+                                  volatile sqeType* sqeAddress) {
+  //*sqeAddress = sqeData;
+
+  // Write byte-by-byte to volatile pointer to ensure all writes are visible
+  // This matches sqeRead's approach and ensures proper volatile semantics
+  const uint8_t* src = reinterpret_cast<const uint8_t*>(&sqeData);
+  volatile uint8_t* dst = reinterpret_cast<volatile uint8_t*>(sqeAddress);
+  for (size_t i = 0; i < sizeof(sqeType); i++) {
+    dst[i] = src[i];
+  }
+
+#ifdef __HIP_DEVICE_COMPILE__
+  __threadfence_system();
+#endif // __HIP_DEVICE_COMPILE__
 }
 
 __host__ __device__ void cqeWrite(cqeType cqeData, cqeType* cqeAddress) {
@@ -156,6 +169,47 @@ static __host__ __device__ uint64_t getRandomLba(unsigned op_index,
   }
 }
 
+/**
+ * Update timing statistics atomically for less-timing mode
+ * Thread-safe function to track min, max, sum, and count
+ */
+__device__ void updateTimingStats(XioTimingStats* stats,
+                                  unsigned long long int duration) {
+  if (stats == nullptr) {
+    return;
+  }
+
+  // Atomically update count and sum
+  atomicAdd((unsigned long long int*)&stats->count, 1ULL);
+  atomicAdd((unsigned long long int*)&stats->sumDuration, duration);
+
+  // Atomically update min (compare-and-swap loop)
+  unsigned long long int oldMin = stats->minDuration;
+  while (duration < oldMin) {
+    unsigned long long int expected = oldMin;
+    unsigned long long int desired = duration;
+    unsigned long long int* addr = (unsigned long long int*)&stats->minDuration;
+    unsigned long long int result = atomicCAS(addr, expected, desired);
+    if (result == expected) {
+      break; // Successfully updated min
+    }
+    oldMin = result; // Retry with new value
+  }
+
+  // Atomically update max (compare-and-swap loop)
+  unsigned long long int oldMax = stats->maxDuration;
+  while (duration > oldMax) {
+    unsigned long long int expected = oldMax;
+    unsigned long long int desired = duration;
+    unsigned long long int* addr = (unsigned long long int*)&stats->maxDuration;
+    unsigned long long int result = atomicCAS(addr, expected, desired);
+    if (result == expected) {
+      break; // Successfully updated max
+    }
+    oldMax = result; // Retry with new value
+  }
+}
+
 __device__ void driveEndpoint(const XioEndpointConfig& config,
                               const nvmeIoParams& ioParams,
                               const nvmeDoorbellParams& doorbellParams,
@@ -164,13 +218,27 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
   sqeType* sqeAddr = static_cast<sqeType*>(config.submissionQueue);
   cqeType* cqeAddr = static_cast<cqeType*>(config.completionQueue);
 
-  const bool sequential_mode = (ioParams.readIo < 0 || ioParams.writeIo < 0);
+  const bool sequential_mode = (ioParams.readIo < 0 || ioParams.writeIo < 0 ||
+                                ioParams.infiniteMode);
   bool sequential_is_read = false;
   unsigned num_ops;
   unsigned num_read_ops = 0;
   unsigned num_write_ops = 0;
   if (sequential_mode) {
-    if (ioParams.readIo < 0 && ioParams.writeIo < 0) {
+    if (ioParams.infiniteMode) {
+      // Infinite mode: determine operation type from which is negative
+      if (ioParams.readIo < 0) {
+        sequential_is_read = true;
+        num_read_ops = 0;
+        num_write_ops = 0;
+        num_ops = 0;
+      } else {
+        sequential_is_read = false;
+        num_read_ops = 0;
+        num_write_ops = 0;
+        num_ops = 0;
+      }
+    } else if (ioParams.readIo < 0 && ioParams.writeIo < 0) {
       num_read_ops = -ioParams.readIo;
       num_write_ops = -ioParams.writeIo;
       num_ops = num_read_ops + num_write_ops;
@@ -221,24 +289,28 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
   // Track submission queue tail
   uint16_t sq_tail = 0;
   uint16_t last_sq_head = 0;
+  // Track last CQE for polling (update after each completion)
+  nvme_ep::cqeType cqe_last = initial_cqe_data;
 
   if (sequential_mode) {
-    for (unsigned i = 0; i < num_ops; i++) {
-      uint16_t cmd_id = (uint16_t)(i + 1);
+    unsigned i = 0;
+    while ((ioParams.infiniteMode || i < num_ops) &&
+           (config.stopRequested == nullptr || !*config.stopRequested)) {
+      // Wrap command ID to avoid overflow (NVMe command IDs are 16-bit)
+      // Use modulo 65535 + 1 to avoid cmd_id = 0
+      uint16_t cmd_id = (uint16_t)((i % 65535) + 1);
 
       bool is_read_op;
-      unsigned op_index;
-      if (num_read_ops > 0 && num_write_ops > 0) {
+      if (ioParams.infiniteMode) {
+        is_read_op = sequential_is_read;
+      } else if (num_read_ops > 0 && num_write_ops > 0) {
         if (i < num_write_ops) {
           is_read_op = false;
-          op_index = i;
         } else {
           is_read_op = true;
-          op_index = i - num_write_ops;
         }
       } else {
         is_read_op = sequential_is_read;
-        op_index = i;
       }
 
       // Calculate LBA
@@ -257,20 +329,24 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
         // For sequential reads, reuse the same buffer for every I/O
         uint64_t buffer_offset = 0;
         if (buffer_offset + transfer_size <= bufferParams.bufferSize) {
-          uint64_t buffer_addr =
-            bufferParams.readBufferDma
-              ? (bufferParams.readBufferDma + buffer_offset)
-              : (uint64_t)(bufferParams.readBuffer + buffer_offset);
+          // Must use DMA address - virtual address won't work for NVMe
+          if (bufferParams.readBufferDma == 0) {
+            __builtin_trap(); // DMA address must be set
+          }
+          uint64_t buffer_addr = bufferParams.readBufferDma + buffer_offset;
           calculatePrps(buffer_addr, transfer_size, sqe);
           prp_valid = true;
         }
       } else if (!is_read_op && has_write_buffer) {
-        uint64_t buffer_offset = op_index * transfer_size;
+        // For sequential writes, reuse the same buffer for every I/O
+        // (same as reads) to support infinite mode
+        uint64_t buffer_offset = 0;
         if (buffer_offset + transfer_size <= bufferParams.bufferSize) {
-          uint64_t buffer_addr =
-            bufferParams.writeBufferDma
-              ? (bufferParams.writeBufferDma + buffer_offset)
-              : (uint64_t)(bufferParams.writeBuffer + buffer_offset);
+          // Must use DMA address - virtual address won't work for NVMe
+          if (bufferParams.writeBufferDma == 0) {
+            __builtin_trap(); // DMA address must be set
+          }
+          uint64_t buffer_addr = bufferParams.writeBufferDma + buffer_offset;
           calculatePrps(buffer_addr, transfer_size, sqe);
           prp_valid = true;
         }
@@ -282,13 +358,35 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
       }
       sqeSetup(sqe, lba, blocks);
 
-      // Record start time
-      if (config.startTimes != nullptr) {
+      // Record start time (full timing mode) or start tracking (less-timing)
+      // Note: In infinite mode, we only use timingStats (not startTimes array)
+      unsigned long long int startTime = 0;
+      if (!ioParams.infiniteMode && config.startTimes != nullptr) {
         config.startTimes[i] = wall_clock64();
+      } else if (config.timingStats != nullptr) {
+        startTime = wall_clock64();
       }
 
-      // Write SQE and increment sq_tail
-      nvme_ep::sqeWrite(sqeLocal, &sqeAddr[sq_tail]);
+      // Write SQE to queue slot
+      // sqeWrite includes memory fence for device code to ensure write
+      // completes
+      volatile sqeType* sqe_slot = &sqeAddr[sq_tail];
+      nvme_ep::sqeWrite(sqeLocal, sqe_slot);
+
+      // Additional memory fence after write to ensure SQE is fully visible
+      // before incrementing tail and ringing doorbell
+      __threadfence_system();
+
+      // Verify critical fields were written correctly (read-back check)
+      // This helps catch cases where the write didn't complete or was corrupted
+      volatile sqeType* verify_slot = sqe_slot;
+      if (verify_slot->opcode != sqeLocal.opcode ||
+          verify_slot->command_id != sqeLocal.command_id) {
+        // SQE write verification failed - trap to prevent corrupted command
+        __builtin_trap();
+      }
+
+      // Increment sq_tail after SQE is fully written and visible
       sq_tail = (sq_tail + 1) % ioParams.queueSize;
 
       // Ring doorbell
@@ -297,13 +395,28 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
       // Wait for completion using cqePoll
       volatile cqeType* cqe_entry = &cqeAddr[cq_head];
       uint16_t new_sq_head = 0;
-      nvme_ep::cqeType cqe_new = nvme_ep::cqePoll(initial_cqe_data, cqe_entry,
+      nvme_ep::cqeType cqe_new = nvme_ep::cqePoll(cqe_last, cqe_entry,
                                                   last_sq_head, &new_sq_head);
 
+      // Check completion status
+      if (!nvme_ep::cqeOk(&cqe_new)) {
+        __builtin_trap();
+      }
+
+      // Update last CQE for next iteration
+      cqe_last = cqe_new;
+
       // Update tracking variables
-      if (config.endTimes != nullptr && cmd_id >= 1 && cmd_id <= num_ops) {
+      if (!ioParams.infiniteMode && config.endTimes != nullptr && cmd_id >= 1 &&
+          cmd_id <= num_ops) {
         unsigned idx = cmd_id - 1;
         config.endTimes[idx] = wall_clock64();
+      } else if (config.timingStats != nullptr && startTime > 0) {
+        unsigned long long int endTime = wall_clock64();
+        if (endTime > startTime) {
+          unsigned long long int duration = endTime - startTime;
+          updateTimingStats(config.timingStats, duration);
+        }
       }
       cq_head = (cq_head + 1) % ioParams.queueSize;
       // Update CQ doorbell to notify controller we consumed the completion
@@ -314,6 +427,7 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
       uint8_t phase = NVME_CQE_STATUS_PHASE(cqe_new.status);
       expected_phase = phase ^ 1;
       last_sq_head = new_sq_head;
+      i++; // Increment loop counter
     }
   } else {
     // Batch mode: enqueue some number of SQEs, then ring doorbell,
@@ -322,9 +436,16 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
     sqeType sqeLocal = {};
     sqeType* sqe = &sqeLocal;
 
+    // For less-timing mode in batch, we need to store start times locally
+    // Allocate on stack (batch size is typically small, max iterations)
+    unsigned long long int batchStartTimes[256]; // Max 256 ops per batch
+    bool useBatchTiming = (config.timingStats != nullptr);
+
     // Issue a batch of commands
     for (unsigned i = 0; i < num_ops; i++) {
-      uint16_t cmd_id = (uint16_t)(i + 1);
+      // Wrap command ID to avoid overflow (NVMe command IDs are 16-bit)
+      // Use modulo 65535 + 1 to avoid cmd_id = 0 (which may be reserved)
+      uint16_t cmd_id = (uint16_t)((i % 65535) + 1);
 
       // Calculate LBA
       uint64_t lba = getRandomLba(i, cmd_id, blocks, ioParams);
@@ -381,9 +502,13 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
 
       sqeSetup(sqe, lba, blocks);
 
-      // Record start time
+      // Record start time (full timing mode) or start tracking (less-timing)
+      unsigned long long int startTime = 0;
       if (config.startTimes != nullptr) {
         config.startTimes[i] = wall_clock64();
+      } else if (useBatchTiming && i < 256) {
+        startTime = wall_clock64();
+        batchStartTimes[i] = startTime;
       }
 
       // Write SQE
@@ -409,13 +534,27 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
 
       if (new_sq_head > last_sq_head && new_sq_head <= num_ops) {
         uint16_t new_completions = new_sq_head - last_sq_head;
+        uint64_t end_time = wall_clock64();
         if (config.endTimes != nullptr) {
-          uint64_t end_time = wall_clock64();
           for (uint16_t i = 0; i < new_completions; i++) {
             uint16_t completed_cmd_id = last_sq_head + 1 + i;
             if (completed_cmd_id >= 1 && completed_cmd_id <= num_ops) {
               unsigned idx = completed_cmd_id - 1;
               config.endTimes[idx] = end_time;
+            }
+          }
+        } else if (useBatchTiming) {
+          // Update timing stats for each completed command
+          for (uint16_t i = 0; i < new_completions; i++) {
+            uint16_t completed_cmd_id = last_sq_head + 1 + i;
+            if (completed_cmd_id >= 1 && completed_cmd_id <= num_ops) {
+              unsigned idx = completed_cmd_id - 1;
+              if (idx < 256 && batchStartTimes[idx] > 0 &&
+                  end_time > batchStartTimes[idx]) {
+                unsigned long long int duration = end_time -
+                                                  batchStartTimes[idx];
+                updateTimingStats(config.timingStats, duration);
+              }
             }
           }
         }
@@ -564,6 +703,12 @@ __host__ void registerCliOptions(CLI::App& app, nvme_ep::nvmeEpConfig* config) {
       "time waiting for completion before issuing the next.")
     ->default_val(0)
     ->group(nvme_group);
+  app
+    .add_flag("--infinite", config->ioParams.infiniteMode,
+              "Infinite mode: run forever in sequential mode. Requires "
+              "exactly one of --read-io or --write-io to be negative, "
+              "the other must be 0.")
+    ->group(nvme_group);
 }
 
 /**
@@ -582,10 +727,29 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
     return "Access pattern must be 'sequential' or 'random'";
   }
 
-  // Validate that at least one I/O count is != 0)
-  if (config->ioParams.readIo == 0 && config->ioParams.writeIo == 0) {
-    return "At least one of --read-io or --write-io must be specified with "
-           "value != 0 (use negative values for sequential mode)";
+  // Validate infinite mode requirements
+  if (config->ioParams.infiniteMode) {
+    bool read_negative = (config->ioParams.readIo < 0);
+    bool write_negative = (config->ioParams.writeIo < 0);
+    if (read_negative && write_negative) {
+      return "--infinite mode requires exactly one of --read-io or "
+             "--write-io to be negative, not both";
+    }
+    if (!read_negative && !write_negative) {
+      return "--infinite mode requires exactly one of --read-io or "
+             "--write-io to be negative";
+    }
+    if ((read_negative && config->ioParams.writeIo != 0) ||
+        (write_negative && config->ioParams.readIo != 0)) {
+      return "--infinite mode requires the non-negative --read-io or "
+             "--write-io to be exactly 0";
+    }
+  } else {
+    // Validate that at least one I/O count is != 0)
+    if (config->ioParams.readIo == 0 && config->ioParams.writeIo == 0) {
+      return "At least one of --read-io or --write-io must be specified with "
+             "value != 0 (use negative values for sequential mode)";
+    }
   }
 
   // Validate that --controller is specified
@@ -869,6 +1033,7 @@ __host__ hipError_t run(XioEndpointConfig* config) {
   ioParams.nsid = nvmeConfig->ioParams.nsid;
   ioParams.lbasPerIo = nvmeConfig->ioParams.lbasPerIo;
   ioParams.queueSize = queue_size;
+  ioParams.infiniteMode = nvmeConfig->ioParams.infiniteMode;
 
   nvme_ep::nvmeDoorbellParams doorbellParams;
   doorbellParams.doorbellOffset = doorbell_offset;

--- a/src/endpoints/test-ep/test-ep.hip
+++ b/src/endpoints/test-ep/test-ep.hip
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <iostream>
@@ -328,10 +330,80 @@ std::vector<std::thread> launchCpuThreads(void* hostSqeAddr, void* hostCqeAddr,
   return cpuThreadHandles;
 }
 
+// Helper function to update timing stats (shared between GPU and CPU code)
+__device__ __host__ void updateTimingStats(XioTimingStats* stats,
+                                           unsigned long long int duration) {
+  if (stats == nullptr) {
+    return;
+  }
+
+#ifdef __HIP_DEVICE_COMPILE__
+  // GPU version: use atomics
+  atomicAdd((unsigned long long int*)&stats->count, 1ULL);
+  atomicAdd((unsigned long long int*)&stats->sumDuration, duration);
+
+  // Atomically update min
+  unsigned long long int oldMin = stats->minDuration;
+  while (duration < oldMin) {
+    unsigned long long int expected = oldMin;
+    unsigned long long int desired = duration;
+    unsigned long long int* addr = (unsigned long long int*)&stats->minDuration;
+    unsigned long long int result = atomicCAS(addr, expected, desired);
+    if (result == expected) {
+      break;
+    }
+    oldMin = result;
+  }
+
+  // Atomically update max
+  unsigned long long int oldMax = stats->maxDuration;
+  while (duration > oldMax) {
+    unsigned long long int expected = oldMax;
+    unsigned long long int desired = duration;
+    unsigned long long int* addr = (unsigned long long int*)&stats->maxDuration;
+    unsigned long long int result = atomicCAS(addr, expected, desired);
+    if (result == expected) {
+      break;
+    }
+    oldMax = result;
+  }
+#else
+  // CPU version: use std::atomic_ullong (atomic<unsigned long long>)
+  // Note: atomic header is included later in the file, but we need it here
+  // Use reinterpret_cast to treat the memory as atomic
+  std::atomic_ullong* countPtr = reinterpret_cast<std::atomic_ullong*>(
+    &stats->count);
+  std::atomic_ullong* sumPtr = reinterpret_cast<std::atomic_ullong*>(
+    &stats->sumDuration);
+  std::atomic_ullong* minPtr = reinterpret_cast<std::atomic_ullong*>(
+    &stats->minDuration);
+  std::atomic_ullong* maxPtr = reinterpret_cast<std::atomic_ullong*>(
+    &stats->maxDuration);
+
+  countPtr->fetch_add(1);
+  sumPtr->fetch_add(duration);
+
+  // Update min
+  unsigned long long int oldMin = minPtr->load();
+  while (duration < oldMin &&
+         !minPtr->compare_exchange_weak(oldMin, duration)) {
+    // Retry
+  }
+
+  // Update max
+  unsigned long long int oldMax = maxPtr->load();
+  while (duration > oldMax &&
+         !maxPtr->compare_exchange_weak(oldMax, duration)) {
+    // Retry
+  }
+#endif
+}
+
 // Endpoint kernel - receives pointers directly like simple-test
 __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
                                 unsigned long long int* startTimes,
                                 unsigned long long int* endTimes,
+                                XioTimingStats* timingStats,
                                 unsigned iterations, unsigned numThreads,
                                 long long delayNs, unsigned doorbell,
                                 uint32_t* doorbellAddr, unsigned queueSize) {
@@ -375,8 +447,11 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
     for (unsigned i = 0; i < iterations; ++i) {
       // Record start time for this iteration (when SQE is posted)
       unsigned long long pollStartTime = wall_clock64();
+      unsigned long long startTime = 0;
       if (myStartTimes != nullptr) {
         myStartTimes[i] = pollStartTime;
+      } else if (timingStats != nullptr) {
+        startTime = pollStartTime;
       }
 
       // Prepare message to CPU
@@ -447,8 +522,13 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
                 (cqeCpuTime != (lastCpuTime & 0xFFFFFFFFULL) ||
                  lastCpuTime == 0)) {
               // Record GPU time immediately when valid CQE is detected
+              unsigned long long endTime = wall_clock64();
               if (myEndTimes != nullptr) {
-                myEndTimes[i] = wall_clock64();
+                myEndTimes[i] = endTime;
+              } else if (timingStats != nullptr && startTime > 0 &&
+                         endTime > startTime) {
+                unsigned long long int duration = endTime - startTime;
+                updateTimingStats(timingStats, duration);
               }
               break;
             }
@@ -465,8 +545,11 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
     for (unsigned i = 0; i < iterations; ++i) {
       // Record start time for this iteration
       unsigned long long pollStartTime = wall_clock64();
+      unsigned long long startTime = 0;
       if (myStartTimes != nullptr) {
         myStartTimes[i] = pollStartTime;
+      } else if (timingStats != nullptr) {
+        startTime = pollStartTime;
       }
 
       // Prepare message to CPU (matches simple-test)
@@ -525,8 +608,13 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
 
       // Record GPU time when CPU response is received (use GPU time for both
       // start and end)
+      unsigned long long endTime = wall_clock64();
       if (myEndTimes != nullptr) {
-        myEndTimes[i] = wall_clock64();
+        myEndTimes[i] = endTime;
+      } else if (timingStats != nullptr && startTime > 0 &&
+                 endTime > startTime) {
+        unsigned long long int duration = endTime - startTime;
+        updateTimingStats(timingStats, duration);
       }
     }
   }
@@ -537,16 +625,16 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
   }
 }
 
-#include <atomic>
 #include <iostream>
 
 // CPU emulation of endpoint kernel - runs kernel logic on CPU threads
 // This allows testing without a GPU
 static void endpoint_kernel_cpu_emulate(
   sqeType* sqePtr, cqeType* cqePtr, unsigned long long int* startTimes,
-  unsigned long long int* endTimes, unsigned iterations, unsigned numThreads,
-  long long delayNs, unsigned doorbell, uint32_t* doorbellAddr,
-  unsigned queueSize, unsigned threadId) {
+  unsigned long long int* endTimes, XioTimingStats* timingStats,
+  unsigned iterations, unsigned numThreads, long long delayNs,
+  unsigned doorbell, uint32_t* doorbellAddr, unsigned queueSize,
+  unsigned threadId) {
   // Use per-thread buffers if multi-threaded (non-doorbell mode)
   bool doorbellMode = (doorbell > 0);
   sqeType* mySqe = (numThreads > 1 && !doorbellMode) ? &sqePtr[threadId]
@@ -589,8 +677,11 @@ static void endpoint_kernel_cpu_emulate(
       // Record start time for this iteration (when SQE is posted)
       // Use CPU time instead of GPU wall clock in emulation mode
       uint64_t pollStartTime = getCpuTime();
+      uint64_t startTime = 0;
       if (myStartTimes != nullptr) {
         myStartTimes[i] = pollStartTime;
+      } else if (timingStats != nullptr) {
+        startTime = pollStartTime;
       }
 
       // Prepare message to CPU
@@ -684,8 +775,13 @@ static void endpoint_kernel_cpu_emulate(
                 (cqeCpuTime != (lastCpuTime & 0xFFFFFFFFULL) ||
                  lastCpuTime == 0)) {
               // Record time immediately when valid CQE is detected
+              uint64_t endTime = getCpuTime();
               if (myEndTimes != nullptr) {
-                myEndTimes[i] = getCpuTime();
+                myEndTimes[i] = endTime;
+              } else if (timingStats != nullptr && startTime > 0 &&
+                         endTime > startTime) {
+                unsigned long long int duration = endTime - startTime;
+                updateTimingStats(timingStats, duration);
               }
               break;
             }
@@ -707,8 +803,11 @@ static void endpoint_kernel_cpu_emulate(
     for (unsigned i = 0; i < iterations; ++i) {
       // Record start time for this iteration
       uint64_t pollStartTime = getCpuTime();
+      uint64_t startTime = 0;
       if (myStartTimes != nullptr) {
         myStartTimes[i] = pollStartTime;
+      } else if (timingStats != nullptr) {
+        startTime = pollStartTime;
       }
 
       // Prepare message to CPU
@@ -756,8 +855,13 @@ static void endpoint_kernel_cpu_emulate(
       lastCpuTime = currentResponse.cpuTime;
 
       // Record time when CPU response is received
+      uint64_t endTime = getCpuTime();
       if (myEndTimes != nullptr) {
-        myEndTimes[i] = getCpuTime();
+        myEndTimes[i] = endTime;
+      } else if (timingStats != nullptr && startTime > 0 &&
+                 endTime > startTime) {
+        unsigned long long int duration = endTime - startTime;
+        updateTimingStats(timingStats, duration);
       }
     }
   }
@@ -854,9 +958,10 @@ hipError_t test_ep_run(XioEndpointConfig* config) {
     for (unsigned t = 0; t < config->numThreads; ++t) {
       gpuEmulationThreads.emplace_back(endpoint_kernel_cpu_emulate, sqePtr,
                                        cqePtr, config->startTimes,
-                                       config->endTimes, config->iterations,
-                                       config->numThreads, config->delayNs,
-                                       doorbell, doorbellPtr, queueSize, t);
+                                       config->endTimes, config->timingStats,
+                                       config->iterations, config->numThreads,
+                                       config->delayNs, doorbell, doorbellPtr,
+                                       queueSize, t);
     }
 
     // Wait for all emulation threads to complete
@@ -868,8 +973,9 @@ hipError_t test_ep_run(XioEndpointConfig* config) {
     uint32_t* doorbellPtr = static_cast<uint32_t*>(doorbellAddr);
     hipLaunchKernelGGL(endpoint_kernel, dim3(1), dim3(config->numThreads), 0, 0,
                        sqePtr, cqePtr, config->startTimes, config->endTimes,
-                       config->iterations, config->numThreads, config->delayNs,
-                       doorbell, doorbellPtr, queueSize);
+                       config->timingStats, config->iterations,
+                       config->numThreads, config->delayNs, doorbell,
+                       doorbellPtr, queueSize);
 
     // Check for kernel launch errors
     err = hipGetLastError();

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -6,6 +6,7 @@
 #ifndef XIO_H
 #define XIO_H
 
+#include <climits>
 #include <cstdint>
 #include <iostream>
 #include <memory>
@@ -40,6 +41,18 @@ class App;
   }
 
 /**
+ * Timing statistics structure for less-timing mode
+ * Tracks min, max, sum, and count of IO completion times
+ */
+struct XioTimingStats {
+  unsigned long long int minDuration = ULLONG_MAX; // Minimum duration in GPU
+                                                   // ticks
+  unsigned long long int maxDuration = 0; // Maximum duration in GPU ticks
+  unsigned long long int sumDuration = 0; // Sum of durations in GPU ticks
+  unsigned long long int count = 0;       // Number of IO operations
+};
+
+/**
  * Base configuration structure for all endpoints
  *
  * Contains common testing parameters that apply to all endpoints.
@@ -65,12 +78,22 @@ struct XioEndpointConfig {
   bool pciMmioBridge = false; // Use PCI MMIO bridge for doorbell routing
 
   // Timing arrays (optional, can be nullptr)
+  // Used when full timing is enabled (default mode)
   unsigned long long int* startTimes = nullptr;
   unsigned long long int* endTimes = nullptr;
+
+  // Timing statistics (optional, can be nullptr)
+  // Used when less-timing mode is enabled
+  XioTimingStats* timingStats = nullptr;
 
   // Queue pointers (host-accessible buffers)
   void* submissionQueue = nullptr; // Host-accessible SQE buffer
   void* completionQueue = nullptr; // Host-accessible CQE buffer
+
+  // Stop flag for graceful shutdown (SIGINT handling)
+  // Allocated with hipHostMalloc to be GPU-accessible
+  // Set to true by signal handler to request kernel stop
+  volatile bool* stopRequested = nullptr;
 
   // Endpoint-specific configuration (opaque pointer)
   // Endpoints cast this to their specific config type

--- a/src/tester/xio-tester.cpp
+++ b/src/tester/xio-tester.cpp
@@ -4,7 +4,10 @@
  */
 
 #include <algorithm>
+#include <cerrno>
+#include <climits>
 #include <cmath>
+#include <csignal>
 #include <cstring>
 #include <ctime>
 #include <iomanip>
@@ -17,6 +20,18 @@
 #include <CLI/CLI.hpp>
 
 #include "xio.h"
+
+// Static pointer to config for signal handler access
+static XioEndpointConfig* g_configForSignalHandler = nullptr;
+
+// SIGINT handler - sets stop flag to request graceful shutdown
+static void sigintHandler(int sig) {
+  (void)sig; // Suppress unused parameter warning
+  if (g_configForSignalHandler != nullptr &&
+      g_configForSignalHandler->stopRequested != nullptr) {
+    *g_configForSignalHandler->stopRequested = true;
+  }
+}
 
 int main(int argc, char** argv) {
   CLI::App app{"xio-tester: A test harness for rocm-xio."};
@@ -64,6 +79,13 @@ int main(int argc, char** argv) {
 
   bool printHistogram = false;
   app.add_flag("--histogram", printHistogram, "Generate performance histogram")
+    ->group("Common Options");
+
+  bool lessTiming = false;
+  app
+    .add_flag("--less-timing", lessTiming,
+              "Use lightweight timing mode (track min/max/mean only, "
+              "useful for large iterations)")
     ->group("Common Options");
 
   app
@@ -260,8 +282,10 @@ int main(int argc, char** argv) {
     totalSqeSize = 1;
   if (totalCqeSize == 0)
     totalCqeSize = 1;
-  size_t totalTimingSize = baseConfig.iterations * baseConfig.numThreads *
-                           sizeof(unsigned long long int);
+  size_t totalTimingSize = lessTiming
+                             ? 0
+                             : (baseConfig.iterations * baseConfig.numThreads *
+                                sizeof(unsigned long long int));
 
   // Allocate queues based on memory mode
   // Bit 0: GPU write location (SQE) - 0=host, 1=device
@@ -285,38 +309,112 @@ int main(int argc, char** argv) {
   }
 
   // Timing buffers are always host-accessible
-  // Try HIP first, but fall back to malloc if HIP is not available (emulate
-  // mode)
-  hipError_t hipErr1 = hipHostMalloc((void**)&hostStartTime, totalTimingSize);
-  if (hipErr1 != hipSuccess) {
-    // HIP not available (e.g., emulate mode), use regular malloc
-    void* ptr = malloc(totalTimingSize);
-    if (ptr == nullptr) {
-      std::cerr << "Error: Failed to allocate start time buffer" << std::endl;
-      return EXIT_FAILURE;
+  // Allocate full timing arrays if timing is enabled (default mode)
+  // Allocate lightweight stats structure if less-timing mode is enabled
+  XioTimingStats* timingStats = nullptr;
+  if (!lessTiming && totalTimingSize > 0) {
+    // Try HIP first, but fall back to malloc if HIP is not available (emulate
+    // mode)
+    hipError_t hipErr1 = hipHostMalloc((void**)&hostStartTime, totalTimingSize);
+    if (hipErr1 != hipSuccess) {
+      // HIP not available (e.g., emulate mode), use regular malloc
+      void* ptr = malloc(totalTimingSize);
+      if (ptr == nullptr) {
+        std::cerr << "Error: Failed to allocate start time buffer" << std::endl;
+        return EXIT_FAILURE;
+      }
+      hostStartTime = static_cast<unsigned long long int*>(ptr);
     }
-    hostStartTime = static_cast<unsigned long long int*>(ptr);
-  }
-  hipError_t hipErr2 = hipHostMalloc((void**)&hostEndTime, totalTimingSize);
-  if (hipErr2 != hipSuccess) {
-    // HIP not available (e.g., emulate mode), use regular malloc
-    void* ptr = malloc(totalTimingSize);
-    if (ptr == nullptr) {
-      std::cerr << "Error: Failed to allocate end time buffer" << std::endl;
-      return EXIT_FAILURE;
+    hipError_t hipErr2 = hipHostMalloc((void**)&hostEndTime, totalTimingSize);
+    if (hipErr2 != hipSuccess) {
+      // HIP not available (e.g., emulate mode), use regular malloc
+      void* ptr = malloc(totalTimingSize);
+      if (ptr == nullptr) {
+        std::cerr << "Error: Failed to allocate end time buffer" << std::endl;
+        return EXIT_FAILURE;
+      }
+      hostEndTime = static_cast<unsigned long long int*>(ptr);
     }
-    hostEndTime = static_cast<unsigned long long int*>(ptr);
+
+    // Initialize timing buffers to zero
+    memset(hostStartTime, 0, totalTimingSize);
+    memset(hostEndTime, 0, totalTimingSize);
+  } else if (lessTiming) {
+    // Allocate lightweight timing stats structure for less-timing mode
+    hipError_t hipErr = hipHostMalloc((void**)&timingStats,
+                                      sizeof(XioTimingStats));
+    if (hipErr != hipSuccess) {
+      // HIP not available (e.g., emulate mode), use regular malloc
+      void* ptr = malloc(sizeof(XioTimingStats));
+      if (ptr == nullptr) {
+        std::cerr << "Error: Failed to allocate timing stats buffer"
+                  << std::endl;
+        return EXIT_FAILURE;
+      }
+      timingStats = static_cast<XioTimingStats*>(ptr);
+    }
+    // Initialize timing stats
+    timingStats->minDuration = ULLONG_MAX;
+    timingStats->maxDuration = 0;
+    timingStats->sumDuration = 0;
+    timingStats->count = 0;
   }
 
-  // Initialize timing buffers to zero
-  memset(hostStartTime, 0, totalTimingSize);
-  memset(hostEndTime, 0, totalTimingSize);
+  // Allocate stop flag for SIGINT handling (GPU-accessible)
+  volatile bool* stopRequestedFlag = nullptr;
+  hipError_t stopFlagErr = hipHostMalloc((void**)&stopRequestedFlag,
+                                         sizeof(bool), hipHostMallocMapped);
+  if (stopFlagErr != hipSuccess) {
+    // Fallback to regular malloc if HIP not available (emulate mode)
+    stopRequestedFlag = static_cast<volatile bool*>(malloc(sizeof(bool)));
+    if (stopRequestedFlag == nullptr) {
+      std::cerr << "Error: Failed to allocate stop flag" << std::endl;
+      // Cleanup and exit
+      if (!lessTiming && hostStartTime != nullptr) {
+        hipError_t hipErrFree1 = hipHostFree(hostStartTime);
+        if (hipErrFree1 != hipSuccess) {
+          free(hostStartTime);
+        }
+      }
+      if (!lessTiming && hostEndTime != nullptr) {
+        hipError_t hipErrFree2 = hipHostFree(hostEndTime);
+        if (hipErrFree2 != hipSuccess) {
+          free(hostEndTime);
+        }
+      }
+      if (lessTiming && timingStats != nullptr) {
+        hipError_t hipErrFree3 = hipHostFree(timingStats);
+        if (hipErrFree3 != hipSuccess) {
+          free(timingStats);
+        }
+      }
+      xioFreeQueue(hostSqeAddr, sqIsDevice, "submission queue");
+      xioFreeQueue(hostCqeAddr, cqIsDevice, "completion queue");
+      return EXIT_FAILURE;
+    }
+  }
+  *stopRequestedFlag = false;
 
   // Assign buffers to our config structure
   baseConfig.startTimes = hostStartTime;
   baseConfig.endTimes = hostEndTime;
+  baseConfig.timingStats = timingStats;
   baseConfig.submissionQueue = hostSqeAddr;
   baseConfig.completionQueue = hostCqeAddr;
+  baseConfig.stopRequested = stopRequestedFlag;
+
+  // Install SIGINT handler for graceful shutdown
+  struct sigaction sa;
+  sa.sa_handler = sigintHandler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  if (sigaction(SIGINT, &sa, nullptr) != 0) {
+    std::cerr << "Warning: Failed to install SIGINT handler: "
+              << strerror(errno) << std::endl;
+  }
+
+  // Store config pointer for signal handler
+  g_configForSignalHandler = &baseConfig;
 
   // Run endpoint test
   hipError_t err = endpoint->run(&baseConfig);
@@ -325,20 +423,46 @@ int main(int argc, char** argv) {
               << " (error code: " << err << ")" << std::endl;
     xioFreeQueue(hostSqeAddr, sqIsDevice, "submission queue");
     xioFreeQueue(hostCqeAddr, cqIsDevice, "completion queue");
-    // Free host memory using HIP or regular free
-    hipError_t hipErrFree1 = hipHostFree(hostStartTime);
-    if (hipErrFree1 != hipSuccess) {
-      free(hostStartTime);
+    // Free host memory using HIP or regular free (only if allocated)
+    if (!lessTiming && hostStartTime != nullptr) {
+      hipError_t hipErrFree1 = hipHostFree(hostStartTime);
+      if (hipErrFree1 != hipSuccess) {
+        free(hostStartTime);
+      }
     }
-    hipError_t hipErrFree2 = hipHostFree(hostEndTime);
-    if (hipErrFree2 != hipSuccess) {
-      free(hostEndTime);
+    if (!lessTiming && hostEndTime != nullptr) {
+      hipError_t hipErrFree2 = hipHostFree(hostEndTime);
+      if (hipErrFree2 != hipSuccess) {
+        free(hostEndTime);
+      }
     }
+    if (lessTiming && timingStats != nullptr) {
+      hipError_t hipErrFree3 = hipHostFree(timingStats);
+      if (hipErrFree3 != hipSuccess) {
+        free(timingStats);
+      }
+    }
+    // Free stop flag on error
+    if (stopRequestedFlag != nullptr) {
+      hipError_t hipErrFree = hipHostFree(const_cast<bool*>(stopRequestedFlag));
+      if (hipErrFree != hipSuccess) {
+        free(const_cast<bool*>(stopRequestedFlag));
+      }
+    }
+    // Clear signal handler pointer
+    g_configForSignalHandler = nullptr;
     return EXIT_FAILURE;
   }
 
-  // Print raw timing data if verbose
-  if (baseConfig.verbose) {
+  // Check if test was interrupted by SIGINT
+  bool wasInterrupted = false;
+  if (stopRequestedFlag != nullptr && *stopRequestedFlag) {
+    wasInterrupted = true;
+    std::cout << "\nTest interrupted by user (SIGINT)" << std::endl;
+  }
+
+  // Print raw timing data if verbose and full timing is enabled
+  if (baseConfig.verbose && !lessTiming) {
     if (baseConfig.numThreads == 1) {
       std::cout << "\nRaw timing data:" << std::endl;
       std::cout << "Index | Start Time      | End Time        | Duration"
@@ -385,50 +509,131 @@ int main(int argc, char** argv) {
     }
   }
 
-  // Calculate durations (skip first iteration per thread, as it
-  // tends to be larger)
-  std::vector<double> durations;
-  for (unsigned t = 0; t < baseConfig.numThreads; ++t) {
-    unsigned baseIdx = t * baseConfig.iterations;
-    for (unsigned i = 1; i < baseConfig.iterations; ++i) {
-      unsigned idx = baseIdx + i;
-      if (hostEndTime[idx] > hostStartTime[idx]) {
-        double durationNs = (hostEndTime[idx] - hostStartTime[idx]) *
-                            gpuClockPeriodNs;
-        durations.push_back(durationNs);
+  // Handle timing statistics based on mode
+  if (lessTiming && timingStats != nullptr) {
+    // Less-timing mode: use same xioPrintStatistics function as normal mode
+    if (timingStats->count > 0) {
+      // Convert timing stats to durations vector for xioPrintStatistics
+      double minDurationNs = static_cast<double>(timingStats->minDuration) *
+                             gpuClockPeriodNs;
+      double maxDurationNs = static_cast<double>(timingStats->maxDuration) *
+                             gpuClockPeriodNs;
+      double meanDurationNs = (static_cast<double>(timingStats->sumDuration) /
+                               static_cast<double>(timingStats->count)) *
+                              gpuClockPeriodNs;
+
+      // Create a synthetic durations vector with min, max, and mean values
+      // distributed to approximate the distribution (for stddev calculation)
+      std::vector<double> durations;
+      if (timingStats->count == 1) {
+        durations.push_back(meanDurationNs);
+      } else if (timingStats->count == 2) {
+        durations.push_back(minDurationNs);
+        durations.push_back(maxDurationNs);
+      } else {
+        // Distribute: 1 min, 1 max, rest mean (gives reasonable stddev)
+        durations.push_back(minDurationNs);
+        durations.push_back(maxDurationNs);
+        for (unsigned long long int i = 2; i < timingStats->count; ++i) {
+          durations.push_back(meanDurationNs);
+        }
+      }
+
+      // Print statistics using same function as normal mode
+      // Use actual count from timingStats instead of configured iterations
+      // Note: readIterations/writeIterations not available without
+      // endpoint-specific headers, so pass 0 to show "Iterations" instead of
+      // "Reads/Writes" Note: verifiedReadsCount not available in less-timing
+      // mode, use UINT_MAX
+      unsigned actualIterations = static_cast<unsigned>(timingStats->count);
+      if (printHistogram) {
+        xioPrintHistogram(durations, actualIterations, baseConfig.numThreads, 0,
+                          0, UINT_MAX);
+      } else {
+        xioPrintStatistics(durations, actualIterations, baseConfig.numThreads,
+                           0, 0, UINT_MAX);
+      }
+    } else {
+      std::cout << "Warning: No timing data collected in less-timing mode"
+                << std::endl;
+    }
+  } else if (!lessTiming) {
+    // Full timing mode: calculate durations from individual timestamps
+    // (skip first iteration per thread, as it tends to be larger)
+    std::vector<double> durations;
+    unsigned actualIterations = 0;
+    for (unsigned t = 0; t < baseConfig.numThreads; ++t) {
+      unsigned baseIdx = t * baseConfig.iterations;
+      for (unsigned i = 0; i < baseConfig.iterations; ++i) {
+        unsigned idx = baseIdx + i;
+        if (hostEndTime[idx] > hostStartTime[idx]) {
+          actualIterations++; // Count all completed iterations
+          if (i > 0) {
+            // Skip first iteration per thread for statistics
+            double durationNs = (hostEndTime[idx] - hostStartTime[idx]) *
+                                gpuClockPeriodNs;
+            durations.push_back(durationNs);
+          }
+        }
       }
     }
-  }
 
-  // Print statistics (printHistogram is already set from common options)
-
-  if (durations.size() > 0) {
-    if (printHistogram) {
-      xioPrintHistogram(durations, baseConfig.iterations,
-                        baseConfig.numThreads);
+    // Print statistics (printHistogram is already set from common options)
+    // Use actual count of completed iterations instead of configured iterations
+    // Note: readIterations/writeIterations not available without
+    // endpoint-specific headers, so pass 0 to show "Iterations" instead of
+    // "Reads/Writes" Note: verifiedReadsCount not tracked in normal mode, use
+    // UINT_MAX
+    if (durations.size() > 0) {
+      if (printHistogram) {
+        xioPrintHistogram(durations, actualIterations, baseConfig.numThreads, 0,
+                          0, UINT_MAX);
+      } else {
+        xioPrintStatistics(durations, actualIterations, baseConfig.numThreads,
+                           0, 0, UINT_MAX);
+      }
     } else {
-      xioPrintStatistics(durations, baseConfig.iterations,
-                         baseConfig.numThreads);
+      std::cout << "Warning: No valid timing data collected" << std::endl;
     }
-  } else {
-    std::cout << "Warning: No valid timing data collected" << std::endl;
   }
 
-  // Print completion message (like simple-test)
-  std::cout << "\nTest completed successfully!" << std::endl;
+  // Print completion message
+  if (!wasInterrupted) {
+    std::cout << "\nTest completed successfully!" << std::endl;
+  }
 
   // Free memory
   xioFreeQueue(hostSqeAddr, sqIsDevice, "submission queue");
   xioFreeQueue(hostCqeAddr, cqIsDevice, "completion queue");
-  // Free host memory using HIP or regular free
-  hipError_t hipErrFree1 = hipHostFree(hostStartTime);
-  if (hipErrFree1 != hipSuccess) {
-    free(hostStartTime);
+  // Free host memory using HIP or regular free (only if allocated)
+  if (!lessTiming && hostStartTime != nullptr) {
+    hipError_t hipErrFree1 = hipHostFree(hostStartTime);
+    if (hipErrFree1 != hipSuccess) {
+      free(hostStartTime);
+    }
   }
-  hipError_t hipErrFree2 = hipHostFree(hostEndTime);
-  if (hipErrFree2 != hipSuccess) {
-    free(hostEndTime);
+  if (!lessTiming && hostEndTime != nullptr) {
+    hipError_t hipErrFree2 = hipHostFree(hostEndTime);
+    if (hipErrFree2 != hipSuccess) {
+      free(hostEndTime);
+    }
   }
+  if (lessTiming && timingStats != nullptr) {
+    hipError_t hipErrFree3 = hipHostFree(timingStats);
+    if (hipErrFree3 != hipSuccess) {
+      free(timingStats);
+    }
+  }
+  // Free stop flag
+  if (stopRequestedFlag != nullptr) {
+    hipError_t hipErrFree = hipHostFree(const_cast<bool*>(stopRequestedFlag));
+    if (hipErrFree != hipSuccess) {
+      free(const_cast<bool*>(stopRequestedFlag));
+    }
+  }
+
+  // Clear signal handler pointer
+  g_configForSignalHandler = nullptr;
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
NOTE: This commit also includes a fix for nvme_ep::sqeWrite that seems to be necessary to make long, stable NVMe runs work. It seems there is some sort of memory scope issue around the sqeWrite that needs to be determined and fixed properly. I am including this here for now and will do a more detailed fix. Runs of many hours were done with this version of sqeWrite. The version previous fails due to malformed IO after several 10s of seconds.

In long running tests recording the start and end times of each IO in an array is prohibitive. This commit adds both an --infinite mode (for running indefinintely and a --less-timing option that only records the min, max and mean of the IO durations.

Also add a SIGINT handler to the nvme-ep (others coming soon) so we can still output the timing results when running in infinite mode and the user triggers a SIGINT.

