### PR TITLE
nvme-ep: Add write-verify tests and fix Identify Namespace validation

### DIFF
--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -99,10 +99,17 @@ setup_and_build_workdir "nvme-ep"
 echo "Building and loading kernel module on host..."
 build_and_load_kernel_module_on_host
 
-# Copy over test program
+# Copy over test program and verification script
 ${SSH_LOCALHOST} "mkdir -p ${WORKING_DIR}/build/"
 ${SCP_COMMAND} ${WORKING_DIR}/build/xio-tester \
   localhost:${WORKING_DIR}/build/xio-tester
+${SSH_LOCALHOST} \
+  "mkdir -p ${WORKING_DIR}/scripts/test/"
+VERIFY_SCRIPT="scripts/test"
+VERIFY_SCRIPT="${VERIFY_SCRIPT}/test-nvme-ep-random-write-verify.sh"
+${SCP_COMMAND} \
+  ${WORKING_DIR}/${VERIFY_SCRIPT} \
+  localhost:${WORKING_DIR}/${VERIFY_SCRIPT}
 
 # Run tests
 echo "=========================================="
@@ -144,6 +151,67 @@ sudo -E ${WORKING_DIR}/build/xio-tester nvme-ep \
 
 # Disable NVMe duration capture
 CAPTURE_NVME_DURATION=0
+
+sleep 3
+
+# Write-and-verify tests: write random LBAs via xio-tester,
+# then read each back with dd and verify the data pattern.
+echo ""
+echo "=========================================="
+echo "Running NVMe-EP write-verify tests"
+echo "=========================================="
+echo ""
+
+VERIFY_CMD="${WORKING_DIR}/${VERIFY_SCRIPT}"
+
+HAVE_VERIFY_DEPS=true
+if ! ${SSH_LOCALHOST} "command -v python3" \
+     > /dev/null 2>&1; then
+  echo "WARN: python3 not found on host;" \
+       "skipping write-verify tests"
+  HAVE_VERIFY_DEPS=false
+fi
+
+if [ "${HAVE_VERIFY_DEPS}" = "true" ]; then
+
+test_run "NVMe-EP write-verify memory-mode 0" \
+  "${SSH_LOCALHOST} \"export LD_LIBRARY_PATH=/opt/rocm/lib; \
+export HSA_FORCE_FINE_GRAIN_PCIE=1; \
+export XIO_TESTER=${WORKING_DIR}/build/xio-tester; \
+export NUM_WRITES=64; \
+export MEMORY_MODE=0; \
+export LFSR_SEED=0xDEAD; \
+export BASE_LBA=0; \
+export TEMP_DIR=${WORKING_DIR}/verify-m0; \
+sudo -E ${VERIFY_CMD} ${NON_ROOTFS_CTRL}\""
+
+sleep 3
+
+test_run "NVMe-EP write-verify memory-mode 3" \
+  "${SSH_LOCALHOST} \"export LD_LIBRARY_PATH=/opt/rocm/lib; \
+export HSA_FORCE_FINE_GRAIN_PCIE=1; \
+export XIO_TESTER=${WORKING_DIR}/build/xio-tester; \
+export NUM_WRITES=64; \
+export MEMORY_MODE=3; \
+export LFSR_SEED=0xBEEF; \
+export BASE_LBA=0; \
+export TEMP_DIR=${WORKING_DIR}/verify-m3; \
+sudo -E ${VERIFY_CMD} ${NON_ROOTFS_CTRL}\""
+
+sleep 3
+
+test_run "NVMe-EP write-verify memory-mode 11" \
+  "${SSH_LOCALHOST} \"export LD_LIBRARY_PATH=/opt/rocm/lib; \
+export HSA_FORCE_FINE_GRAIN_PCIE=1; \
+export XIO_TESTER=${WORKING_DIR}/build/xio-tester; \
+export NUM_WRITES=64; \
+export MEMORY_MODE=11; \
+export LFSR_SEED=0xCAFE; \
+export BASE_LBA=0; \
+export TEMP_DIR=${WORKING_DIR}/verify-m11; \
+sudo -E ${VERIFY_CMD} ${NON_ROOTFS_CTRL}\""
+
+fi # HAVE_VERIFY_DEPS
 
 # Report results and exit with appropriate code
 test_report "${NVME_NAMESPACE}"

