### PR TITLE
refactor: move test-ep into xio::test_ep namespace with Doxygen docs

### DIFF
--- a/src/endpoints/common/xio-endpoint.hip
+++ b/src/endpoints/common/xio-endpoint.hip
@@ -8,7 +8,6 @@
 
 #include <CLI/CLI.hpp>
 
-#include "test-ep.h"
 #include "xio-endpoint-registry.h"
 #include "xio.h"
 
@@ -19,7 +18,9 @@
 #include "test-ep.h"
 
 // Forward declarations for endpoint-specific run functions
-extern hipError_t test_ep_run(xio::XioEndpointConfig* config);
+namespace xio::test_ep {
+extern hipError_t run(XioEndpointConfig* config);
+} // namespace xio::test_ep
 namespace xio::nvme_ep {
 extern hipError_t run(XioEndpointConfig* config);
 std::string validateConfig(nvmeEpConfig* config);
@@ -99,11 +100,11 @@ public:
   }
 
   __host__ size_t getSubmissionQueueEntrySize() const override {
-    return TEST_EP_SQE_SIZE;
+    return test_ep::sqeSize;
   }
 
   __host__ size_t getCompletionQueueEntrySize() const override {
-    return TEST_EP_CQE_SIZE;
+    return test_ep::cqeSize;
   }
 
   __host__ size_t
