### PR TITLE
docs: Add documentation infrastructure using ROCm best practices

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 ---
-# clang-format configuration for rocm-axiio project
+# clang-format configuration for rocm-xio project
 # Based on observed code style and best practices
 
 # Base style

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+check-hidden = true
+skip = ./.git,./build,./build-docs,./build-*,./src/include/external
+ignore-words-list = hsa,nvme,bdf,prp,sqe,cqe,bnxt

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,55 @@
+name: docs-check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/**/*.h'
+      - 'README.md'
+      - '.codespellrc'
+      - '.github/workflows/docs-check.yml'
+
+jobs:
+  sphinx:
+    name: sphinx-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code.
+      uses: actions/checkout@v5.0.0
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake doxygen
+        pip install -r requirements.txt
+    - name: Configure docs-only build
+      run: |
+        cmake -S . -B build \
+          -DXIO_DOCS_ONLY=ON \
+          -DXIO_BUILD_DOCS=ON
+    - name: Build documentation
+      run: cmake --build build --target sphinx-html
+
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code.
+      uses: actions/checkout@v5.0.0
+    - name: Install codespell
+      run: pip install codespell
+    - name: Run codespell
+      run: codespell
+
+  rst-lint:
+    name: rst-lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code.
+      uses: actions/checkout@v5.0.0
+    - name: Install doc8
+      run: pip install doc8
+    - name: Lint RST files
+      run: doc8 docs/ --max-line-length 80

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -7,12 +7,13 @@ on:
       - main
     paths:
       - '**.md'
+      - 'docs/**'
       - '.wordlist.txt'
       - '.spellcheck.yml'
 
 jobs:
   spell-check:
-    name: spell-check for rocm-axiio
+    name: spell-check for rocm-xio
     runs-on: ubuntu-latest
     steps:
     - name: Check out code.

--- a/.github/workflows/test-emulate.yml
+++ b/.github/workflows/test-emulate.yml
@@ -49,8 +49,3 @@ jobs:
     - name: Run tester using test-ep in emulate mode with doorbell
       run: |
         ./build/xio-tester test-ep --emulate -n 100 -t 1 --doorbell 64 -v
-
-
- 
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 build/
+build-*/
 # Exception: scripts/build/ contains build scripts that should be tracked
 !scripts/build/
 bin/
@@ -63,6 +64,9 @@ src/tester/dump-queue-test
 # Reference materials (external)
 src/reference/
 gda-experiments/rocSHMEM/
+
+# Spell-check artifacts
+wordlist.dic
 
 # Python cache
 __pycache__/

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -6,10 +6,23 @@ matrix:
   sources:
   - '*.md'
   - 'src/**/*.md'
-  - 'docs/**/*.md'
   - 'scripts/**/*.md'
   pipeline:
   - pyspelling.filters.markdown
+  dictionary:
+    wordlists:
+    - .wordlist.txt
+    output: wordlist.dic
+    encoding: utf-8
+  default_encoding: utf-8
+  expect_match: true
+- name: restructuredtext
+  aspell:
+    lang: en
+  sources:
+  - 'docs/**/*.rst'
+  pipeline:
+  - pyspelling.filters.text
   dictionary:
     wordlists:
     - .wordlist.txt

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -182,12 +182,19 @@ wH
 
 # ===== Commands and Tools =====
 alola
+amdclang
 aspell
 bashrc
+bugfix
+bugfixes
+bugfixing
 CMake
 CMAKE
 cmake
 CMakeFiles
+CMakeLists
+ctest
+CXX
 DoozyX
 gcc
 github
@@ -199,6 +206,8 @@ Makefile
 pty
 pyspelling
 rojopolis
+shellcheck
+ShellCheck
 srun
 sqsh
 sudo
@@ -207,6 +216,10 @@ wordlist
 
 # ===== Miscellaneous =====
 api
+automatable
+CamelCase
+Changelog
+CPUs
 datacenter
 ar
 atlassian
@@ -320,6 +333,7 @@ objdump
 offload
 pageable
 pageable
+PascalCase
 passthrough
 passthrough
 perf
@@ -398,8 +412,19 @@ libdrm
 mknod
 
 # ===== Additional Terms =====
+codespellrc
+dkms
+instantiation
+MERCHANTABILITY
+NONINFRINGEMENT
+param
+pragma
+PRs
+STYLEGUIDE
 Subdirectory
 subdirectory
+sublicense
+vX
 
 # ===== Common Documentation Terms =====
 OAM
@@ -463,11 +488,14 @@ pageBase
 pageSize
 
 # ===== HTML and Markdown Terms =====
+blockquote
 br
 href
 li
+lightgrey
 lt
 ol
+svg
 ul
 
 # ===== Code Constants and Types =====
@@ -729,3 +757,56 @@ writerows
 xargs
 xticks
 ylabel
+
+# ===== API Identifiers (Doxygen/Breathe) =====
+allocateGpuAccessibleBuffer
+allocateQueue
+checkKernelModuleLoaded
+const
+createEndpoint
+dataPatternParams
+detectBdfFromDevice
+EndpointInfo
+EndpointType
+endpointName
+freeGpuAccessibleBuffer
+freeQueue
+genPciMmioBridgeCmd
+loadKernelModule
+mapPciBar
+nvmeBufferParams
+nvmeDoorbellParams
+nvmeEpConfig
+nvmeIoParams
+printDeviceInfo
+RdmaEpConfig
+registerMemoryForGpu
+SdmaEpConfig
+setupQueueForGpu
+TestEpConfig
+vram
+XioEndpoint
+XioEndpointConfig
+xioBufferInfo
+xioQueueSetup
+XioTimingStats
+
+# ===== Documentation Infrastructure Terms =====
+Breathe
+breathe
+codespell
+conf
+Doxygen
+doxygen
+Doxyfile
+doxygenclass
+doxygenfunction
+doxygenstruct
+doxygenunion
+DXIO
+intra
+maxdepth
+rst
+Sphinx
+toctree
+undoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for rocm-xio
+
+## UNRELEASED - rocm-xio 0.0.1
+
+### Added
+
+### Changed
+
+### Removed
+
+### Limitations
+
+### Known issues

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,28 @@ set(ROCM_XIO_LIBRARY_SOVERSION
   "${ROCM_XIO_LIBRARY_MAJOR}"
 )
 
-project(rocm-xio
-  VERSION ${ROCM_XIO_LIBRARY_VERSION}
-  DESCRIPTION "ROCm Library for GPU-Initiated IO"
-  LANGUAGES CXX HIP
-)
+option(XIO_DOCS_ONLY
+  "Only configure documentation targets (no HIP/ROCm needed)"
+  OFF)
+
+if(XIO_DOCS_ONLY)
+  project(rocm-xio
+    VERSION ${ROCM_XIO_LIBRARY_VERSION}
+    DESCRIPTION "ROCm Library for GPU-Initiated IO"
+    LANGUAGES CXX
+  )
+else()
+  project(rocm-xio
+    VERSION ${ROCM_XIO_LIBRARY_VERSION}
+    DESCRIPTION "ROCm Library for GPU-Initiated IO"
+    LANGUAGES CXX HIP
+  )
+endif()
+
+# Add cmake/ to the module search path (all modes need this)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+
+if(NOT XIO_DOCS_ONLY)
 
 # This project uses static libraries by necessity
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
@@ -122,9 +139,6 @@ if(${hsakmt_FOUND})
 else()
     message(FATAL_ERROR "find_package did NOT find hsakmt")
 endif()
-
-# Include helper modules
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 # Include build options modules early so options are available
 # This makes XIO_USE_SANITIZERS, XIO_USE_CODE_COVERAGE available as