--- a/scripts/test/test-nvme-ep-random-write-verify.sh
+++ b/scripts/test/test-nvme-ep-random-write-verify.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Write random LBAs via xio-tester nvme-ep, then read each
+# back with dd and verify the data matches the expected LFSR
+# pattern.
+#
+# The LFSR seed controls both the data pattern and the LBA
+# sequence (via getRandomLba in nvme-ep.hip).
+
+set -e
+
+NVME_DEVICE=""
+LFSR_SEED="${LFSR_SEED:-0x1234}"
+BASE_LBA="${BASE_LBA:-0}"
+NUM_WRITES="${NUM_WRITES:-64}"
+MEMORY_MODE="${MEMORY_MODE:-0}"
+QUEUE_LENGTH="${QUEUE_LENGTH:-128}"
+
+XIO_TESTER="${XIO_TESTER:-./build/xio-tester}"
+TEMP_DIR="${TEMP_DIR:-/tmp/nvme-ep-rw-verify}"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <nvme-controller>"
+    echo ""
+    echo "Environment variables:"
+    echo "  LFSR_SEED     Seed for pattern + LBA sequence"
+    echo "  BASE_LBA      Starting LBA (default: 0)"
+    echo "  NUM_WRITES    Number of writes (default: 64)"
+    echo "  MEMORY_MODE   Memory mode (default: 0)"
+    echo "  XIO_TESTER    Path to xio-tester binary"
+    exit 1
+fi
+
+NVME_DEVICE="$1"
+shift
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --seed|-s) LFSR_SEED="$2"; shift 2 ;;
+        --base-lba|-b) BASE_LBA="$2"; shift 2 ;;
+        --num-writes|-n) NUM_WRITES="$2"; shift 2 ;;
+        --help|-h)
+            echo "Usage: $0 <nvme-controller>"
+            echo "Options:"
+            echo "  --seed, -s        LFSR seed"
+            echo "  --base-lba, -b    Starting LBA"
+            echo "  --num-writes, -n  Number of writes"
+            exit 0 ;;
+        *) echo "Error: Unknown option $1"
+           exit 1 ;;
+    esac
+done
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: requires root"
+    exit 1
+fi
+
+if [ ! -e "$NVME_DEVICE" ]; then
+    echo "Error: $NVME_DEVICE not found"
+    exit 1
+fi
+
+if [ ! -f "$XIO_TESTER" ]; then
+    echo "Error: xio-tester not found at $XIO_TESTER"
+    exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "Error: python3 not found"
+    exit 1
+fi
+
+NS="${NVME_DEVICE}n1"
+if [ ! -e "$NS" ]; then
+    echo "Error: namespace $NS not found"
+    exit 1
+fi
+
+mkdir -p "$TEMP_DIR"
+
+LBA_SIZE=$(blockdev --getss "$NS")
+NS_BYTES=$(blockdev --getsize64 "$NS")
+NS_CAPACITY=$((NS_BYTES / LBA_SIZE))
+
+echo "========================================"
+echo "Random write-verify test"
+echo "========================================"
+echo "Controller:    $NVME_DEVICE"
+echo "Namespace:     $NS"
+echo "LFSR seed:     $LFSR_SEED"
+echo "Base LBA:      $BASE_LBA"
+echo "Num writes:    $NUM_WRITES"
+echo "Memory mode:   $MEMORY_MODE"
+echo "LBA size:      $LBA_SIZE bytes"
+echo "NS capacity:   $NS_CAPACITY LBAs"
+echo ""
+
+echo "Step 1: Writing $NUM_WRITES random LBAs..."
+write_cmd="$XIO_TESTER nvme-ep"
+write_cmd="$write_cmd --write-io -${NUM_WRITES}"
+write_cmd="$write_cmd --controller $NVME_DEVICE"
+write_cmd="$write_cmd --access-pattern random"
+write_cmd="$write_cmd --lbas-per-io 1"
+write_cmd="$write_cmd --lfsr-seed $LFSR_SEED"
+write_cmd="$write_cmd --base-lba $BASE_LBA"
+write_cmd="$write_cmd --queue-length $QUEUE_LENGTH"
+write_cmd="$write_cmd -m $MEMORY_MODE"
+
+echo "Command: $write_cmd"
+WRITE_LOG="$TEMP_DIR/write.log"
+if ! $write_cmd > "$WRITE_LOG" 2>&1; then
+    echo "Write FAILED - xio-tester output:"
+    cat "$WRITE_LOG"
+    exit 1
+fi
+
+echo "Write completed"
+echo ""
+
+echo "Step 2: Computing LBAs and verifying..."
+
+python3 << PYEOF
+import subprocess, sys, os
+
+lfsr_seed_str = '${LFSR_SEED}'
+if lfsr_seed_str.startswith('0x') or \
+   lfsr_seed_str.startswith('0X'):
+    lfsr_seed = int(lfsr_seed_str, 16)
+else:
+    lfsr_seed = int(lfsr_seed_str)
+
+num_writes = ${NUM_WRITES}
+base_lba = ${BASE_LBA}
+lba_size = ${LBA_SIZE}
+ns_capacity = ${NS_CAPACITY}
+ns_dev = '${NS}'
+temp_dir = '${TEMP_DIR}'
+
+
+def get_random_lba(op_index, cmd_id,
+                   lfsr_seed, base_lba,
+                   lba_range):
+    """Reproduces getRandomLba() from nvme-ep.hip."""
+    M64 = 0xFFFFFFFFFFFFFFFF
+    M32 = 0xFFFFFFFF
+    # cmd_id * 0x85ebca6b is uint32_t in C++
+    seed = (op_index * 0x9e3779b9
+            + ((cmd_id * 0x85ebca6b) & M32)
+            + lfsr_seed) & M64
+    seed = (seed ^ (seed >> 16)) & M64
+    seed = (seed * 0xc2b2ae35) & M64
+    seed = (seed ^ (seed >> 13)) & M64
+    seed = (seed * 0x9e3779b9) & M64
+    seed = (seed ^ (seed >> 16)) & M64
+    return base_lba + (seed % lba_range)
+
+
+def generate_expected_block(lba_size, lfsr_seed):
+    """Reproduces dataPattern() from nvme-ep.h.
+
+    In sequential mode buffer_offset=0 for all writes,
+    so offset=0 => lba=0, base_seed=0, seed=lfsr_seed.
+    """
+    M32 = 0xFFFFFFFF
+    pattern = bytearray(lba_size)
+    for j in range(lba_size):
+        rng = (lfsr_seed + j) & M32
+        rng ^= rng >> 16
+        rng = (rng * 0x85ebca6b) & M32
+        rng ^= rng >> 13
+        rng = (rng * 0xc2b2ae35) & M32
+        rng ^= rng >> 16
+        pattern[j] = rng & 0xFF
+    return bytes(pattern)
+
+
+# Compute which LBAs were written (de-duplicate)
+written_lbas = set()
+for i in range(num_writes):
+    cmd_id = (i % 65535) + 1
+    lba = get_random_lba(
+        i, cmd_id, lfsr_seed, base_lba, ns_capacity)
+    written_lbas.add(lba)
+
+unique_lbas = sorted(written_lbas)
+print(f"Unique LBAs written: {len(unique_lbas)}"
+      f" (from {num_writes} ops)")
+
+# Generate expected pattern (same for all LBAs)
+expected = generate_expected_block(lba_size, lfsr_seed)
+expected_file = os.path.join(temp_dir, "expected.bin")
+with open(expected_file, 'wb') as f:
+    f.write(expected)
+
+print(f"Expected pattern ({lba_size} bytes):"
+      f" first 8 = {expected[:8].hex()}")
+
+# Verify each LBA
+fail_count = 0
+ok_count = 0
+for lba in unique_lbas:
+    read_file = os.path.join(
+        temp_dir, f"lba_{lba}.bin")
+    rc = subprocess.run(
+        ['dd', f'if={ns_dev}',
+         f'bs={lba_size}', f'skip={lba}',
+         'count=1', f'of={read_file}'],
+        capture_output=True)
+    if rc.returncode != 0:
+        print(f"FAIL: dd read LBA {lba} failed:"
+              f" {rc.stderr.decode().strip()}")
+        fail_count += 1
+        continue
+
+    with open(read_file, 'rb') as f:
+        actual = f.read()
+
+    if actual != expected:
+        print(f"FAIL: LBA {lba} mismatch"
+              f" (got {len(actual)} bytes,"
+              f" first 8 = {actual[:8].hex()})")
+        fail_count += 1
+        if fail_count <= 3:
+            for j in range(min(len(actual),
+                               len(expected))):
+                if actual[j] != expected[j]:
+                    print(f"  first diff at byte {j}:"
+                          f" got 0x{actual[j]:02x}"
+                          f" expected"
+                          f" 0x{expected[j]:02x}")
+                    break
+    else:
+        ok_count += 1
+
+print(f"Results: {ok_count} OK, {fail_count} FAIL"
+      f" / {len(unique_lbas)} LBAs")
+
+if fail_count == 0:
+    print("All LBAs verified OK")
+    sys.exit(0)
+else:
+    print("Data verification FAILED")
+    sys.exit(1)
+PYEOF

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -1148,33 +1148,26 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
   int ret = 0;
   struct nvme_passthru_cmd cmd;
   struct nvme_id_ns* id_ns = nullptr;