@@ -141,7 +142,7 @@ public:
   }
 
   __host__ hipError_t run(XioEndpointConfig* config) override {
-    return test_ep_run(config);
+    return test_ep::run(config);
   }
 
   __host__ void configureCliOptions(CLI::App& app) override {

--- a/src/endpoints/test-ep/test-ep.h
+++ b/src/endpoints/test-ep/test-ep.h
@@ -17,92 +17,168 @@ namespace xio {
 struct XioEndpointConfig;
 } // namespace xio
 
-namespace test_ep {
+namespace xio::test_ep {
+
+/**
+ * Magic identifier written into the magic field of every
+ * submission queue entry (SQE) by the GPU. The CPU-side
+ * polling threads use this value to detect a valid SQE.
+ */
+constexpr uint64_t magicId = 0xDEADBEEFCAFEBABEULL;
+
+/**
+ * Magic identifier written into the magic field of every
+ * completion queue entry (CQE) by the CPU. The GPU polls
+ * for this value to detect a valid completion.
+ */
+constexpr uint64_t cqeMagicId = 0xBABECAFEBEEFDEADULL;
+
+/**
+ * Size of a submission queue entry in bytes.
+ */
+constexpr size_t sqeSize = 64;
+
+/**
+ * Size of a completion queue entry in bytes.
+ */
+constexpr size_t cqeSize = 16;
 
 /**
  * Test endpoint configuration structure
  *
- * Contains test-ep-specific configuration parameters.
+ * Contains test-ep-specific configuration parameters that
+ * control CPU thread behaviour, doorbell mode, emulation,
+ * and iteration count.
  */
 struct TestEpConfig {
-  // Enable CPU threads to poll SQEs and generate CQEs
-  // When enabled, CPU threads will poll host memory for SQEs written by GPU
-  // and generate CQEs with delay support
-  bool enableCpuThreads = true; // Default: enabled to match simple-test
-                                // behavior
+  /**
+   * @brief Enable CPU threads to poll SQEs and generate
+   *        CQEs.
+   *
+   * When enabled, CPU threads poll host memory for SQEs
+   * written by the GPU and generate CQEs with optional
+   * delay support.
+   */
+  bool enableCpuThreads = true;
 
-  // Doorbell mode queue length
-  // When > 0, enables doorbell mode with the specified queue length.
-  // CPU threads do not poll individual SQEs. Instead, a single CPU thread polls
-  // a doorbell address. The GPU writes SQEs to the submission queue and rings
-  // the doorbell after each SQE enqueue. Doorbell location is controlled by
-  // memory mode bit 2 (0=host, 1=device).
-  unsigned doorbell = 0; // Default: 0 (disabled, polling mode)
+  /**
+   * @brief Doorbell mode queue length.
+   *
+   * When greater than 0 doorbell mode is enabled with the
+   * specified queue length. A single CPU thread polls a
+   * doorbell address instead of individual SQEs. The GPU
+   * writes SQEs to the submission queue and rings the
+   * doorbell after each enqueue. Doorbell location is
+   * controlled by memory mode bit 2 (0=host, 1=device).
+   * A value of 0 disables doorbell mode (polling mode).
+   */
+  unsigned doorbell = 0;
 
-  // Emulate mode: run kernel code on CPU instead of GPU
-  // Useful for testing without a GPU or in CI environments
-  bool emulate = false; // Default: false (use GPU)
+  /**
+   * @brief Emulate mode flag.
+   *
+   * When true the kernel code runs on CPU threads instead
+   * of the GPU. Useful for testing without a GPU or in CI
+   * environments.
+   */
+  bool emulate = false;
 
-  // Number of iterations to run
-  unsigned iterations = 128; // Default: 128
+  /**
+   * @brief Number of iterations to run.
+   */
+  unsigned iterations = 128;
 
-  // Default constructor
+  /** @brief Default constructor. */
   TestEpConfig() = default;
 };
 
-} // namespace test_ep
-
-// Magic ID for test-ep queue entries (matches simple-test)
-#define TEST_EP_MAGIC_ID 0xDEADBEEFCAFEBABEULL
-#define TEST_EP_CQE_MAGIC_ID 0xBABECAFEBEEFDEADULL
-
-// Test endpoint queue entry sizes (matches simple-test)
-#define TEST_EP_SQE_SIZE 64 // Matches GpuToCpuMsg
-#define TEST_EP_CQE_SIZE 16 // Matches CpuToGpuMsg
-
-// Test endpoint queue entry structures (matches simple-test structures)
+/**
+ * Submission queue entry (SQE) for the test endpoint
+ *
+ * Written by the GPU and read by CPU polling threads.
+ * Layout matches the simple-test GpuToCpuMsg structure.
+ */
 struct test_sqe {
-  uint64_t magic;     // 8 bytes - magic number for validation
-  uint64_t iteration; // 8 bytes - iteration number (thread ID in upper 32 bits,
-                      // iteration in lower 32 bits)
-  uint64_t gpuTime;   // 8 bytes - GPU wall clock time
-  uint64_t data[5];   // 40 bytes - data payload
+  uint64_t magic;     ///< Magic number for validation
+  uint64_t iteration; ///< Iteration number (thread ID in
+                      ///< upper 32 bits, iteration in
+                      ///< lower 32 bits)
+  uint64_t gpuTime;   ///< GPU wall clock timestamp
+  uint64_t data[5];   ///< Data payload (40 bytes)
 };
 
+/**
+ * Completion queue entry (CQE) for the test endpoint
+ *
+ * Written by the CPU and polled by the GPU.
+ * Layout matches the simple-test CpuToGpuMsg structure.
+ */
 struct test_cqe {
-  uint64_t magic;   // 8 bytes - magic number for validation
-  uint64_t cpuTime; // 8 bytes - CPU wall clock time
+  uint64_t magic;   ///< Magic number for validation
+  uint64_t cpuTime; ///< CPU wall clock timestamp
 };
 
-static_assert(sizeof(struct test_sqe) == TEST_EP_SQE_SIZE,
-              "test_sqe size mismatch");
-static_assert(sizeof(struct test_cqe) == TEST_EP_CQE_SIZE,
-              "test_cqe size mismatch");
+static_assert(sizeof(test_sqe) == sqeSize, "test_sqe size mismatch");
+static_assert(sizeof(test_cqe) == cqeSize, "test_cqe size mismatch");
 
-// Forward declarations for CPU thread support
-// CPU thread launcher function (host-only)
-// Launches CPU threads to poll SQEs and generate CQEs
-// Parameters:
-//   hostSqeAddr: Host-accessible SQE buffer (from hipHostMalloc)
-//   hostCqeAddr: Host-accessible CQE buffer (from hipHostMalloc)
-//   hostEndTimes: Host-accessible end times array (optional, can be nullptr)
-//   numThreads: Number of CPU threads to launch (one per GPU thread)
-//   iterations: Number of iterations per thread
-//   delayNs: Delay configuration (from XioEndpointConfig)
-//   doorbellMode: If true, use doorbell mode (single CPU thread polling
-//   doorbell) doorbell: Doorbell address (nullptr if not in doorbell mode)
-//   queueSize: Size of submission queue in doorbell mode
-// Returns: Vector of thread handles (caller must join)
+/**
+ * Type aliases for queue entry types
+ */
+typedef struct test_sqe sqeType;
+typedef struct test_cqe cqeType;
+
+/**
+ * Launch CPU threads that poll SQEs and generate CQEs
+ *
+ * Each CPU thread services one GPU thread's queue buffer
+ * (polling mode) or a single CPU thread services a shared
+ * circular queue via doorbell notification.
+ *
+ * @param hostSqeAddr  Host-accessible SQE buffer
+ *                     (from hipHostMalloc).
+ * @param hostCqeAddr  Host-accessible CQE buffer
+ *                     (from hipHostMalloc).
+ * @param numThreads   Number of CPU threads to launch
+ *                     (one per GPU thread in polling mode).
+ * @param iterations   Number of iterations per thread.
+ * @param delayNs      Delay in nanoseconds before each CQE
+ *                     response. Negative values denote a
+ *                     fixed delay; positive values denote a
+ *                     random delay up to this value.
+ * @param doorbell     Doorbell queue length. When greater
+ *                     than 0, enables doorbell mode with a
+ *                     single CPU polling thread.
+ * @param doorbellAddr Doorbell address (nullptr when not in
+ *                     doorbell mode).
+ * @param queueSize    Submission queue size in entries
+ *                     (doorbell mode only).
+ * @return Vector of std::thread handles. The caller must
+ *         join all returned threads before tearing down
+ *         the queue buffers.
+ *
+ * @note This is a host-only function.
+ */
 std::vector<std::thread> launchCpuThreads(
   void* hostSqeAddr, void* hostCqeAddr, unsigned numThreads,
-  unsigned iterations, long long delayNs, bool doorbellMode = false,
-  void* doorbell = nullptr, unsigned queueSize = 0);
+  unsigned iterations, long long delayNs, unsigned doorbell = 0,
+  void* doorbellAddr = nullptr, unsigned queueSize = 0);
 
-// Run endpoint test - launches GPU kernel and waits for completion
-// Parameters:
-//   config: Endpoint configuration (includes submissionQueue and
-//   completionQueue)
-// Returns: HIP error code
-hipError_t test_ep_run(xio::XioEndpointConfig* config);
+/**
+ * Run the test endpoint
+ *
+ * Launches the GPU kernel (or CPU emulation threads) and
+ * waits for completion. CPU polling threads are started
+ * automatically when numThreads > 0.
+ *
+ * @param config Endpoint configuration containing queue
+ *               pointers, timing arrays, thread count,
+ *               and the endpoint-specific TestEpConfig
+ *               in the endpointConfig field.
+ * @return hipSuccess on success, or a HIP error code on
+ *         failure.
+ */
+hipError_t run(XioEndpointConfig* config);
+
+} // namespace xio::test_ep
 
 #endif // TEST_EP_H

