### PR TITLE
rebase: mods for eiden

### DIFF
--- a/.alola/rocm-xio-tests.common
+++ b/.alola/rocm-xio-tests.common
@@ -5,6 +5,11 @@
 #
 # rocm-xio-tests.common - shared setup for rocm-xio-tests.*.sbatch
 
+SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH_LOCALHOST="${SSH_COMMAND} localhost"
+
+SCP_COMMAND="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
 # Project directory (repo root). When submitted from .alola, use its parent.
 if [ -n "${SLURM_SUBMIT_DIR}" ]; then
   case "${SLURM_SUBMIT_DIR}" in
@@ -41,18 +46,18 @@ setup_and_build_workdir() {
 
 build_and_load_kernel_module_on_host() {
   echo "Building and loading kernel module on host via ssh localhost ..."
-  ssh localhost "mkdir -p ${WORKING_DIR}/kernel/rocm-xio"
-  scp -r ${WORKING_DIR}/kernel/rocm-xio/* localhost:${WORKING_DIR}/kernel/rocm-xio
-  ssh localhost "cd ${WORKING_DIR}/kernel/rocm-xio && ls -la"
-  ssh localhost "cd ${WORKING_DIR}/kernel/rocm-xio && make clean"
-  ssh localhost "cd ${WORKING_DIR}/kernel/rocm-xio && make -j $(nproc)"
-  ssh localhost "cd ${WORKING_DIR}/kernel/rocm-xio && sudo make install"
-  ssh localhost "sudo modprobe -r rocm-xio && sudo modprobe rocm-xio"
+  ${SSH_LOCALHOST} "mkdir -p ${WORKING_DIR}/kernel/rocm-xio"
+  ${SCP_COMMAND} -r ${WORKING_DIR}/kernel/rocm-xio/* localhost:${WORKING_DIR}/kernel/rocm-xio
+  ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && ls -la"
+  ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && make clean"
+  ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && make -j $(nproc)"
+  ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && sudo make install"
+  ${SSH_LOCALHOST} "sudo modprobe -r rocm-xio && sudo modprobe rocm-xio"
 }
 
 unload_kernel_module_on_host() {
   echo "Unloading kernel module on host via ssh localhost ..."
-  ssh localhost "sudo modprobe -r rocm-xio"
+  ${SSH_LOCALHOST} "sudo modprobe -r rocm-xio"
 }
 
 function find_root_device() {

--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -15,7 +15,7 @@
 #   To check compatible nodes: sinfo -Na -o "%N %100f" | grep NVME
 #SBATCH --constraint=MARKHAM&NVME&ROCM7.2.0
 
-set -e
+set -xe
 if [ -n "${SLURM_SUBMIT_DIR}" ]; then
   . "${SLURM_SUBMIT_DIR}/rocm-xio-tests.common"
 else
@@ -26,7 +26,7 @@ cleanup() {
   echo "Cleaning up..."
   unload_kernel_module_on_host
   rm -rf "${WORKING_DIR}"
-  ssh localhost "sudo rm -rf ${WORKING_DIR}"
+  ${SSH_LOCALHOST} "sudo rm -rf ${WORKING_DIR}"
 }
 trap cleanup EXIT
 
@@ -72,8 +72,8 @@ echo "Building and loading kernel module on host..."
 build_and_load_kernel_module_on_host
 
 # Copy over test program
-ssh localhost "mkdir -p ${WORKING_DIR}/build/"
-scp ${WORKING_DIR}/build/xio-tester \
+${SSH_LOCALHOST} "mkdir -p ${WORKING_DIR}/build/"
+${SCP_COMMAND} ${WORKING_DIR}/build/xio-tester \
   localhost:${WORKING_DIR}/build/xio-tester
 
 # Run tests
@@ -83,7 +83,7 @@ echo "=========================================="
 echo "NVMe Controller: ${NON_ROOTFS_CTRL}"
 echo ""
 
-ssh localhost "export LD_LIBRARY_PATH=/opt/rocm/lib; \
+${SSH_LOCALHOST} "export LD_LIBRARY_PATH=/opt/rocm/lib; \
   export HSA_FORCE_FINE_GRAIN_PCIE=1; \
   sudo -E ${WORKING_DIR}/build/xio-tester \
     nvme-ep --controller ${NON_ROOTFS_CTRL} \

--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -14,7 +14,7 @@
 #SBATCH --constraint=MARKHAM
 #SBATCH --gpus-per-node=1
 
-set -e
+set -xe
 if [ -n "${SLURM_SUBMIT_DIR}" ]; then
   . "${SLURM_SUBMIT_DIR}/rocm-xio-tests.common"
 else

--- a/.alola/rocm-xio-tests.two-gpu.sbatch
+++ b/.alola/rocm-xio-tests.two-gpu.sbatch
@@ -19,7 +19,7 @@
 #SBATCH --constraint=MARKHAM&(GFX942|GFX950)
 #SBATCH --gres=gpu:2
 
-set -e
+set -xe
 if [ -n "${SLURM_SUBMIT_DIR}" ]; then
   . "${SLURM_SUBMIT_DIR}/rocm-xio-tests.common"
 else


### PR DESCRIPTION
Align test-ep with the xio::nvme_ep namespacing convention:

- Nest all declarations under namespace xio::test_ep
- Replace preprocessor macros (TEST_EP_MAGIC_ID, etc.) with constexpr constants (magicId, cqeMagicId, sqeSize, cqeSize)
- Rename test_ep_run() to xio::test_ep::run()
- Fix launchCpuThreads() header/impl signature mismatch (bool doorbellMode -> unsigned doorbell)
- Add Doxygen comments to all public structs, fields, constants, and functions in test-ep.h
- Update xio-endpoint.hip call sites accordingly