-  uint8_t flbas = 0;
-  uint8_t lba_format_idx = 0;
-  uint8_t* lbaf_ptr = nullptr;
-  uint8_t lbads = 0;
-  uint16_t status = 0;
-  uint8_t* response_base = nullptr;
 
   if (!nvme_device || !lba_size) {
     return -EINVAL;
   }
 
-  // Allocate buffer for Identify Namespace response
   id_ns = static_cast<struct nvme_id_ns*>(malloc(nvme_ep::nvmeAdminRespSize));
   if (!id_ns) {
     return -ENOMEM;
   }
   memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
 
-  // Open NVMe device with retry (device may be temporarily busy)
   nvme_fd = openDeviceWithRetry(nvme_device, O_RDONLY, "NVMe device", 5, 100);
   if (nvme_fd < 0) {
     ret = -errno;
     goto cleanup;
   }
 
-  // Send Identify Namespace command (with retry for transient
-  // controller errors, e.g. after VRAM-backed queue teardown)
+  // Send Identify Namespace with retry for both status
+  // errors and invalid response data (e.g. lbads=0 from
+  // transient controller state after VRAM queue teardown)
   for (int attempt = 0; attempt < 5; attempt++) {
     memset(&cmd, 0, sizeof(cmd));
     cmd.opcode = nvme_admin_identify;
@@ -1182,7 +1175,7 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
     cmd.cdw10 = 0; // CNS=0 (Identify Namespace)
     cmd.addr = reinterpret_cast<uint64_t>(id_ns);
     cmd.data_len = nvme_ep::nvmeAdminRespSize;
-    cmd.timeout_ms = 0; // Use default timeout
+    cmd.timeout_ms = 0;
 
     ret = ioctlEintrSafe(nvme_fd, NVME_IOCTL_ADMIN_CMD, &cmd);
     if (ret < 0) {
@@ -1191,20 +1184,19 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
       goto cleanup;
     }
 
-    if (!(cmd.result & 0xFFFE)) {
-      break; // Success
-    }
-
-    status = (cmd.result >> 1) & 0xFF;
-    if (attempt < 4) {
-      int delay_ms = 100 * (1 << attempt);
-      fprintf(stdout,
-              "Identify Namespace returned status 0x%02x, "
-              "retrying in %d ms (attempt %d/5)...\n",
-              status, delay_ms, attempt + 1);
-      usleep(delay_ms * 1000);
-      memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
-    } else {
+    if (cmd.result & 0xFFFE) {
+      uint16_t status = (cmd.result >> 1) & 0xFF;
+      if (attempt < 4) {
+        int delay_ms = 100 * (1 << attempt);
+        fprintf(stdout,
+                "Identify Namespace returned status "
+                "0x%02x, retrying in %d ms "
+                "(attempt %d/5)...\n",
+                status, delay_ms, attempt + 1);
+        usleep(delay_ms * 1000);
+        memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
+        continue;
+      }
       fprintf(stdout,
               "Identify Namespace failed with status "
               "0x%02x after 5 attempts\n",
@@ -1212,30 +1204,64 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
       ret = -EIO;
       goto cleanup;
     }
-  }
 
-  // Extract FLBAS (Formatted LBA and Metadata Size)
-  flbas = id_ns->flbas;
-  lba_format_idx = flbas & 0x0F;
+    // Command succeeded -- validate response data
+    uint8_t flbas = id_ns->flbas;
+    uint8_t lba_format_idx = flbas & 0x0F;
 
-  // Validate LBA format index
-  if (lba_format_idx > id_ns->nlbaf) {
-    fprintf(stdout, "Invalid LBA format index %u (max supported: %u)\n",
-            lba_format_idx, id_ns->nlbaf);
-    ret = -EINVAL;
+    if (lba_format_idx > id_ns->nlbaf) {
+      if (attempt < 4) {
+        int delay_ms = 100 * (1 << attempt);
+        fprintf(stdout,
+                "Invalid LBA format index %u "
+                "(max %u), retrying in %d ms "
+                "(attempt %d/5)...\n",
+                lba_format_idx, id_ns->nlbaf, delay_ms, attempt + 1);
+        usleep(delay_ms * 1000);
+        memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
+        continue;
+      }
+      fprintf(stdout,
+              "Invalid LBA format index %u "
+              "(max supported: %u) after "
+              "5 attempts\n",
+              lba_format_idx, id_ns->nlbaf);
+      ret = -EINVAL;
+      goto cleanup;
+    }
+
+    uint8_t lbads = id_ns->lbaf[lba_format_idx].ds;
+
+    // NVMe spec mandates lbads >= 9 (512-byte minimum)
+    if (lbads < 9) {
+      if (attempt < 4) {
+        int delay_ms = 100 * (1 << attempt);
+        fprintf(stdout,
+                "Identify Namespace returned "
+                "lbads=%u (expected >= 9), "
+                "retrying in %d ms "
+                "(attempt %d/5)...\n",
+                lbads, delay_ms, attempt + 1);
+        usleep(delay_ms * 1000);
+        memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
+        continue;
+      }
+      fprintf(stdout,
+              "Identify Namespace returned invalid "
+              "lbads=%u after 5 attempts\n",
+              lbads);
+      ret = -EIO;
+      goto cleanup;
+    }
+
+    *lba_size = 1U << lbads;
+    fprintf(stdout, "Selected LBA size: %u bytes (lbads=%u)\n", *lba_size,
+            lbads);
+    ret = 0;
     goto cleanup;
   }
 
-  // Extract LBADS (LBA Data Size) from LBA Format structure
-  response_base = reinterpret_cast<uint8_t*>(id_ns);
-  lbaf_ptr = response_base + 128 + (lba_format_idx * 4);
-  lbads = lbaf_ptr[2] & 0xFF;
-
-  // LBA size = 2^LBADS bytes
-  *lba_size = 1U << lbads;
-  fprintf(stdout, "Selected LBA size: %u bytes (lbads=%u)\n", *lba_size, lbads);
-
-  ret = 0;
+  ret = -EIO;
 
 cleanup:
   if (nvme_fd >= 0) {
@@ -1253,28 +1279,26 @@ __host__ int queryNamespaceCapacity(const char* nvme_device, uint32_t nsid,
   int ret = 0;
   struct nvme_passthru_cmd cmd;
   struct nvme_id_ns* id_ns = nullptr;
-  uint16_t status = 0;
 
   if (!nvme_device || !capacity_lbas) {
     return -EINVAL;
   }
 
-  // Allocate buffer for Identify Namespace response
   id_ns = static_cast<struct nvme_id_ns*>(malloc(nvme_ep::nvmeAdminRespSize));
   if (!id_ns) {
     return -ENOMEM;
   }
   memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
 
-  // Open NVMe device with retry (device may be temporarily busy)
   nvme_fd = openDeviceWithRetry(nvme_device, O_RDONLY, "NVMe device", 5, 100);
   if (nvme_fd < 0) {
     ret = -errno;
     goto cleanup;
   }
 
-  // Send Identify Namespace command (with retry for transient
-  // controller errors, e.g. after VRAM-backed queue teardown)
+  // Send Identify Namespace with retry for both status
+  // errors and invalid response data (nsze=0 from
+  // transient controller state after VRAM queue teardown)
   for (int attempt = 0; attempt < 5; attempt++) {
     memset(&cmd, 0, sizeof(cmd));
     cmd.opcode = nvme_admin_identify;
@@ -1282,7 +1306,7 @@ __host__ int queryNamespaceCapacity(const char* nvme_device, uint32_t nsid,
     cmd.cdw10 = 0; // CNS=0 (Identify Namespace)
     cmd.addr = reinterpret_cast<uint64_t>(id_ns);
     cmd.data_len = nvme_ep::nvmeAdminRespSize;
-    cmd.timeout_ms = 0; // Use default timeout
+    cmd.timeout_ms = 0;
 
     ret = ioctlEintrSafe(nvme_fd, NVME_IOCTL_ADMIN_CMD, &cmd);
     if (ret < 0) {
@@ -1291,20 +1315,19 @@ __host__ int queryNamespaceCapacity(const char* nvme_device, uint32_t nsid,
       goto cleanup;
     }
 
-    if (!(cmd.result & 0xFFFE)) {
-      break; // Success
-    }
-
-    status = (cmd.result >> 1) & 0xFF;
-    if (attempt < 4) {
-      int delay_ms = 100 * (1 << attempt);
-      fprintf(stdout,
-              "Identify Namespace returned status 0x%02x, "
-              "retrying in %d ms (attempt %d/5)...\n",
-              status, delay_ms, attempt + 1);
-      usleep(delay_ms * 1000);
-      memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
-    } else {
+    if (cmd.result & 0xFFFE) {
+      uint16_t status = (cmd.result >> 1) & 0xFF;
+      if (attempt < 4) {
+        int delay_ms = 100 * (1 << attempt);
+        fprintf(stdout,
+                "Identify Namespace returned status "
+                "0x%02x, retrying in %d ms "
+                "(attempt %d/5)...\n",
+                status, delay_ms, attempt + 1);
+        usleep(delay_ms * 1000);
+        memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
+        continue;
+      }
       fprintf(stdout,
               "Identify Namespace failed with status "
               "0x%02x after 5 attempts\n",
@@ -1312,14 +1335,34 @@ __host__ int queryNamespaceCapacity(const char* nvme_device, uint32_t nsid,
       ret = -EIO;
       goto cleanup;
     }
+
+    // Command succeeded -- validate response data
+    if (id_ns->nsze == 0) {
+      if (attempt < 4) {
+        int delay_ms = 100 * (1 << attempt);
+        fprintf(stdout,
+                "Identify Namespace returned "
+                "nsze=0, retrying in %d ms "
+                "(attempt %d/5)...\n",
+                delay_ms, attempt + 1);
+        usleep(delay_ms * 1000);
+        memset(id_ns, 0, nvme_ep::nvmeAdminRespSize);
+        continue;
+      }
+      fprintf(stdout, "Identify Namespace returned "
+                      "nsze=0 after 5 attempts\n");
+      ret = -EIO;
+      goto cleanup;
+    }
+
+    *capacity_lbas = id_ns->nsze;
+    fprintf(stdout, "Namespace capacity: %llu LBAs\n",
+            (unsigned long long)*capacity_lbas);
+    ret = 0;
+    goto cleanup;
   }
 
-  // Extract NSZE (Namespace Size) - capacity in LBAs
-  *capacity_lbas = id_ns->nsze;
-  fprintf(stdout, "Namespace capacity: %llu LBAs\n",
-          (unsigned long long)*capacity_lbas);
-
-  ret = 0;
+  ret = -EIO;
 
 cleanup:
   if (nvme_fd >= 0) {


### PR DESCRIPTION
Add end-to-end write-verify tests that exercise the NVMe write path across memory modes 0, 3, and 11, then read back each LBA with dd and verify the data matches the expected LFSR pattern.

New test script (scripts/test/test-nvme-ep-random-write-verify.sh):
- Runs xio-tester with --write-io -64 (sequential mode, random access pattern) to write 64 random LBAs
- Embeds Python to reproduce getRandomLba() and dataPattern() algorithms, computing which LBAs were written and what data to expect
- Reads each LBA back via dd and compares against the expected LFSR pattern
- Uses blockdev for LBA size and namespace capacity (no nvme-cli dependency)

Updated sbatch (rocm-xio-tests.nvme-ep.sbatch):
- Copies the verification script to the host alongside xio-tester
- Adds three write-verify test_run blocks (memory modes 0, 3, 11) with distinct LFSR seeds (0xDEAD, 0xBEEF, 0xCAFE)
- Gracefully skips write-verify tests if python3 is unavailable

Fix queryLbaSize() and queryNamespaceCapacity() in nvme-ep.hip:
- Move response data validation inside the retry loop so corrupted Identify Namespace responses trigger a retry instead of being silently accepted
- queryLbaSize: reject lbads < 9 (NVMe spec mandates >= 512-byte LBAs); use id_ns->lbaf[idx].ds instead of raw byte offsets
- queryNamespaceCapacity: reject nsze == 0
- Both functions now retry with exponential backoff on invalid response data, addressing transient controller state after VRAM-backed queue teardown that previously returned lbads=0