--- a/src/endpoints/test-ep/test-ep.hip
+++ b/src/endpoints/test-ep/test-ep.hip
@@ -17,22 +17,13 @@
 #include "test-ep.h"
 #include "xio.h"
 
-using namespace xio;
+namespace xio::test_ep {
 
-// Get CPU wall clock time in nanoseconds (host-only)
 static inline uint64_t getCpuTime() {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return ts.tv_sec * 1000000000ULL + ts.tv_nsec;
 }
-
-// Use types from test-ep.h
-typedef struct test_sqe sqeType;
-typedef struct test_cqe cqeType;
-
-// Verify that the queue entry sizes match test-ep expectations
-static_assert(sizeof(sqeType) == TEST_EP_SQE_SIZE, "test-ep SQE size mismatch");
-static_assert(sizeof(cqeType) == TEST_EP_CQE_SIZE, "test-ep CQE size mismatch");
 
 // Helper function to compare sqeType structs
 __host__ __device__ bool sqeEqual(const sqeType* a, const sqeType* b) {
@@ -82,7 +73,7 @@ __host__ __device__ sqeType sqePoll(sqeType sqeLast,
   sqeType sqeNew;
   while (true) {
     sqeNew = sqeRead(sqeAddress);
-    if (sqeNew.magic == TEST_EP_MAGIC_ID && !sqeEqual(&sqeNew, &sqeLast))
+    if (sqeNew.magic == magicId && !sqeEqual(&sqeNew, &sqeLast))
       return sqeNew;
   }
 }
@@ -92,7 +83,7 @@ __host__ __device__ cqeType cqePoll(cqeType cqeLast,
   cqeType cqeNew;
   while (true) {
     cqeNew = cqeRead(cqeAddress);
-    if (cqeNew.magic == TEST_EP_CQE_MAGIC_ID && !cqeEqual(&cqeNew, &cqeLast))
+    if (cqeNew.magic == cqeMagicId && !cqeEqual(&cqeNew, &cqeLast))
       return cqeNew;
   }
 }
@@ -101,7 +92,7 @@ __host__ __device__ cqeType cqePoll(cqeType cqeLast,
 __host__ cqeType cqeGenFromSqe(const sqeType* sqeData) {
   (void)sqeData; // Not used, but kept for API compatibility
   cqeType result;
-  result.magic = TEST_EP_CQE_MAGIC_ID;
+  result.magic = cqeMagicId;
   result.cpuTime = getCpuTime(); // Use CPU time for CQE
   return result;
 }
@@ -130,7 +121,7 @@ static void cpuThreadDoorbell(volatile sqeType* sqeQueue,
       currentMsg.magic = sqe->magic;
 
       // If magic is not set, SQE hasn't been written yet - wait for it
-      if (currentMsg.magic != TEST_EP_MAGIC_ID) {
+      if (currentMsg.magic != magicId) {
         std::this_thread::yield();
         continue;
       }
@@ -178,7 +169,7 @@ static void cpuThreadDoorbell(volatile sqeType* sqeQueue,
       // Store sequence number in upper 32 bits, CPU time in lower 32 bits
       // This allows GPU to verify CQE corresponds to its SQE
       volatile cqeType* cqe = &cqeQueue[cqeIndex];
-      cqe->magic = TEST_EP_CQE_MAGIC_ID;
+      cqe->magic = cqeMagicId;
       cqe->cpuTime = ((uint64_t)sqeSeq << 32) | (cpuTime & 0xFFFFFFFFULL);
 
       head++;
@@ -222,7 +213,7 @@ static void cpuThread(volatile sqeType* hostSqeAddr,
       // Check if this is a new message for this thread and iteration
       // Match simple-test logic exactly: check magic, thread index, iteration
       // number, and that gpuTime has changed (new message)
-      if (currentMsg.magic == TEST_EP_MAGIC_ID && msgThreadIdx == threadIdx &&
+      if (currentMsg.magic == magicId && msgThreadIdx == threadIdx &&
           iter == i && currentMsg.gpuTime != lastGpuTimeSeen) {
         break;
       }
@@ -260,7 +251,7 @@ static void cpuThread(volatile sqeType* hostSqeAddr,
 
     // Generate response message (matches simple-test)
     cqeType response = {};
-    response.magic = TEST_EP_CQE_MAGIC_ID;
+    response.magic = cqeMagicId;
     response.cpuTime = cpuTime;
 
     // Write response to memory (matches simple-test)
@@ -276,16 +267,16 @@ static void cpuThread(volatile sqeType* hostSqeAddr,
 // Export test-ep functions
 __host__ __device__ void test_ep_emulateEndpoint(unsigned sqeIterations,
                                                  void* sqeAddr, void* cqeAddr) {
-  sqeType sqeNew = {TEST_EP_MAGIC_ID, 0, 0, {0}};
-  sqeType sqeOld = {TEST_EP_MAGIC_ID, 0, 0, {0}};
-  sqeType sqeStop = {TEST_EP_MAGIC_ID, 0xFFFFFFFFFFFFFFFFULL, 0, {0}};
-  cqeType cqeLocal = {TEST_EP_CQE_MAGIC_ID, 0};
+  sqeType sqeNew = {magicId, 0, 0, {0}};
+  sqeType sqeOld = {magicId, 0, 0, {0}};
+  sqeType sqeStop = {magicId, 0xFFFFFFFFFFFFFFFFULL, 0, {0}};
+  cqeType cqeLocal = {cqeMagicId, 0};
 
   while (!sqeEqual(&sqeNew, &sqeStop)) {
     sqeNew = sqePoll(sqeOld, (volatile sqeType*)sqeAddr);
 #ifdef __HIP_DEVICE_COMPILE__
     // Device code - can't call getCpuTime, just use a dummy value
-    cqeLocal.magic = TEST_EP_CQE_MAGIC_ID;
+    cqeLocal.magic = cqeMagicId;
     cqeLocal.cpuTime = 0;
 #else
     // Host code - can call getCpuTime
@@ -458,7 +449,7 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
 
       // Prepare message to CPU
       sqeType msg = {};
-      msg.magic = TEST_EP_MAGIC_ID;
+      msg.magic = magicId;
       msg.iteration = ((uint64_t)tid << 32) | i;
       uint64_t sqeGpuTime = wall_clock64();
       msg.gpuTime = sqeGpuTime;
@@ -514,7 +505,7 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
         uint64_t cqeValue = myCqe->cpuTime;
         currentResponse.magic = magic;
         currentResponse.cpuTime = cqeValue;
-        if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
+        if (currentResponse.magic == cqeMagicId) {
           if (cqeValue != 0) {
             // Verify CQE corresponds to our SQE by checking sequence number
             // matches
@@ -557,7 +548,7 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
       // Prepare message to CPU (matches simple-test)
       // Encode thread index in upper 32 bits, iteration in lower 32 bits
       sqeType msg = {};
-      msg.magic = TEST_EP_MAGIC_ID;
+      msg.magic = magicId;
       msg.iteration = ((uint64_t)tid << 32) | i;
       msg.gpuTime = wall_clock64();
 
@@ -595,7 +586,7 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
         currentResponse.magic = magic;
         currentResponse.cpuTime = cpuTime;
         // Check if this is a new response
-        if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
+        if (currentResponse.magic == cqeMagicId) {
           if (currentResponse.cpuTime != 0) {
             // Accept if this is a new response (cpuTime changed)
             // Or if this is the first valid response (lastCpuTime was 0)
@@ -627,10 +618,7 @@ __global__ void endpoint_kernel(sqeType* sqePtr, cqeType* cqePtr,
   }
 }
 
-#include <iostream>
-
 // CPU emulation of endpoint kernel - runs kernel logic on CPU threads
-// This allows testing without a GPU
 static void endpoint_kernel_cpu_emulate(
   sqeType* sqePtr, cqeType* cqePtr, unsigned long long int* startTimes,
   unsigned long long int* endTimes, XioTimingStats* timingStats,
@@ -688,7 +676,7 @@ static void endpoint_kernel_cpu_emulate(
 
       // Prepare message to CPU
       sqeType msg = {};
-      msg.magic = TEST_EP_MAGIC_ID;
+      msg.magic = magicId;
       msg.iteration = ((uint64_t)threadId << 32) | i;
       uint64_t sqeGpuTime = getCpuTime(); // Use CPU time in emulation
       msg.gpuTime = sqeGpuTime;
@@ -767,7 +755,7 @@ static void endpoint_kernel_cpu_emulate(
         uint64_t cqeValue = myCqePtr->cpuTime;
         currentResponse.magic = magic;
         currentResponse.cpuTime = cqeValue;
-        if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
+        if (currentResponse.magic == cqeMagicId) {
           if (cqeValue != 0) {
             // Verify CQE corresponds to our SQE by checking sequence number
             // matches
@@ -814,7 +802,7 @@ static void endpoint_kernel_cpu_emulate(
 
       // Prepare message to CPU
       sqeType msg = {};
-      msg.magic = TEST_EP_MAGIC_ID;
+      msg.magic = magicId;
       msg.iteration = ((uint64_t)threadId << 32) | i;
       msg.gpuTime = getCpuTime(); // Use CPU time in emulation
 
@@ -845,7 +833,7 @@ static void endpoint_kernel_cpu_emulate(
         uint64_t cpuTime = volatileCqe->cpuTime;
         currentResponse.magic = magic;
         currentResponse.cpuTime = cpuTime;
-        if (currentResponse.magic == TEST_EP_CQE_MAGIC_ID) {
+        if (currentResponse.magic == cqeMagicId) {
           if (currentResponse.cpuTime != 0) {
             if (currentResponse.cpuTime != lastCpuTime || lastCpuTime == 0) {
               break;
@@ -869,13 +857,11 @@ static void endpoint_kernel_cpu_emulate(
   }
 }
 
-// Run method implementation for test-ep - launches GPU kernel and waits for
-// completion
-hipError_t test_ep_run(XioEndpointConfig* config) {
+hipError_t run(XioEndpointConfig* config) {
   std::vector<std::thread> cpuThreadHandles;
 
   // Get test-ep specific config
-  test_ep::TestEpConfig* testEpConfig = static_cast<test_ep::TestEpConfig*>(
+  TestEpConfig* testEpConfig = static_cast<TestEpConfig*>(
     config->endpointConfig);
   unsigned doorbell = (testEpConfig != nullptr) ? testEpConfig->doorbell : 0;
   bool emulate = (testEpConfig != nullptr) ? testEpConfig->emulate : false;
@@ -1022,3 +1008,5 @@ hipError_t test_ep_run(XioEndpointConfig* config) {
 
   return hipSuccess;
 }
+
+} // namespace xio::test_ep


### PR DESCRIPTION
Align test-ep with the xio::nvme_ep namespacing convention:

- Nest all declarations under namespace xio::test_ep
- Replace preprocessor macros (TEST_EP_MAGIC_ID, etc.) with constexpr constants (magicId, cqeMagicId, sqeSize, cqeSize)
- Rename test_ep_run() to xio::test_ep::run()
- Fix launchCpuThreads() header/impl signature mismatch (bool doorbellMode -> unsigned doorbell)
- Add Doxygen comments to all public structs, fields, constants, and functions in test-ep.h
- Update xio-endpoint.hip call sites accordingly