@@ -400,6 +414,11 @@ install(FILES
 if(BUILD_TESTING)
   add_subdirectory(tests/unit/rdma-ep)
 endif()
+
+endif() # NOT XIO_DOCS_ONLY
+
+# Documentation (optional, requires -DXIO_BUILD_DOCS=ON)
+include(XIODocumentation)
 
 # Utility targets
 include(XIOUtilityTargets)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# rocm-xio Code of Conduct
+
+rocm-xio is a part of ROCm and, like other ROCm components, requires that
+engagement with the rocm-xio community abides by the
+[GitHub community guidelines][gh-guidelines] and the
+[GitHub community code of conduct][gh-coc].
+
+[gh-guidelines]: https://docs.github.com/en/site-policy/github-terms/github-community-guidelines
+[gh-coc]: https://docs.github.com/en/site-policy/github-terms/github-community-code-of-conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to rocm-xio
+
+Thank you for contributing! This guide outlines the development workflow,
+contribution standards, and best practices when working on rocm-xio.
+
+## Development Setup
+
+Install the dependencies listed in [INSTALL.md](INSTALL.md) and build the
+project. Run the test suite with `ctest .` before submitting changes.
+
+## Branching Model
+
+The main development trunk of rocm-xio is the `main` branch.
+
+rocm-xio generally uses trunk-based development, where feature branches are
+intended to be relatively short-lived. When necessary, feature branches will
+be created and prefixed with `feature/`. These feature branches will be
+deleted after the feature has been merged to `main`. Any feature branches
+which are not merged to `main`, but should be kept around for posterity,
+will be renamed `feature` --> `inactive`.
+
+External developers must use forks for development. You will sometimes see
+branches from AMD staff named `<category>/<user>/<description>`. These will
+be very short-lived.
+
+### Release branches
+
+Releases are tagged `vX.Y.Z`, where `X`, `Y`, and `Z` are the major, minor,
+and patch versions of the release.
+
+Releases occur from `main`. Upon release, the tag is created and the minor
+version number is bumped. The major version number will only be bumped on
+`main` when making an API/ABI-breaking change.
+
+Release branches are created retroactively and only when it is necessary to
+bugfix supported versions of the library. Bugfixing should take place on
+`main` and be cherry-picked to any branches that are being maintained.
+
+## Pull Requests
+
+We welcome pull requests from outside contributors. Pull requests must pass
+our CI and be approved by at least one code owner. Outside contributors
+should fully fill out the PR template for non-trivial PRs.
+
+Please also ensure that your code complies with this project's coding style,
+as detailed in [STYLEGUIDE.md](STYLEGUIDE.md).
+
+## Issue Reporting
+
+* Non-security issues should be reported as GitHub issues
+* Security issues should be reported as directed in [SECURITY.md](SECURITY.md)
+* Feature requests should be made using GitHub discussions

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,121 @@
+# Install guide for rocm-xio
+
+## Quick Install Guide
+
+rocm-xio depends on ROCm. Install ROCm and amdgpu-dkms as described in
+the [ROCm quick start installation guide][rocm-install].
+
+On Ubuntu 24.04, install the required packages:
+
+```
+sudo apt install rocm-hip-sdk rocminfo libcli11-dev cmake \
+  libdrm-dev libhsa-runtime-dev
+```
+
+Then build rocm-xio:
+
+```
+git clone https://github.com/ROCm/rocm-xio.git
+cd rocm-xio
+mkdir -p build
+cmake -S . -B build
+cmake --build build --target all
+```
+
+Verify the build by listing available endpoints:
+
+```
+./build/xio-tester --list-endpoints
+```
+
+Run a quick NVMe test (requires an NVMe device):
+
+```
+export HSA_FORCE_FINE_GRAIN_PCIE=1
+sudo ./build/xio-tester nvme-ep --controller /dev/nvme0 \
+  --read-io 50 --write-io 50 --verbose
+```
+
+## Building rocm-xio
+
+> [!NOTE]
+> rocm-xio is early-access software that has undergone testing on limited
+> hardware. It may not work on your system at this time.
+
+Supported hardware:
+
+* rocm-xio should work with the [GPUs that ROCm supports][rocm-gpus]
+* Storage is currently limited to local NVMe drives
+* rocm-xio has only been tested on AMD CPUs/systems
+
+Supported compilers: amdclang++ (preferred), clang++, g++
+
+Supported platforms: Linux
+
+### Requirements
+
+* CMake 3.21 or later
+* ROCm HIP SDK
+* HSA runtime libraries
+* libdrm and libdrm\_amdgpu development packages
+
+### Configure
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| OFFLOAD\_ARCH | (auto) | GPU architecture |
+| ROCM\_PATH | /opt/rocm | ROCm installation path |
+| XIO\_BUILD\_DOCS | OFF | Build documentation (Sphinx) |
+| XIO\_DOCS\_ONLY | OFF | Docs-only build (no HIP) |
+| INSTALL\_TESTER | OFF | Install xio-tester binary |
+
+Sanitizer options (clang only):
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| XIO\_USE\_SANITIZERS | OFF | address, leak, undefined |
+| XIO\_USE\_THREAD\_SANITIZER | OFF | thread (incompatible with above) |
+| XIO\_USE\_INTEGER\_SANITIZER | OFF | integer (clang only) |
+| XIO\_USE\_CODE\_COVERAGE | OFF | coverage instrumentation |
+
+### Build
+
+```
+cmake --build build
+```
+
+### Run tests
+
+```
+ctest --test-dir build
+```
+
+### Install and package
+
+The default install prefix follows ROCm conventions (`/opt/rocm`).
+
+```
+cmake --install build
+```
+
+Custom install prefix:
+
+```
+cmake --install build --prefix /tmp/rocm-xio-test
+```
+
+### Documentation
+
+Build the documentation with Sphinx + Breathe + Doxygen:
+
+```
+cmake -S . -B build -DXIO_BUILD_DOCS=ON
+cmake --build build --target sphinx-html
+```
+
+Output appears in `build/docs/html/index.html`.
+
+For full build details see [docs/building.rst](docs/building.rst).
+
+[rocm-install]: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html
+[rocm-gpus]: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,263 +1,32 @@
-# rocm-xio: A ROCm Library for Accelerator-Initiated IO
+# rocm-xio
 
-## Introduction
+[![MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/ROCm/rocm-xio/blob/main/LICENSE.md)
+[![Build](https://github.com/ROCm/rocm-xio/actions/workflows/build-check.yml/badge.svg)](https://github.com/ROCm/rocm-xio/actions/workflows/build-check.yml)
+[![Docs](https://github.com/ROCm/rocm-xio/actions/workflows/docs-check.yml/badge.svg)](https://github.com/ROCm/rocm-xio/actions/workflows/docs-check.yml)
+[![Test](https://github.com/ROCm/rocm-xio/actions/workflows/test-emulate.yml/badge.svg)](https://github.com/ROCm/rocm-xio/actions/workflows/test-emulate.yml)
+[![Spelling](https://github.com/ROCm/rocm-xio/actions/workflows/spell-check.yml/badge.svg)](https://github.com/ROCm/rocm-xio/actions/workflows/spell-check.yml)
+[![Platform](https://img.shields.io/badge/platform-linux-lightgrey.svg)](INSTALL.md)
+[![ROCm](https://img.shields.io/badge/ROCm-supported-green.svg)](https://rocm.docs.amd.com)
+[![Language](https://img.shields.io/badge/language-HIP%20%7C%20C%2B%2B-orange.svg)](https://rocm.docs.amd.com/projects/HIP/en/latest/)
 
-This repository contains the source code for a ROCm library that provides
-an API for Accelerator-Initiated IO (XIO) for AMD GPU `__device__` code.
+> [!CAUTION]
+> This release is an *early-access* software technology preview. Running
+> production workloads is *not* recommended.
 
-This library enables AMD GPUs to perform direct IO operations to hardware
-devices (NVMe SSDs, RDMA NICs, SDMA engines) without CPU intervention.
+ROCm library for Accelerator-Initiated IO (XIO). Enables AMD GPUs to perform
+direct IO to NVMe SSDs, RDMA NICs, and SDMA engines from `__device__` code
+without CPU intervention.
 
-This library targets a number of devices which we refer to as endpoints. The
-list of supported devices we can issue IO to is given in the
-[endpoints](./endpoints) sub-folder.
+## Installing and Using rocm-xio
 
-## Quick Reference
+See [INSTALL.md](INSTALL.md) for dependencies, supported hardware, and build
+instructions.
 
-### Dependencies
+## Documentation
 
-```bash
-# Install required packages
-sudo apt install rocm-hip-sdk rocminfo libcli11-dev cmake \
-  libdrm-dev libhsa-runtime-dev
-```
+Full documentation lives in the [`docs/`](docs/) directory and covers
+building, endpoints, the kernel module, memory modes, and the API reference.
 
-### Build and Run
+## License
 
-```bash
-# 1. Configure CMake build
-mkdir -p build && cd build
-cmake ..
-
-# 2. Build library and tester
-cmake --build . --target all
-
-# Output locations:
-# - Library: build/lib/librocm-xio.a
-# - Tester:  build/bin/xio-tester
-
-# 3. Run with GPU + NVMe
-export HSA_FORCE_FINE_GRAIN_PCIE=1
-sudo ./build/bin/xio-tester nvme-ep --controller /dev/nvme0 \
-  --read-io 50 --write-io 50 --verbose
-```
-
-### CMake Configuration Options
-
-```bash
-# Specify GPU architecture (auto-detected if not specified)
-cmake -DOFFLOAD_ARCH=gfx942:xnack+ ..
-
-# Specify ROCm installation path (default: /opt/rocm)
-cmake -DROCM_PATH=/opt/rocm-7.1.0 ..
-
-# Configure and build in one step
-cmake --build . --target all
-```
-
-### CMake Build Targets
-
-**Primary targets:**
-```bash
-cmake --build . --target rocm-xio    # Build library only
-cmake --build . --target xio-tester   # Build tester only
-cmake --build . --target all            # Build library + tester (default)
-```
-
-**Code generation targets:**
-```bash
-cmake --build . --target endpoint-registry-generated
-cmake --build . --target nvme-ep-generated
-cmake --build . --target rdma-vendor-headers-generated
-cmake --build . --target fetch-nvme-headers
-cmake --build . --target fetch-rdma-headers
-cmake --build . --target fetch-external-headers
-```
-
-**Utility targets:**
-```bash
-cmake --build . --target list           # List supported GPU architectures
-cmake --build . --target asm            # Dump library assembly code
-cmake --build . --target lint-format    # Check code formatting
-cmake --build . --target format         # Fix code formatting
-cmake --build . --target lint-spell     # Check spelling in docs
-cmake --build . --target lint-all       # Run all linting checks
-cmake --build . --target clean-all      # Remove all build artifacts
-cmake --build . --target clean-external # Remove external headers
-```
-
-### Installation
-
-**Install to default location (typically `/opt/rocm`):**
-```bash
-cd build
-cmake --build . --target install
-```
-
-**Install to custom location for testing:**
-```bash
-cd build
-cmake --install . --prefix /tmp/rocm-xio-test
-
-# Test the installation
-export CMAKE_PREFIX_PATH=/tmp/rocm-xio-test:$CMAKE_PREFIX_PATH
-cd /tmp
-cat > test-find-package.cmake << 'EOF'
-cmake_minimum_required(VERSION 3.21)
-project(test)
-find_package(rocm-xio REQUIRED)
-message(STATUS "Found rocm-xio version: ${rocm-xio_VERSION}")
-message(STATUS "Include dirs: ${ROCM_AXIIO_INCLUDE_DIRS}")
-message(STATUS "Libraries: ${ROCM_AXIIO_LIBRARIES}")
-EOF
-cmake -P test-find-package.cmake
-```
-
-**Install with tester executable:**
-```bash
-cd build
-cmake -DINSTALL_TESTER=ON ..
-cmake --build . --target install --prefix /tmp/rocm-xio-test
-```
-
-### Kernel Module Build
-
-The kernel module (`kernel/rocm-xio/`) uses the standard Linux kernel
-build system (Kbuild) and must be built separately:
-
-```bash
-# Build kernel module
-cd kernel/rocm-xio
-make
-
-# Install kernel module
-sudo make install
-
-# Load module
-sudo modprobe rocm-xio
-
-# Create device node (after loading)
-sudo mknod /dev/rocm-xio c $(grep rocm-xio /proc/devices | awk '{print $1}') 0
-sudo chmod 666 /dev/rocm-xio
-```
-
-**Note:** The kernel module build is independent of the CMake build system
-and uses its own Makefile following Linux kernel conventions.
-
-## Build System
-
-This project uses CMake for building userspace code (library and tester).
-The build system follows ROCm best practices and patterns from hipFile and
-TransferBench.
-
-### Build Output Structure
-
-```
-build/
-├── bin/
-│   └── xio-tester          # Test application
-├── lib/
-│   └── librocm-xio.a       # Static library
-└── CMakeFiles/               # CMake internal files
-```
-
-### Key Features
-
-- **HIP compilation**: Uses `hipcc` with `-fgpu-rdc` for relocatable device
-  code
-- **Device code extraction**: Tester executable links with `hipcc` to extract
-  device code from static library
-- **Code generation**: Automatic generation of endpoint registry and external
-  headers
-- **GPU architecture detection**: Auto-detects GPU architecture via `rocminfo`
-  or can be specified via `OFFLOAD_ARCH` option
-
-### CMake Requirements
-
-- CMake 3.21 or later
-- ROCm HIP SDK
-- HSA runtime libraries
-- libdrm and libdrm_amdgpu development packages
-
-## Endpoints
-
-Endpoints define the hardware interfaces and protocols for different IO
-devices. Each endpoint provides its own queue entry formats and IO semantics.
-
-### **test-ep** - Test endpoint for development and testing
-  - Used for validating the XIO framework
-
-### **nvme-ep** - NVMe endpoint
-  - Implements NVMe command submission (SQE) and completion (CQE) handling
-  - Supports Read and Write commands
-  - Definitions based on Linux kernel NVMe headers and NVMe specification
-
-### **sdma-ep** - SDMA (System DMA) endpoint
-  - Enables GPU-initiated DMA transfers using AMD SDMA hardware engines
-  - Supports peer-to-peer GPU transfers via XGMI/Infinity Fabric
-  - Requires MI300X or similar datacenter GPUs with SDMA support
-
-### Listing Available Endpoints
-
-To see all available endpoints:
-```bash
-./build/bin/xio-tester --list-endpoints
-```
-
-### Environment Variables for Radeon GPUs
-
-**IMPORTANT**: On consumer Radeon GPUs (RX series), you **should** set the
-following environment variable before running any tests:
-```bash
-export HSA_FORCE_FINE_GRAIN_PCIE=1
-```
-This enables fine-grained memory coherence which is required for GPU-to-CPU
-memory visibility. Without this setting, the GPU will encounter page faults
-when accessing host memory.
-
-**Note**: On MI-series accelerators (MI300X, etc.), this is typically not
-required as fine-grained memory is available by default.
-
-## Additional Useful Information
-
-On MI300X, the host allocation should be always `UNCACHED`. I think a
-`__threadfence()` should work for MI300X. However it has been seen that
-`__threadfence_system()` is needed on Radeon GPUs.
-
-I learned last week the hard way again that you do not have fine-grain memory
-on Radeon GPUs unless you set `HSA_FORCE_FINE_GRAIN_PCIE=1`.
-
-Coarse-grained memory basically means that a change at a memory location might
-only become visible to the CPU once the kernel finishes. Fine-grained means
-that changes to memory should be visible 'immediately' (with immediately being
-obviously the wrong term, but basically not just at the end of the kernel
-runtime). So its about visibility and cache coherence. As is often the case
-there is a good [Confluence page][ref-mem-grain] by Joseph Greathouse on this
-topic! It definitely impacts device memory. The part that I am unsure is
-whether it impacts things like `hipHostMalloc()`'d memory, which is host
-memory but managed by ROCr, I don't know whether similar rules apply to it as
-well.
-
-`hipHostMalloc()` comes in two flavors. One is pinned and the other is
-pageable/migratable. The pinned version is almost always what we will want in
-rocm-xio because we do not want to have the delay that happens if a device
-tries to access an unmapped page-able memory page. Because that results in an
-XNACK and associated PTE updates. That would be more useful for very large VMAs
-which the __device__ code is going to access randomly and sporadically.
-
-The last 2 weeks of my pain have stemmed from two things:
-
-If __device__ code does a store to host memory what is needed to ensure that a
-process running on a host cpu core can see the store? The answer here is
-(I think) hipHostMalloc(), volatile pragmas (on the host) and
-`__threadfence_system()` (on the device).
-
-If __host__ code does a store to host memory what is needed to ensure that a
-process running on a GPU core can see the store? Here the answer is (I think)
-just hipHostMalloc(). The hipHostMalloc() ensures the memory if flagged as
-uncached and so any CPU process writes to that VMA become visible at the system
-level. I think. I am adding all this to the top-level README for now till we
-get a nice clean scriptable way to ensuring these rules are applied at the
-system level and vary depending on the GPU and endpoint(s) used.
-
-[ref-mem-grain]: https://amd.atlassian.net/wiki/spaces/AMDGPU/pages/777526553/Cache+coherence+summary+by+Joseph+Greathouse
+[MIT](LICENSE.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you have discovered a security vulnerability in the rocm-xio library,
+please do NOT report it publicly using a GitHub issue. Instead, you should
+report the issue via the AMD Product Security website:
+
+https://www.amd.com/en/resources/product-security.html

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,87 @@
+# rocm-xio Style Guide
+
+## File and Directory Structure
+
+### Naming
+
+* Use hyphens instead of underscores in file and directory names (e.g.,
+  `nvme-ep`, `xio-tester`)
+
+## Formatting
+
+* Code must meet the requirements of our `.clang-format` configuration
+  (LLVM base style, 80-column limit, 2-space indentation)
+* Run formatting checks with:
+  `cmake --build build --target lint-format`
+* Auto-fix formatting with:
+  `cmake --build build --target format`
+
+## Naming Conventions
+
+* Use `snake_case` for variables and functions
+* Use `PascalCase` for types and classes
+* Use `UPPER_SNAKE_CASE` for macros and constants
+* Prefix public API symbols with `xio_` or `Xio`
+
+## Comments and Documentation
+
+* Public headers MUST have Doxygen markup for all public symbols using
+  `/** @brief ... */` style
+* Document all `@param` and `@return` values
+* Use `@note` for caveats and `@see` for related items
+* Private headers should have Doxygen markup flagged with `@internal`
+
+## Header Guidelines
+
+* Use `#pragma once` instead of include guards
+* Place local headers (quoted) ahead of system headers (brackets), with
+  each block in alphabetical order
+* Follow [include-what-you-use](https://include-what-you-use.org/)
+  guidelines
+
+## Language Features and Idioms
+
+### CMake
+
+* We use CMake 3.21+ (see the root `CMakeLists.txt` for the specific
+  version)
+* Use modern CMake paradigms and avoid "legacy CMake"
+
+### C/C++ and HIP
+
+* C++17 is required (`CMAKE_CXX_STANDARD 17`)
+* GNU extensions are disabled (`CMAKE_CXX_EXTENSIONS OFF`)
+* Use modern C++ idioms
+* Code should be platform-independent where possible
+* HIP device code uses `-fgpu-rdc` for relocatable device code
+
+### Shell scripts
+
+* All shell scripts should be run through
+  [ShellCheck](https://www.shellcheck.net/) and report no issues
+* Use `#!/usr/bin/env bash` as a platform-independent shebang line
+* bash-isms are allowed, within reason
+
+## Error Handling
+
+* Use HIP error checking for all HIP API calls
+* Propagate errors to callers rather than silently ignoring them
+
+## Testing Conventions
+
+* All new functionality introduced MUST include tests
+  * This could include unit tests, system tests, and integration tests
+  * These tests MUST be automatable via `ctest`
+* Bugfixes MUST include a test that fails before the fix and passes
+  after
+
+## Tooling and Enforcement
+
+* **clang-format**: enforced via `.clang-format` and the `lint-format`
+  CMake target
+* **codespell**: spell-checking via `.codespellrc` and the
+  `lint-codespell` CMake target
+* **Sphinx + Doxygen**: API documentation via `sphinx-html`
+  CMake target
+* **CI**: GitHub Actions workflows for build, docs, spelling, and test
+  checks

--- a/cmake/XIODocumentation.cmake
+++ b/cmake/XIODocumentation.cmake
@@ -1,0 +1,104 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# XIODocumentation.cmake
+# Sphinx + Breathe + Doxygen documentation pipeline
+# (following ROCm best practices)
+#
+# A Python venv is created automatically in the build tree
+# and populated from requirements.txt.
+
+option(XIO_BUILD_DOCS
+  "Build documentation with Sphinx + Breathe + Doxygen"
+  OFF)
+
+if(XIO_BUILD_DOCS)
+  find_package(Doxygen REQUIRED)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+  # ── Python venv with Sphinx + Breathe ──────────────────
+  set(XIO_DOCS_VENV "${CMAKE_BINARY_DIR}/docs-venv")
+  set(XIO_DOCS_VENV_STAMP
+    "${XIO_DOCS_VENV}/stamp")
+  set(XIO_DOCS_REQUIREMENTS
+    "${CMAKE_SOURCE_DIR}/requirements.txt")
+
+  if(WIN32)
+    set(XIO_VENV_BIN "${XIO_DOCS_VENV}/Scripts")
+  else()
+    set(XIO_VENV_BIN "${XIO_DOCS_VENV}/bin")
+  endif()
+
+  set(SPHINX_BUILD "${XIO_VENV_BIN}/sphinx-build")
+
+  add_custom_command(
+    OUTPUT ${XIO_DOCS_VENV_STAMP}
+    COMMAND ${Python3_EXECUTABLE} -m venv ${XIO_DOCS_VENV}
+    COMMAND ${XIO_VENV_BIN}/pip install
+      --quiet --upgrade pip
+    COMMAND ${XIO_VENV_BIN}/pip install
+      --quiet -r ${XIO_DOCS_REQUIREMENTS}
+    COMMAND ${CMAKE_COMMAND} -E touch
+      ${XIO_DOCS_VENV_STAMP}
+    DEPENDS ${XIO_DOCS_REQUIREMENTS}
+    COMMENT "Creating docs venv and installing deps"
+    VERBATIM
+  )
+
+  add_custom_target(docs-venv
+    DEPENDS ${XIO_DOCS_VENV_STAMP}
+  )
+
+  # ── Paths ──────────────────────────────────────────────
+  set(XIO_DOC_PATH "${CMAKE_BINARY_DIR}/docs")
+  set(BREATHE_DOC_XML_DIR
+    "${XIO_DOC_PATH}/xml")
+
+  set(XIO_DOXYFILE_INPUT
+    "${CMAKE_SOURCE_DIR}/src/include \
+     ${CMAKE_SOURCE_DIR}/src/endpoints/nvme-ep \
+     ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep \
+     ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep \
+     ${CMAKE_SOURCE_DIR}/src/endpoints/sdma-ep \
+     ${CMAKE_SOURCE_DIR}/src/endpoints/common \
+     ${CMAKE_SOURCE_DIR}/src/common"
+  )
+
+  # Configure Doxyfile (substitutes @VARIABLES@)
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/docs/Doxyfile.in
+    ${CMAKE_BINARY_DIR}/Doxyfile
+    @ONLY
+  )
+
+  # Configure conf.py (substitutes Breathe XML path)
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/docs/conf.py
+    ${CMAKE_BINARY_DIR}/docs-sphinx/conf.py
+    @ONLY
+  )
+
+  # ── Doxygen target: source headers -> XML ──────────────
+  add_custom_target(doxygen
+    COMMAND ${DOXYGEN_EXECUTABLE}
+      ${CMAKE_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Generating Doxygen XML"
+    VERBATIM
+  )
+
+  # ── Sphinx target: RST + Doxygen XML -> HTML ───────────
+  # Target name follows ROCm convention (ROCMSphinxDoc)
+  add_custom_target(sphinx-html
+    COMMAND ${SPHINX_BUILD}
+      -b html
+      -c ${CMAKE_BINARY_DIR}/docs-sphinx
+      ${CMAKE_SOURCE_DIR}/docs
+      ${XIO_DOC_PATH}/html
+    DEPENDS doxygen docs-venv
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Building Sphinx HTML documentation"
+    VERBATIM
+  )
+endif()

--- a/cmake/XIOUtilityTargets.cmake
+++ b/cmake/XIOUtilityTargets.cmake
@@ -98,9 +98,28 @@ else()
   )
 endif()
 
+# Codespell (code + docs spell-checking, like hipFile)
+find_program(CODESPELL codespell PATHS ENV PATH)
+
+if(CODESPELL)
+  add_custom_target(lint-codespell
+    COMMAND ${CODESPELL} ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Checking spelling with codespell"
+  )
+else()
+  add_custom_target(lint-codespell
+    COMMAND ${CMAKE_COMMAND} -E echo
+      "Error: codespell not found. Install with:"
+    COMMAND ${CMAKE_COMMAND} -E echo
+      "  pip install codespell"
+    COMMAND ${CMAKE_COMMAND} -E false
+  )
+endif()
+
 # Combined linting
 add_custom_target(lint-all
-  DEPENDS lint-format lint-spell
+  DEPENDS lint-format lint-spell lint-codespell
   COMMENT "Run all linting checks"
 )
 
@@ -108,6 +127,8 @@ add_custom_target(lint
   DEPENDS lint-format
   COMMENT "Run linting checks"
 )
+
+if(NOT XIO_DOCS_ONLY)
 
 # Assembly dump target
 find_program(OBJDUMP llvm-objdump PATHS
@@ -117,7 +138,8 @@ if(OBJDUMP)
   add_custom_target(asm
     COMMAND ${OBJDUMP} --demangle --disassemble-all
       $<TARGET_FILE:rocm-xio>
-    COMMAND ${CMAKE_COMMAND} -E echo "Use 'make asm | less -R' to view"
+    COMMAND ${CMAKE_COMMAND} -E echo
+      "Use 'make asm | less -R' to view"
     DEPENDS rocm-xio
     COMMENT "Dumping assembly of library"
   )
@@ -130,12 +152,16 @@ else()
 endif()
 
 # List supported GPUs
-find_program(CLANGXX clang++ PATHS /opt/rocm/llvm/bin ENV PATH)
+find_program(CLANGXX clang++ PATHS
+  /opt/rocm/llvm/bin ENV PATH)
 
 if(CLANGXX)
   add_custom_target(list
-    COMMAND ${CLANGXX} --target=amdgcn --print-supported-cpus 2>&1
-      | grep -E gfx[1-9] | sort -t'x' -k2,2n | sed 's/^[ \\t]*/  /'
+    COMMAND ${CLANGXX}
+      --target=amdgcn --print-supported-cpus 2>&1
+      | grep -E gfx[1-9]
+      | sort -t'x' -k2,2n
+      | sed 's/^[ \\t]*/  /'
     COMMENT "Listing supported GPUs"
   )
 else()
@@ -145,3 +171,5 @@ else()
     COMMAND ${CMAKE_COMMAND} -E false
   )
 endif()
+
+endif() # NOT XIO_DOCS_ONLY

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,0 +1,65 @@
+# Doxyfile for rocm-xio
+# Generated from docs/Doxyfile.in by CMake
+#
+# Doxygen generates XML consumed by Breathe; Sphinx
+# produces the final HTML output.
+
+PROJECT_NAME           = "@PROJECT_NAME@"
+PROJECT_NUMBER         = "@PROJECT_VERSION@"
+PROJECT_BRIEF          = "ROCm Library for GPU-Initiated IO"
+
+OUTPUT_DIRECTORY       = @XIO_DOC_PATH@
+INPUT                  = @XIO_DOXYFILE_INPUT@
+RECURSIVE              = YES
+FILE_PATTERNS          = *.h *.hip
+
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+
+# Exclude generated headers and external vendored headers
+EXCLUDE_PATTERNS       = */external/* \
+                         *-generated.h \
+                         *-gen.h
+
+# XML output for Breathe (Sphinx integration)
+GENERATE_HTML          = NO
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+
+# Warning settings
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_DOC_ERROR      = YES
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
+WARN_NO_PARAMDOC       = NO
+
+# Preprocessing (needed for HIP __host__/__device__)
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+PREDEFINED             = __host__= \
+                         __device__= \
+                         __global__= \
+                         __shared__= \
+                         __attribute__(x)= \
+                         __HIP_DEVICE_COMPILE__=0
+
+# Source browsing (available via Breathe)
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+
+# Diagrams
+HAVE_DOT               = NO
+
+# Sorting
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = YES
+
+# Miscellaneous
+OPTIMIZE_OUTPUT_FOR_C  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+SHOW_INCLUDE_FILES     = YES

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,162 @@
+API Reference
+=============
+
+This page documents the rocm-xio public C++ API, extracted from annotated
+source headers by Doxygen and rendered via Breathe.
+
+Core Framework
+--------------
+
+Base Classes
+^^^^^^^^^^^^
+
+.. doxygenclass:: xio::XioEndpoint
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::XioEndpointConfig
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::XioTimingStats
+   :members:
+   :undoc-members:
+
+Endpoint Registry
+^^^^^^^^^^^^^^^^^
+
+.. doxygenstruct:: EndpointInfo
+   :members:
+   :undoc-members:
+
+.. doxygenfunction:: xio::createEndpoint(EndpointType type)
+
+.. doxygenfunction:: xio::createEndpoint(const std::string &endpointName)
+
+Memory and Buffer Management
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenstruct:: xio::xioBufferInfo
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::xioQueueSetup
+   :members:
+   :undoc-members:
+
+.. doxygenfunction:: xio::allocateQueue
+
+.. doxygenfunction:: xio::freeQueue
+
+.. doxygenfunction:: xio::allocateGpuAccessibleBuffer
+
+.. doxygenfunction:: xio::freeGpuAccessibleBuffer
+
+.. doxygenfunction:: xio::setupQueueForGpu
+
+.. doxygenfunction:: xio::registerMemoryForGpu
+
+Doorbell and MMIO
+^^^^^^^^^^^^^^^^^
+
+.. doxygenstruct:: xio::pci_mmio_bridge_ring_meta
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::pci_mmio_bridge_command
+   :members:
+   :undoc-members:
+
+.. doxygenfunction:: xio::mapPciBar
+
+.. doxygenfunction:: xio::genPciMmioBridgeCmd
+
+Device Helpers
+^^^^^^^^^^^^^^
+
+.. doxygenfunction:: xio::printDeviceInfo
+
+.. doxygenfunction:: xio::checkKernelModuleLoaded
+
+.. doxygenfunction:: xio::loadKernelModule
+
+.. doxygenfunction:: xio::detectBdfFromDevice
+
+NVMe Endpoint
+-------------
+
+.. doxygenstruct:: xio::nvme_ep::nvmeEpConfig
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::nvme_ep::nvmeIoParams
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::nvme_ep::nvmeDoorbellParams
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::nvme_ep::nvmeBufferParams
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::nvme_ep::dataPatternParams
+   :members:
+   :undoc-members:
+
+RDMA Endpoint
+-------------
+
+.. doxygenstruct:: rdma_ep::RdmaEpConfig
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: rdma_wqe
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: rdma_cqe
+   :members:
+   :undoc-members:
+
+SDMA Endpoint
+-------------
+
+.. doxygenstruct:: sdma_ep::SdmaEpConfig
+   :members:
+   :undoc-members:
+
+Test Endpoint
+-------------
+
+.. doxygenstruct:: xio::test_ep::TestEpConfig
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::test_ep::test_sqe
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: xio::test_ep::test_cqe
+   :members:
+   :undoc-members:
+
+Kernel Module IOCTL Structures
+------------------------------
+
+.. doxygenstruct:: rocm_axiio_vram_req
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: rocm_axiio_register_queue_addr_req
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: rocm_axiio_register_buffer_req
+   :members:
+   :undoc-members:
+
+.. doxygenstruct:: rocm_axiio_mmio_bridge_shadow_req
+   :members:
+   :undoc-members:

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -1,0 +1,175 @@
+Building rocm-xio
+=================
+
+Dependencies
+------------
+
+.. code-block:: bash
+
+   sudo apt install rocm-hip-sdk rocminfo libcli11-dev cmake \
+     libdrm-dev libhsa-runtime-dev
+
+Quick Start
+-----------
+
+.. code-block:: bash
+
+   mkdir -p build
+   cmake -S . -B build
+   cmake --build build --target all
+
+Output locations:
+
+- Library: ``build/librocm-xio.a``
+- Tester: ``build/xio-tester``
+
+CMake Configuration Options
+----------------------------
+
+.. code-block:: bash
+
+   # Specify GPU architecture (auto-detected if not specified)
+   cmake -S . -B build -DOFFLOAD_ARCH=gfx942:xnack+
+
+   # Specify ROCm installation path (default: /opt/rocm)
+   cmake -S . -B build -DROCM_PATH=/opt/rocm-7.1.0
+
+   # Build documentation (Sphinx + Breathe + Doxygen)
+   cmake -S . -B build -DXIO_BUILD_DOCS=ON
+
+CMake Build Targets
+-------------------
+
+Primary targets
+^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   cmake --build build --target rocm-xio   # Library only
+   cmake --build build --target xio-tester  # Tester only
+   cmake --build build --target all         # Both (default)
+
+Code generation targets
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   cmake --build build --target endpoint-registry-generated
+   cmake --build build --target nvme-ep-generated
+   cmake --build build --target rdma-vendor-headers-generated
+   cmake --build build --target fetch-nvme-headers
+   cmake --build build --target fetch-rdma-headers
+   cmake --build build --target fetch-external-headers
+
+Utility targets
+^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   cmake --build build --target list           # Supported GPUs
+   cmake --build build --target asm            # Dump assembly
+   cmake --build build --target lint-format    # Check formatting
+   cmake --build build --target format         # Fix formatting
+   cmake --build build --target lint-spell     # Spell-check docs
+   cmake --build build --target lint-codespell # codespell check
+   cmake --build build --target lint-all       # All linting
+   cmake --build build --target doxygen        # Doxygen XML
+   cmake --build build --target sphinx-html    # Full HTML docs
+   cmake --build build --target clean-all      # Remove artifacts
+   cmake --build build --target clean-external # Remove headers
+
+Build Output Structure
+----------------------
+
+::
+
+   build/
+   ├── xio-tester              # Test application
+   ├── librocm-xio.a           # Static library
+   ├── docs/                   # (if XIO_BUILD_DOCS=ON)
+   │   ├── html/               # Sphinx HTML output
+   │   └── xml/                # Doxygen XML (intermediate)
+   └── CMakeFiles/
+
+Build System Details
+--------------------
+
+- **HIP compilation**: Uses ``hipcc`` with ``-fgpu-rdc`` for relocatable
+  device code
+- **Device code extraction**: Tester links with ``hipcc`` to extract device
+  code from the static library
+- **Code generation**: Automatic generation of the endpoint registry and
+  external headers
+- **GPU architecture detection**: Auto-detects via ``rocminfo`` or can be
+  specified via ``OFFLOAD_ARCH``
+
+Requirements
+^^^^^^^^^^^^
+
+- CMake 3.21 or later
+- ROCm HIP SDK
+- HSA runtime libraries
+- libdrm and libdrm_amdgpu development packages
+
+Installation
+------------
+
+Default location (typically ``/opt/rocm``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   cmake --install build
+
+Custom location
+^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   cmake --install build --prefix /tmp/rocm-xio-test
+
+   export CMAKE_PREFIX_PATH=/tmp/rocm-xio-test:$CMAKE_PREFIX_PATH
+   cd /tmp
+   cat > test-find-package.cmake << 'EOF'
+   cmake_minimum_required(VERSION 3.21)
+   project(test)
+   find_package(rocm-xio REQUIRED)
+   message(STATUS "Found rocm-xio: ${rocm-xio_VERSION}")
+   EOF
+   cmake -P test-find-package.cmake
+
+Install with tester
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   cmake -S . -B build -DINSTALL_TESTER=ON
+   cmake --install build --prefix /tmp/rocm-xio-test
+
+Install layout
+^^^^^^^^^^^^^^
+
+::
+
+   <prefix>/                         # /opt/rocm by default
+   ├── bin/
+   │   └── xio-tester                # (INSTALL_TESTER=ON only)
+   ├── include/rocm-xio/
+   │   ├── xio.h
+   │   ├── xio-endpoint-registry.h
+   │   └── endpoints/
+   │       ├── nvme-ep/
+   │       │   └── nvme-ep.h
+   │       ├── rdma-ep/
+   │       │   └── rdma-ep.h
+   │       ├── sdma-ep/
+   │       │   ├── sdma-ep.h
+   │       │   └── sdma_pkt_struct.h
+   │       └── test-ep/
+   │           └── test-ep.h
+   └── lib/
+       ├── librocm-xio.a
+       └── cmake/rocm-xio/
+           ├── rocm-xio-config.cmake
+           ├── rocm-xio-config-version.cmake
+           └── rocm-xio-targets.cmake

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,53 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""Sphinx configuration for rocm-xio documentation."""
+
+project = "rocm-xio"
+author = "Advanced Micro Devices, Inc."
+copyright = (
+    "2024-2026 Advanced Micro Devices, Inc. "
+    "All rights reserved."
+)
+
+version = "0.0.1"
+release = version
+
+# -- Extensions --------------------------------------------------
+
+extensions = [
+    "breathe",
+]
+
+# -- Breathe (Doxygen XML import) --------------------------------
+
+breathe_projects = {
+    "rocm-xio": "@BREATHE_DOC_XML_DIR@",
+}
+breathe_default_project = "rocm-xio"
+breathe_default_members = ("members",)
+
+# -- General -----------------------------------------------------
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+templates_path = []
+
+# Breathe cannot parse anonymous unions inside structs
+# (rdma_wqe, rdma_cqe). Suppress the resulting warnings.
+suppress_warnings = [
+    "cpp.duplicate_declaration",
+]
+
+# -- HTML output -------------------------------------------------
+
+html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "repository_url": (
+        "https://github.com/ROCm/rocm-xio"
+    ),
+    "use_repository_button": True,
+    "show_toc_level": 2,
+}
+html_title = f"rocm-xio {version}"
+html_static_path = []

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -1,0 +1,140 @@
+Endpoints
+=========
+
+Endpoints define hardware interfaces and protocols for different IO devices.
+Each endpoint provides its own queue entry formats and IO semantics.
+
+Listing Available Endpoints
+---------------------------
+
+.. code-block:: bash
+
+   ./build/xio-tester --list-endpoints
+
+test-ep -- Test Endpoint
+------------------------
+
+A software-only endpoint for validating the XIO framework. No hardware required.
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester test-ep --verbose
+
+nvme-ep -- NVMe Endpoint
+-------------------------
+
+Implements NVMe command submission (SQE) and completion (CQE) handling.
+Supports Read and Write commands with configurable IO patterns.
+
+.. code-block:: bash
+
+   export HSA_FORCE_FINE_GRAIN_PCIE=1
+   sudo ./build/xio-tester nvme-ep \
+     --controller /dev/nvme0 \
+     --read-io 50 --write-io 50 --verbose
+
+Key features:
+
+- Direct GPU-to-NVMe submission via memory-mapped queues
+- Sequential and pseudo-random LBA access patterns
+- Configurable queue depth, IO size, and iteration count
+
+rdma-ep -- RDMA Endpoint
+-------------------------
+
+GPU-Direct RDMA endpoint supporting four major vendors:
+
+===========  ====================================
+Vendor       Hardware
+===========  ====================================
+MLX5         Mellanox/NVIDIA ConnectX (IB/RoCE)
+BNXT_RE      Broadcom NetXtreme RDMA Engine
+IONIC        Pensando Ionic RDMA (SmartNIC)
+rocm-ernic   AMD Emulated RDMA NIC
+===========  ====================================
+
+Emulation mode:
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester rdma-ep
+
+Hardware mode:
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester rdma-ep --hardware
+
+All vendors support GPU-direct doorbell ringing using system-scope atomics. No
+HSA memory locking is needed (unlike NVMe, RDMA NICs support this pattern
+natively).
+
+sdma-ep -- SDMA Endpoint
+-------------------------
+
+GPU-initiated DMA transfers using AMD hardware SDMA engines. Based on the
+anvil library from AMD's RAD team.
+
+Hardware Requirements
+^^^^^^^^^^^^^^^^^^^^^
+
+- AMD Instinct datacenter GPUs
+- ROCm 6.0+ with hsakmt library
+- P2P mode: multi-GPU system with XGMI/Infinity Fabric
+- Single-GPU mode: use ``--to-host``
+
+Usage Examples
+^^^^^^^^^^^^^^
+
+Single-GPU (SDMA to pinned host memory):
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester sdma-ep \
+     --to-host -n 10 -v
+
+P2P (two GPUs, default GPU 0 to GPU 1):
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester sdma-ep -n 100 -v
+
+With data verification (LFSR pattern):
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester sdma-ep \
+     --to-host --verify -n 10 -v
+
+Larger transfer size:
+
+.. code-block:: bash
+
+   sudo ./build/xio-tester sdma-ep \
+     --to-host -n 8 -s 1048576 --verify
+
+Transfer size (``-s``) accepts bytes or suffixes: ``4k``, ``1M``, ``2G``.
+Suffixes are power-of-2 (KiB, MiB, GiB). Value must be a multiple of 4.
+
+Limitations
+^^^^^^^^^^^
+
+- Hardware-only (no emulation mode)
+- P2P requires at least two GPUs
+- Requires hsakmt (KFD kernel driver interface)
+
+Environment Variables
+---------------------
+
+On consumer Radeon GPUs (RX series), set the following before running any
+tests:
+
+.. code-block:: bash
+
+   export HSA_FORCE_FINE_GRAIN_PCIE=1
+
+This enables fine-grained memory coherence required for GPU-to-CPU memory
+visibility. Without it the GPU will encounter page faults when accessing host
+memory.
+
+On MI-series accelerators (MI300X, etc.) this is typically not required.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,66 @@
+rocm-xio: ROCm Library for GPU-Initiated IO
+============================================
+
+Introduction
+------------
+
+rocm-xio provides an API for Accelerator-Initiated IO (XIO) for AMD GPU
+``__device__`` code. It enables AMD GPUs to perform direct IO operations to
+hardware devices without CPU intervention.
+
+Supported Endpoints
+-------------------
+
+============  ==================  ================================
+Endpoint      Device              Description
+============  ==================  ================================
+``nvme-ep``   NVMe SSDs           NVMe command submission /
+                                  completion
+``rdma-ep``   RDMA NICs           GPU-Direct RDMA (4 vendors)
+``sdma-ep``   AMD SDMA engines    GPU-initiated DMA transfers
+``test-ep``   Software-only       Framework validation endpoint
+============  ==================  ================================
+
+Architecture
+------------
+
+All endpoints derive from the :cpp:class:`xio::XioEndpoint` base class and
+share a common :cpp:class:`xio::XioEndpointConfig` configuration structure.
+The endpoint registry allows runtime discovery and instantiation via
+``xio::createEndpoint()``.
+
+Quick Start
+-----------
+
+.. code-block:: bash
+
+   sudo apt install rocm-hip-sdk rocminfo \
+     libcli11-dev cmake libdrm-dev libhsa-runtime-dev
+   mkdir -p build
+   cmake -S . -B build
+   cmake --build build --target all
+
+   export HSA_FORCE_FINE_GRAIN_PCIE=1
+   sudo ./build/xio-tester nvme-ep \
+     --controller /dev/nvme0 \
+     --read-io 50 --write-io 50 --verbose
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   building
+   endpoints
+   kernel-module
+   memory-modes
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api
+
+License
+-------
+
+MIT License

--- a/docs/kernel-module.rst
+++ b/docs/kernel-module.rst
@@ -1,0 +1,42 @@
+Kernel Module
+=============
+
+The ``rocm-xio`` kernel module (``kernel/rocm-xio/``) provides low-level
+hardware access for queue registration and doorbell mapping. It uses the
+standard Linux kernel build system (Kbuild) and must be built separately from
+the CMake build.
+
+Building
+--------
+
+.. code-block:: bash
+
+   cd kernel/rocm-xio
+   make
+
+Installing
+----------
+
+.. code-block:: bash
+
+   sudo make install
+   sudo modprobe rocm-xio
+
+Device Node Setup
+-----------------
+
+After loading the module, create the device node:
+
+.. code-block:: bash
+
+   sudo mknod /dev/rocm-xio c \
+     $(grep rocm-xio /proc/devices | awk '{print $1}') 0
+   sudo chmod 666 /dev/rocm-xio
+
+Notes
+-----
+
+- The kernel module build is independent of the CMake build system and uses its
+  own Makefile following Linux kernel conventions.
+- The module must be loaded before running endpoints that require hardware queue
+  registration (e.g. ``nvme-ep``).

--- a/docs/memory-modes.rst
+++ b/docs/memory-modes.rst
@@ -1,0 +1,60 @@
+Memory Modes and Coherence
+==========================
+
+This page documents memory coherence considerations when using rocm-xio on
+different AMD GPU families.
+
+Fine-Grained vs. Coarse-Grained Memory
+---------------------------------------
+
+**Coarse-grained** memory means that a store to a memory location may only
+become visible to the CPU once the GPU kernel finishes. **Fine-grained** memory
+means stores are visible with system-level coherence (not just at kernel
+completion).
+
+On consumer Radeon GPUs, fine-grained PCIe memory is only available when the
+environment variable is set:
+
+.. code-block:: bash
+
+   export HSA_FORCE_FINE_GRAIN_PCIE=1
+
+On MI-series accelerators (MI300X, etc.) fine-grained memory is available by
+default.
+
+Host Memory Allocation
+----------------------
+
+``hipHostMalloc()`` comes in two flavours:
+
+1. **Pinned** -- pages are locked in physical memory. This is almost always
+   what rocm-xio needs because device access to an unmapped pageable page
+   triggers an XNACK and associated PTE updates, adding latency.
+2. **Pageable / migratable** -- useful for very large VMAs where device code
+   accesses memory randomly and sporadically.
+
+On MI300X the host allocation should be **UNCACHED**.
+
+Device-to-Host Visibility
+-------------------------
+
+If ``__device__`` code stores to host memory, the following are needed so a
+host CPU core can see the store:
+
+- ``hipHostMalloc()`` for the allocation
+- ``volatile`` qualification on the host-side pointer
+- ``__threadfence_system()`` on the device side
+
+Host-to-Device Visibility
+-------------------------
+
+If ``__host__`` code stores to host memory that a GPU core reads,
+``hipHostMalloc()`` alone is typically sufficient because it marks the memory as
+uncached, making CPU writes visible at the system level.
+
+Thread Fences
+-------------
+
+- ``__threadfence()`` -- sufficient on MI300X for intra-device ordering
+- ``__threadfence_system()`` -- needed on Radeon GPUs for cross-device
+  (GPU-to-CPU) ordering

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=7.0
+breathe>=4.35
+sphinx-book-theme>=1.0

--- a/scripts/build/generate-endpoint-files.sh
+++ b/scripts/build/generate-endpoint-files.sh
@@ -41,7 +41,7 @@ get_endpoint_define() {
 }
 
 # Helper function to get endpoint description (matches hardcoded values
-# in src/endpoints/common/axiio-endpoint.hip)
+# in src/endpoints/common/xio-endpoint.hip)
 get_endpoint_description() {
   local ep="$1"
   case "$ep" in

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -1128,7 +1128,7 @@ __host__ hipError_t run(XioEndpointConfig* config) {
   // Wait for GPU kernel to complete
   hipError_t err = hipDeviceSynchronize();
 
-  // Detect if an error occured
+  // Detect if an error occurred
   if (err != hipSuccess) {
     fprintf(stdout, "Info: Device synchronization error: %s (code: %d).\n",
             hipGetErrorString(err), err);

--- a/src/endpoints/rdma-ep/README.md
+++ b/src/endpoints/rdma-ep/README.md
@@ -44,7 +44,8 @@ make rdma-ep-tester
 
 ## Key Features
 
-- **rocSHMEM GDA Pattern**: Direct GPU doorbell writes using system-scope atomics
+- **rocSHMEM GDA Pattern**: Direct GPU doorbell writes using
+  system-scope atomics
 - **Vendor Abstraction**: Unified API across 4 different RDMA vendors
 - **Emulation Support**: Test without physical RDMA hardware
 - **GPU-Direct I/O**: Zero-copy, zero-CPU-overhead RDMA operations
@@ -61,11 +62,15 @@ __device__ void ring_mlx5_doorbell(volatile uint64_t* db, uint64_t val) {
 }
 ```
 
-No HSA memory locking needed! (Unlike NVMe, RDMA NICs support this pattern natively)
+No HSA memory locking needed! (Unlike NVMe, RDMA NICs support this pattern
+natively)
 
 ## Documentation
 
-See [`docs/RDMA_ENDPOINT_ARCHITECTURE.md`](../../docs/RDMA_ENDPOINT_ARCHITECTURE.md) for complete architecture documentation.
+See the [RDMA endpoint architecture][rdma-arch] docs for complete architecture
+documentation.
+
+[rdma-arch]: ../../docs/RDMA_ENDPOINT_ARCHITECTURE.md
 
 ## Reference Materials
 
@@ -91,4 +96,3 @@ test_rdma_vendor(RDMAVendor::MLX5, "MLX5", use_emulation);
 ## License
 
 MIT License
-

--- a/src/endpoints/sdma-ep/README.md
+++ b/src/endpoints/sdma-ep/README.md
@@ -4,22 +4,23 @@
 
 The SDMA (System DMA) endpoint enables GPU-initiated DMA transfers using
 AMD's hardware SDMA engines. SDMA engines are specialized DMA controllers
-on AMD GPUs that can perform memory-to-memory transfers, including
-peer-to-peer (P2P) GPU transfers, without CPU intervention.
+on AMD GPUs that can perform memory-to-memory transfers, including peer-to-peer
+(P2P) GPU transfers, without CPU intervention.
 
 ## Hardware Requirements
 
 - **AMD MI300X** or similar datacenter GPU with SDMA hardware support
 - **ROCm 6.0+** with hsakmt library support
 - **P2P mode**: Multi-GPU system and XGMI/Infinity Fabric for GPU-to-GPU
-- **Single-GPU mode** (`--to-host`): One GPU; destination is pinned host memory
+- **Single-GPU mode** (`--to-host`): One GPU; destination is pinned host
+  memory
 
 ## Implementation
 
-The sdma-ep implementation is based on the **anvil library** from AMD's RAD
-team (commit 6df07028). The anvil library provides low-level hardware queue
-management for SDMA engines via the hsakmt (HSA Kernel Mode Driver Thunk)
-interface.
+The sdma-ep implementation is based on the **anvil library** from AMD's
+RAD team (commit 6df07028). The anvil library provides low-level hardware
+queue management for SDMA engines via the hsakmt (HSA Kernel Mode Driver
+Thunk) interface.
 
 ### Components
 
@@ -28,8 +29,8 @@ interface.
 - **anvil.hpp / anvil.hip**: Host-side SDMA queue management and
   initialization
 - **anvil_device.hpp**: Device-side SDMA queue primitives for GPU kernels
-- **sdma_pkt_struct.h**: AMD SDMA packet structures and opcodes (source of
-  truth for hardware packet layout)
+- **sdma_pkt_struct.h**: AMD SDMA packet structures and opcodes (source
+  of truth for hardware packet layout)
 
 ### SDMA Operations
 
@@ -38,7 +39,7 @@ The anvil library provides device-side functions for SDMA operations:
 - `anvil::put(handle, dst, src, size)` - DMA copy operation
 - `anvil::signal(handle, signal_addr)` - Atomic signal increment
 - `anvil::putWithSignal(handle, dst, src, size, signal)` - Copy with
-completion signal
+  completion signal
 
 ## Usage
 
@@ -76,23 +77,24 @@ __global__ void myKernel(anvil::SdmaQueueDeviceHandle* handle) {
 ## Limitations
 
 - **Hardware-only**: Emulation mode is not supported. SDMA operations
-require real AMD GPU hardware with SDMA engines.
-- **P2P mode**: Requires at least two GPUs. Use `--to-host` for single-GPU
-testing (destination is pinned host memory).
-- **Privileged operations**: Requires hsakmt library which interfaces with
-the kernel driver (KFD).
+  require real AMD GPU hardware with SDMA engines.
+- **P2P mode**: Requires at least two GPUs. Use `--to-host` for
+  single-GPU testing (destination is pinned host memory).
+- **Privileged operations**: Requires hsakmt library which interfaces
+  with the kernel driver (KFD).
 
 ## Testing
 
 SDMA endpoint testing requires real hardware.
 
-**Transfer size:** Default is 4KB per iteration. Use `-s` / `--transfer-size`
-for larger moves. The value is in bytes; you can use a number or a suffix:
-`4k`, `1M`, `2G`. Suffixes are **power-of-2** (binary): k = 1024, M = 1024²,
-G = 1024³ (i.e. KiB, MiB, GiB), not SI (power-of-10). Value must be a multiple of 4.
+**Transfer size:** Default is 4KB per iteration. Use `-s` /
+`--transfer-size` for larger moves. The value is in bytes; you can use
+a number or a suffix: `4k`, `1M`, `2G`. Suffixes are **power-of-2** (binary):
+k = 1024, M = 1024², G = 1024³ (i.e. KiB, MiB, GiB), not SI (power-of-10).
+Value must be a multiple of 4.
 
-**Single-GPU (no P2P):** Use `--to-host` so the destination is pinned host
-memory. Only one GPU is required:
+**Single-GPU (no P2P):** Use `--to-host` so the destination is pinned
+host memory. Only one GPU is required:
 
 ```bash
 # Single GPU: SDMA from device to pinned host memory
@@ -105,9 +107,9 @@ sudo ./build/xio-tester sdma-ep --to-host --verify -n 10 -v
 sudo ./build/xio-tester sdma-ep --to-host -n 8 -s 1048576 --verify
 ```
 
-**P2P (two GPUs):** Default mode copies from GPU 0 to GPU 1. Use `--src-gpu`
-and `--dst-gpu` to choose HIP device IDs. Use `--verify` to validate the
-destination buffer after transfer:
+**P2P (two GPUs):** Default mode copies from GPU 0 to GPU 1. Use
+`--src-gpu` and `--dst-gpu` to choose HIP device IDs. Use `--verify`
+to validate the destination buffer after transfer:
 
 ```bash
 # Two GPUs: P2P transfer (default GPU 0 -> GPU 1)
@@ -123,10 +125,10 @@ sudo ./build/xio-tester sdma-ep --src-gpu 0 --dst-gpu 1 -n 100 -v
 sudo ./build/xio-tester sdma-ep --src-gpu 0 --dst-gpu 1 -n 8 -s 1048576 --verify
 ```
 
-The reference **shader_sdma** bench (RAD) sweeps transfer sizes from 1KB to
-1GB (`--minCopySize` / `--maxCopySize`, doubling each step). sdma-ep uses a
-single transfer size per run; use `-s` to test specific sizes (e.g. 4K
-default, 1M, 64M).
+The reference **shader_sdma** bench (RAD) sweeps transfer sizes from
+1KB to 1GB (`--minCopySize` / `--maxCopySize`, doubling each step). sdma-ep
+uses a single transfer size per run; use `-s` to test specific sizes (e.g.
+4K default, 1M, 64M).
 
 Note: The CI workflow does not test sdma-ep as it requires specific hardware
 and cannot run in emulation mode.
@@ -144,9 +146,10 @@ definitions and anvil device helpers could be added as test modes:
 - **Const fill**: Fill a buffer with a constant (SDMA_OP_CONST_FILL).
 - **Fence**: Ordering between operations (SDMA_OP_FENCE); anvil has
   `CreateFencePacket`.
-- **Signal-only**: Atomic increment on a completion counter (SDMA_OP_ATOMIC);
-  used today with putWithSignal.
-- **Write linear**: Write from embedded packet data (SDMA_OP_WRITE_LINEAR).
+- **Signal-only**: Atomic increment on a completion counter
+  (SDMA_OP_ATOMIC); used today with putWithSignal.
+- **Write linear**: Write from embedded packet data
+  (SDMA_OP_WRITE_LINEAR).
 
 ### Confirming XGMI traffic with counters
 
@@ -155,34 +158,33 @@ On P2P runs you can try to confirm data movement over XGMI by reading
 
 **1. AMD SMI**
 
-If [AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/) is
-installed (e.g. with ROCm):
+If [AMD SMI][amdsmi-docs] is installed (e.g. with ROCm):
 
 ```bash
 # XGMI metrics for all GPUs (read/write data per link)
 amd-smi xgmi -m -g all
 ```
 
-Sample once before and once after; the **delta** (after − before) is the
+Sample once before and once after; the **delta** (after - before) is the
 traffic in that interval. The XGMI traffic counters are **not resettable**
 (only XGMI *error* counts: `sudo amd-smi reset --xgmierr -g all`). If
-display is in **TB**, use a large run (e.g. `-n 1000 -s 100M` = 100 GB) to
-see a visible delta, or try `--json` / `--csv` for higher precision.
+display is in **TB**, use a large run (e.g. `-n 1000 -s 100M` = 100 GB)
+to see a visible delta, or try `--json` / `--csv` for higher precision.
 
 **If the counter does not increment:** On some systems and driver versions,
 the XGMI read/write values reported by amd-smi may **not** include SDMA P2P
 traffic (they can be tied to other engines or paths). So a non-incrementing
 counter does not prove that data is not moving over XGMI. In that case rely
-on: (1) **LFSR verification** (`--verify`) — confirms the correct data
-reached the destination; (2) **P2P topology** — `hipDeviceCanAccessPeer` and
-anvil’s use of the SDMA→XGMI path; (3) **timing** — sub-millisecond averages
-for large transfers are consistent with XGMI bandwidth, not host bounce.
+on: (1) **LFSR verification** (`--verify`) -- confirms the correct data
+reached the destination; (2) **P2P topology** --
+`hipDeviceCanAccessPeer` and anvil's use of the SDMA-to-XGMI path; (3)
+**timing** -- sub-millisecond averages for large transfers are consistent
+with XGMI bandwidth, not host bounce.
 
 **2. ROCm Systems Profiler (time series)**
 
-For a trace over time (e.g. to correlate with your run), use [ROCm Systems
-Profiler](https://rocm.docs.amd.com/projects/rocprofiler-systems/) with AMD
-SMI metrics:
+For a trace over time (e.g. to correlate with your run), use
+[ROCm Systems Profiler][rocprof-docs] with AMD SMI metrics:
 
 ```bash
 export ROCPROFSYS_USE_AMD_SMI=true
@@ -190,9 +192,9 @@ export ROCPROFSYS_AMD_SMI_METRICS=busy,temp,power,mem_usage,xgmi,pcie
 rocprof-sys-sample -- ./build/xio-tester sdma-ep -n 8 -s 1M --verify
 ```
 
-Open the generated Perfetto trace; the XGMI Read Data and XGMI Write Data
-tracks show traffic over time. Only available on multi-GPU systems with
-XGMI links; otherwise values are N/A.
+Open the generated Perfetto trace; the XGMI Read Data and XGMI Write
+Data tracks show traffic over time. Only available on multi-GPU systems
+with XGMI links; otherwise values are N/A.
 
 ## References
 
@@ -200,3 +202,6 @@ XGMI links; otherwise values are N/A.
 - ROCm hsakmt documentation
 - Anvil library (RAD team, commit 6df07028)
 - MI300X OAM topology documentation
+
+[amdsmi-docs]: https://rocm.docs.amd.com/projects/amdsmi/en/latest/
+[rocprof-docs]: https://rocm.docs.amd.com/projects/rocprofiler-systems/

--- a/src/endpoints/sdma-ep/anvil_device.hpp
+++ b/src/endpoints/sdma-ep/anvil_device.hpp
@@ -275,9 +275,9 @@ struct SdmaQueueDeviceHandle {
     __hip_atomic_store(wptr, pendingWptr, __ATOMIC_RELAXED,
                        __HIP_MEMORY_SCOPE_AGENT);
 
-    // Ensure all updates are visisble before ringing the doorbell
+    // Ensure all updates are visible before ringing the doorbell
     // This assumes we write to uncached memory
-    // Wait for all stores to be commited
+    // Wait for all stores to be committed
     __builtin_amdgcn_s_waitcnt(0);
     // This is nop on gfx942
     __builtin_amdgcn_wave_barrier();
@@ -378,9 +378,9 @@ struct SdmaQueueSingleProducerDeviceHandle : SdmaQueueDeviceHandle {
                                                uint64_t pendingWptr) {
     *wptr = (HSAuint64)pendingWptr;
 
-    // Ensure all updates are visisble before ringing the doorbell
+    // Ensure all updates are visible before ringing the doorbell
     // This assumes we write to uncached memory
-    // Wait for all stores to be commited
+    // Wait for all stores to be committed
     __builtin_amdgcn_s_waitcnt(0);
     // This is nop on gfx942
     __builtin_amdgcn_wave_barrier();

--- a/src/endpoints/sdma-ep/sdma-ep.hip
+++ b/src/endpoints/sdma-ep/sdma-ep.hip
@@ -238,9 +238,9 @@ __global__ void sdma_ping_pong_kernel(anvil::SdmaQueueDeviceHandle* handle,
 }
 
 // Kernel that sends data from rank0 to rank1
-// rank0 is re-using the same buffer for `transfers_per_iteration` iterations
+// rank0 is reusing the same buffer for `transfers_per_iteration` iterations
 // This kernel tests the different variations to determine that the source
-// buffer can be re-used
+// buffer can be reused
 __global__ void sdma_buffer_reuse_kernel(
   anvil::SdmaQueueDeviceHandle* handle, void* dstBuf, void* srcBuf,
   size_t nElem, unsigned iterations, uint64_t** signals, int rank,
@@ -311,7 +311,7 @@ __global__ void sdma_buffer_reuse_kernel(
             }
           }
         }
-        // Wait for buffer re-use
+        // Wait for buffer reuse
         if (threadIdx.x == 0) {
           if (use_counter) {
             anvil::waitCounter(counter, (i * transfers_per_iteration) + t + 1);

--- a/src/endpoints/test-ep/README.md
+++ b/src/endpoints/test-ep/README.md
@@ -2,4 +2,8 @@
 
 ## Introduction
 
-llvm-objdump-18 -st ../build/CMakeFiles/rocm-axiio-objects.dir/test-ep/test-ep.hip.o
+```bash
+llvm-objdump-18 -st \
+  ../build/CMakeFiles/rocm-xio-objects.dir/\
+test-ep/test-ep.hip.o
+```


### PR DESCRIPTION
Create a docs/ directory with structured reStructuredText (.rst) files extracted from the monolithic README (building, endpoints, kernel-module, memory-modes), following hipFile's convention.

Add Doxygen-based API doc generation via cmake/XIODocumentation.cmake with a XIO_BUILD_DOCS option and `make doc` target. Simplify the root README to a project overview with links into docs/.

Add codespell integration (.codespellrc, lint-codespell CMake target) alongside the existing pyspelling setup. Create a docs-check.yml GitHub workflow with three jobs: Doxygen build, codespell, and doc8 RST linting. Update spell-check.yml and .spellcheck.yml to cover docs/ RST sources.
