### PR TITLE
nvme-ep: Support multi-page I/O queues with CQR and PRP2

### DIFF
--- a/.alola/rocm-xio-tests.common
+++ b/.alola/rocm-xio-tests.common
@@ -33,6 +33,17 @@ elif [ -e "${PROJECT_DIR}/.alola/.env-setup.sh" ]; then
   exit 1
 fi
 
+# Display useful information about this slurm-based run
+display_job_info() {
+  echo "======================================================================"
+  echo "Job ID:   ${SLURM_JOB_ID}"
+  echo "Job Name: ${SLURM_JOB_NAME}"
+  echo "Node(s)   ${SLURM_NODELIST}"
+  echo "Working Directory: ${SLURM_SUBMIT_DIR}"
+  echo "Start Time:        $(date)"
+  echo "======================================================================"
+}
+
 # Detect GPU arch and set sdma_ep_allowed based on a SDMA whitelist.
 detect_gpu_arch() {
   ROCM_GPU_ARCH=$(/opt/rocm/bin/rocminfo | grep -m 1 -E gfx[^0]{1} | \
@@ -65,7 +76,10 @@ build_and_load_kernel_module_on_host() {
   ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && make clean"
   ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && make -j $(nproc)"
   ${SSH_LOCALHOST} "cd ${WORKING_DIR}/kernel/rocm-xio && sudo make install"
-  ${SSH_LOCALHOST} "sudo modprobe -r rocm-xio && sudo modprobe rocm-xio"
+  ${SSH_LOCALHOST} "sudo depmod -a"
+  ${SSH_LOCALHOST} "sudo modprobe -r rocm-xio || true"
+  ${SSH_LOCALHOST} "sudo insmod ${WORKING_DIR}/kernel/rocm-xio/rocm-xio.ko"
+  ${SSH_LOCALHOST} "lsmod | grep rocm_xio && modinfo rocm_xio | head -5"
 }
 
 unload_kernel_module_on_host() {

--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -39,6 +39,9 @@ trap cleanup EXIT
 # Initialize test tracking
 test_init
 
+# Display job information
+display_job_info
+
 echo "=========================================="
 echo "NVMe-EP Unit Test Script"
 echo "=========================================="

--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -31,6 +31,9 @@ THREADS=4
 DOORBELL=64
 DELAY=1000
 
+# Display job information
+display_job_info
+
 # Initialize test tracking
 test_init
 

--- a/.alola/rocm-xio-tests.two-gpu.sbatch
+++ b/.alola/rocm-xio-tests.two-gpu.sbatch
@@ -32,6 +32,9 @@ test_init
 ITERATIONS="${ITERATIONS:-128}"
 TRANSFER_SIZE="${TRANSFER_SIZE:-1048576}"
 
+# Display job information
+display_job_info
+
 cd "${PROJECT_DIR}"
 detect_gpu_arch
 if ! $sdma_ep_allowed; then

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ kernel/*/.tmp_versions/
 kernel/*/.*.cmd
 kernel/*/.module-common.o
 kernel/*/..module-common.o.cmd
+kernel/*/.*.o.d
 
 # Generated files
 src/include/xio-endpoint-registry-gen.h

--- a/kernel/rocm-xio/rocm-xio.c
+++ b/kernel/rocm-xio/rocm-xio.c
@@ -37,6 +37,7 @@
 #include <linux/io_uring.h>
 #include <linux/kernel.h>
 #include <linux/kprobes.h>
+#include <linux/kref.h>
 #include <linux/mm.h>
 #include <linux/module.h>
 #include <linux/nvme.h>
@@ -64,6 +65,9 @@ static struct kprobe nvme_kp = {
 
 /* Enable/disable injection (module parameter) */
 static bool inject_enabled = true;
+
+/* Forward declaration for kref_put release callback */
+static void contig_alloc_release(struct kref* ref);
 module_param(inject_enabled, bool, 0644);
 MODULE_PARM_DESC(inject_enabled,
                  "Enable automatic PRP injection for NVMe commands");
@@ -74,7 +78,8 @@ struct queue_addr_entry {
   __u64 phys_addr;
   __u64 size;
   __u8 queue_type; /* 0=SQ, 1=CQ */
-  __u16 nvme_bdf;  /* NVMe device BDF (0xBBDD format), 0 if unknown */
+  __u16 nvme_bdf;  /* NVMe device BDF (0xBBDD format) */
+  __u64 prp2;      /* PRP2 for PC=0 queues (0=none) */
   struct list_head list;
 };
 
@@ -97,6 +102,45 @@ static DEFINE_SPINLOCK(queue_addrs_lock);
 
 static LIST_HEAD(vram_buffers);
 static DEFINE_SPINLOCK(vram_buffers_lock);
+
+/* Contiguous DMA allocations for CQR=1 multi-page queues */
+struct contig_alloc_entry {
+  void* cpu_addr;
+  dma_addr_t dma_addr;
+  size_t size;
+  __u32 id;
+  struct pci_dev* pdev;
+  struct file* owner;
+  struct kref ref;
+  struct list_head list;
+};
+
+static LIST_HEAD(contig_allocs);
+static DEFINE_SPINLOCK(contig_allocs_lock);
+static __u32 contig_alloc_next_id = 1;
+
+static void contig_alloc_release(struct kref* ref) {
+  struct contig_alloc_entry* ca = container_of(ref, struct contig_alloc_entry,
+                                               ref);
+  dma_free_coherent(&ca->pdev->dev, ca->size, ca->cpu_addr, ca->dma_addr);
+  pci_dev_put(ca->pdev);
+  kfree(ca);
+}
+
+static void contig_vma_open(struct vm_area_struct* vma) {
+  struct contig_alloc_entry* ca = vma->vm_private_data;
+  kref_get(&ca->ref);
+}
+
+static void contig_vma_close(struct vm_area_struct* vma) {
+  struct contig_alloc_entry* ca = vma->vm_private_data;
+  kref_put(&ca->ref, contig_alloc_release);
+}
+
+static const struct vm_operations_struct contig_vm_ops = {
+  .open = contig_vma_open,
+  .close = contig_vma_close,
+};
 
 /* PCI MMIO bridge shadow buffer mapping */
 static __u64 mmio_bridge_shadow_gpa = 0;
@@ -641,6 +685,27 @@ static __u16 lookup_queue_bdf(__u64 virt_addr) {
 }
 
 /*
+ * Look up PRP2 value for queue (CREATE_SQ/CREATE_CQ with PC=0).
+ * Returns PRP2 if found, 0 otherwise.
+ */
+static __u64 lookup_queue_prp2(__u64 virt_addr) {
+  struct queue_addr_entry* entry;
+  __u64 prp2 = 0;
+
+  spin_lock(&queue_addrs_lock);
+  list_for_each_entry(entry, &queue_addrs, list) {
+    if (virt_addr >= entry->virt_addr &&
+        virt_addr < (entry->virt_addr + entry->size)) {
+      prp2 = entry->prp2;
+      break;
+    }
+  }
+  spin_unlock(&queue_addrs_lock);
+
+  return prp2;
+}
+
+/*
  * Look up physical address for data buffer (I/O commands).
  * First checks registered VRAM buffers, then falls back to virt_to_phys.
  */
@@ -750,12 +815,19 @@ static int nvme_submit_user_cmd_pre(struct kprobe* p, struct pt_regs* regs) {
     /* Look up physical address from registered queue addresses */
     phys_addr = lookup_queue_phys_addr(ubuffer);
     if (phys_addr) {
+      __u64 prp2_val;
+
       cmd->common.dptr.prp1 = cpu_to_le64(phys_addr);
-      pr_info("  ✅ Injected PRP1: 0x%016llx\n", (unsigned long long)phys_addr);
+      pr_info("  Injected PRP1: 0x%016llx\n", (unsigned long long)phys_addr);
+
+      prp2_val = lookup_queue_prp2(ubuffer);
+      if (prp2_val) {
+        cmd->common.dptr.prp2 = cpu_to_le64(prp2_val);
+        pr_info("  Injected PRP2: 0x%016llx\n", (unsigned long long)prp2_val);
+      }
     } else {
-      /* If not found, use ubuffer directly (assume it's already physical,
-       * as userspace may have gotten it via GET_VRAM_PHYS_ADDR) */
-      pr_info("rocm-axiio: Queue not registered, using ubuffer directly\n");
+      pr_info("rocm-axiio: Queue not registered, "
+              "using ubuffer directly\n");
       cmd->common.dptr.prp1 = cpu_to_le64(ubuffer);
     }
   }
@@ -894,6 +966,7 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
       entry->size = req.size;
       entry->queue_type = req.queue_type;
       entry->nvme_bdf = req.nvme_bdf;
+      entry->prp2 = req.prp2;
 
       spin_lock(&queue_addrs_lock);
       list_add(&entry->list, &queue_addrs);
@@ -1193,44 +1266,230 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
       return 0;
     }
 
+    case ROCM_XIO_ALLOC_CONTIG_QUEUE: {
+      struct rocm_xio_alloc_contig_req req;
+      struct contig_alloc_entry* ca;
+      struct pci_dev* pdev;
+      unsigned int bus, devfn;
+      void* cpu_addr;
+      dma_addr_t dma_addr;
+
+      if (copy_from_user(&req, (void __user*)arg, sizeof(req)))
+        return -EFAULT;
+
+      if (req.size == 0 || req.size > (16 * 1024 * 1024)) {
+        pr_err("rocm-axiio: contig alloc: invalid "
+               "size %llu\n",
+               (unsigned long long)req.size);
+        return -EINVAL;
+      }
+
+      bus = (req.nvme_bdf >> 8) & 0xFF;
+      devfn = req.nvme_bdf & 0xFF;
+      pdev = pci_get_domain_bus_and_slot(0, bus, devfn);
+      if (!pdev) {
+        char pci_addr[16];
+        format_bdf_as_pci_addr(req.nvme_bdf, pci_addr, sizeof(pci_addr));
+        pr_err("rocm-axiio: contig alloc: NVMe "
+               "device not found (%s)\n",
+               pci_addr);
+        return -ENODEV;
+      }
+
+      cpu_addr = dma_alloc_coherent(&pdev->dev, req.size, &dma_addr,
+                                    GFP_KERNEL);
+      if (!cpu_addr) {
+        pr_err("rocm-axiio: contig alloc: "
+               "dma_alloc_coherent failed for "
+               "%llu bytes\n",
+               (unsigned long long)req.size);
+        pci_dev_put(pdev);
+        return -ENOMEM;
+      }
+
+      memset(cpu_addr, 0, req.size);
+
+      ca = kmalloc(sizeof(*ca), GFP_KERNEL);
+      if (!ca) {
+        dma_free_coherent(&pdev->dev, req.size, cpu_addr, dma_addr);
+        pci_dev_put(pdev);
+        return -ENOMEM;
+      }
+
+      ca->cpu_addr = cpu_addr;
+      ca->dma_addr = dma_addr;
+      ca->size = req.size;
+      ca->pdev = pdev;
+      ca->owner = file;
+      kref_init(&ca->ref);
+
+      spin_lock(&contig_allocs_lock);
+      ca->id = contig_alloc_next_id++;
+      list_add(&ca->list, &contig_allocs);
+      spin_unlock(&contig_allocs_lock);
+
+      req.phys_addr = (__u64)dma_addr;
+      req.mmap_offset = ca->id;
+
+      {
+        char pci_addr[16];
+        format_bdf_as_pci_addr(req.nvme_bdf, pci_addr, sizeof(pci_addr));
+        pr_info("rocm-axiio: contig alloc: "
+                "size=%llu dma=0x%llx id=%u "
+                "(%s)\n",
+                (unsigned long long)req.size, (unsigned long long)dma_addr,
+                ca->id, pci_addr);
+      }
+
+      if (copy_to_user((void __user*)arg, &req, sizeof(req))) {
+        spin_lock(&contig_allocs_lock);
+        list_del(&ca->list);
+        spin_unlock(&contig_allocs_lock);
+        dma_free_coherent(&pdev->dev, req.size, cpu_addr, dma_addr);
+        pci_dev_put(pdev);
+        kfree(ca);
+        return -EFAULT;
+      }
+
+      return 0;
+    }
+
+    case ROCM_XIO_FREE_CONTIG_QUEUE: {
+      struct rocm_xio_free_contig_req req;
+      struct contig_alloc_entry *ca, *tmp;
+      bool found = false;
+
+      if (copy_from_user(&req, (void __user*)arg, sizeof(req)))
+        return -EFAULT;
+
+      spin_lock(&contig_allocs_lock);
+      list_for_each_entry_safe(ca, tmp, &contig_allocs, list) {
+        if (ca->id == req.mmap_offset && ca->owner == file) {
+          list_del(&ca->list);
+          found = true;
+          break;
+        }
+      }
+      spin_unlock(&contig_allocs_lock);
+
+      if (!found) {
+        pr_warn("rocm-axiio: contig free: id=%u "
+                "not found or not owned by caller\n",
+                req.mmap_offset);
+        return -ENOENT;
+      }
+
+      pr_info("rocm-axiio: contig free: id=%u "
+              "dma=0x%llx size=%zu\n",
+              ca->id, (unsigned long long)ca->dma_addr, ca->size);
+
+      kref_put(&ca->ref, contig_alloc_release);
+
+      return 0;
+    }
+
     default:
       return -ENOTTY;
   }
 }
 
-/* MMAP implementation for high-performance address translation */
+/* MMAP implementation: pgoff=0 -> MMIO bridge, pgoff>=1 -> contig queue */
 static int rocm_xio_mmap(struct file* file, struct vm_area_struct* vma) {
   unsigned long pfn;
+  unsigned long size;
   int ret;
 
-  mutex_lock(&mmio_bridge_lock);
+  if (vma->vm_pgoff == 0) {
+    /* Existing MMIO bridge shadow buffer path */
+    mutex_lock(&mmio_bridge_lock);
 
-  /* Check if shadow buffer is configured */
-  if (mmio_bridge_shadow_gpa == 0) {
+    if (mmio_bridge_shadow_gpa == 0) {
+      mutex_unlock(&mmio_bridge_lock);
+      pr_err("rocm-axiio: PCI MMIO bridge shadow "
+             "buffer not configured\n");
+      return -EINVAL;
+    }
+
+    pfn = mmio_bridge_shadow_gpa >> PAGE_SHIFT;
+
+    ret = remap_pfn_range(vma, vma->vm_start, pfn, mmio_bridge_shadow_size,
+                          vma->vm_page_prot);
+    if (ret < 0) {
+      mutex_unlock(&mmio_bridge_lock);
+      pr_err("rocm-axiio: Failed to remap shadow "
+             "buffer: %d\n",
+             ret);
+      return ret;
+    }
+
+    pr_info("rocm-axiio: Mapped MMIO bridge shadow: "
+            "GPA=0x%llx size=%llu vaddr=0x%lx\n",
+            (unsigned long long)mmio_bridge_shadow_gpa,
+            (unsigned long long)mmio_bridge_shadow_size, vma->vm_start);
+
     mutex_unlock(&mmio_bridge_lock);
-    pr_err("rocm-axiio: PCI MMIO bridge shadow buffer not configured\n");
-    return -EINVAL;
+    return 0;
   }
 
-  /* Map the shadow buffer physical address */
-  pfn = mmio_bridge_shadow_gpa >> PAGE_SHIFT;
+  /* pgoff >= 1: contiguous queue allocation mapping */
+  {
+    struct contig_alloc_entry* ca = NULL;
+    __u32 target_id = (__u32)vma->vm_pgoff;
+    bool found = false;
 
-  /* Remap the physical pages to userspace */
-  ret = remap_pfn_range(vma, vma->vm_start, pfn, mmio_bridge_shadow_size,
-                        vma->vm_page_prot);
-  if (ret < 0) {
-    mutex_unlock(&mmio_bridge_lock);
-    pr_err("rocm-axiio: Failed to remap shadow buffer: %d\n", ret);
-    return ret;
+    spin_lock(&contig_allocs_lock);
+    list_for_each_entry(ca, &contig_allocs, list) {
+      if (ca->id == target_id && ca->owner == vma->vm_file) {
+        /*
+         * Take a reference while still under the lock to
+         * protect against concurrent FREE_CONTIG_QUEUE
+         * dropping the last reference and freeing @ca.
+         */
+        kref_get(&ca->ref);
+        found = true;
+        break;
+      }
+    }
+    spin_unlock(&contig_allocs_lock);
+
+    if (!found) {
+      pr_err("rocm-axiio: contig mmap: id=%u "
+             "not found or not owned by mapping file\n",
+             target_id);
+      return -ENOENT;
+    }
+
+    size = vma->vm_end - vma->vm_start;
+    if (size > ca->size) {
+      pr_err("rocm-axiio: contig mmap: requested "
+             "size %lu > alloc size %zu\n",
+             size, ca->size);
+      kref_put(&ca->ref, contig_alloc_release);
+      return -EINVAL;
+    }
+
+    vma->vm_pgoff = 0;
+
+    ret = dma_mmap_coherent(&ca->pdev->dev, vma, ca->cpu_addr, ca->dma_addr,
+                            size);
+    if (ret < 0) {
+      pr_err("rocm-axiio: contig mmap: "
+             "dma_mmap_coherent failed: "
+             "%d\n",
+             ret);
+      kref_put(&ca->ref, contig_alloc_release);
+      return ret;
+    }
+
+    vma->vm_private_data = ca;
+    vma->vm_ops = &contig_vm_ops;
+
+    pr_info("rocm-axiio: contig mmap: id=%u "
+            "dma=0x%llx size=%lu vaddr=0x%lx\n",
+            target_id, (unsigned long long)ca->dma_addr, size, vma->vm_start);
+
+    return 0;
   }
-
-  pr_info("rocm-axiio: Mapped PCI MMIO bridge shadow buffer: GPA=0x%llx, "
-          "size=%llu, vaddr=0x%lx\n",
-          (unsigned long long)mmio_bridge_shadow_gpa,
-          (unsigned long long)mmio_bridge_shadow_size, vma->vm_start);
-
-  mutex_unlock(&mmio_bridge_lock);
-  return 0;
 }
 
 /* io_uring_cmd handler for high-performance async operations */
@@ -1250,12 +1509,38 @@ static int rocm_xio_uring_cmd(struct io_uring_cmd* ioucmd,
   return -ENOSYS;
 }
 
+static int rocm_xio_release(struct inode* inode, struct file* file) {
+  struct contig_alloc_entry *ca, *tmp;
+  LIST_HEAD(to_release);
+
+  spin_lock(&contig_allocs_lock);
+  list_for_each_entry_safe(ca, tmp, &contig_allocs, list) {
+    if (ca->owner == file) {
+      list_del(&ca->list);
+      list_add(&ca->list, &to_release);
+    }
+  }
+  spin_unlock(&contig_allocs_lock);
+
+  list_for_each_entry_safe(ca, tmp, &to_release, list) {
+    list_del(&ca->list);
+    pr_info("rocm-axiio: release: freeing "
+            "contig id=%u dma=0x%llx "
+            "size=%zu\n",
+            ca->id, (unsigned long long)ca->dma_addr, ca->size);
+    kref_put(&ca->ref, contig_alloc_release);
+  }
+
+  return 0;
+}
+
 /* File operations */
 static struct file_operations fops = {
   .owner = THIS_MODULE,
   .unlocked_ioctl = rocm_xio_ioctl,
   .mmap = rocm_xio_mmap,
-  .uring_cmd = rocm_xio_uring_cmd, /* For io_uring async operations */
+  .release = rocm_xio_release,
+  .uring_cmd = rocm_xio_uring_cmd,
 };
 
 static int __init rocm_xio_init(void) {
@@ -1339,6 +1624,27 @@ static void __exit rocm_xio_exit(void) {
     kfree(entry);
   }
   spin_unlock(&vram_buffers_lock);
+
+  /* Clean up contiguous DMA allocations */
+  {
+    struct contig_alloc_entry *ca, *ca_tmp;
+    LIST_HEAD(to_free);
+
+    spin_lock(&contig_allocs_lock);
+    list_for_each_entry_safe(ca, ca_tmp, &contig_allocs, list) {
+      list_del(&ca->list);
+      list_add(&ca->list, &to_free);
+    }
+    spin_unlock(&contig_allocs_lock);
+
+    list_for_each_entry_safe(ca, ca_tmp, &to_free, list) {
+      list_del(&ca->list);
+      pr_info("rocm-axiio: exit: freeing contig "
+              "id=%u dma=0x%llx size=%zu\n",
+              ca->id, (unsigned long long)ca->dma_addr, ca->size);
+      kref_put(&ca->ref, contig_alloc_release);
+    }
+  }
 
   device_destroy(rocm_xio_class, MKDEV(major_number, 0));
   class_destroy(rocm_xio_class);

--- a/kernel/rocm-xio/rocm-xio.h
+++ b/kernel/rocm-xio/rocm-xio.h
@@ -37,6 +37,10 @@
   _IOW(ROCM_XIO_IOC_MAGIC, 9, struct rocm_xio_unregister_buffer_req)
 #define ROCM_XIO_GET_MMIO_BRIDGE_SHADOW_BUFFER                                 \
   _IOWR(ROCM_XIO_IOC_MAGIC, 10, struct rocm_xio_mmio_bridge_shadow_req)
+#define ROCM_XIO_ALLOC_CONTIG_QUEUE                                            \
+  _IOWR(ROCM_XIO_IOC_MAGIC, 11, struct rocm_xio_alloc_contig_req)
+#define ROCM_XIO_FREE_CONTIG_QUEUE                                             \
+  _IOW(ROCM_XIO_IOC_MAGIC, 12, struct rocm_xio_free_contig_req)
 
 /* Flags for VRAM physical address request */
 #define ROCM_XIO_FLAG_EMULATED                                                 \
@@ -88,10 +92,11 @@ struct rocm_xio_bind_device_req {
 /* Register queue address for injection (explicit virt->phys mapping) */
 struct rocm_xio_register_queue_addr_req {
   __u64 virt_addr; /* Input: Virtual address (userspace pointer) */
-  __u64 phys_addr; /* Input: Physical address (from GET_VRAM_PHYS_ADDR) */
+  __u64 phys_addr; /* Input: Physical address (PRP1 for kprobe) */
   __u64 size;      /* Input: Queue size in bytes */
   __u8 queue_type; /* Input: 0=SQ, 1=CQ, 2=both */
-  __u16 nvme_bdf;  /* Input: NVMe device BDF (0xBBDD format), 0 if unknown */
+  __u16 nvme_bdf;  /* Input: NVMe device BDF (0xBBDD format) */
+  __u64 prp2;      /* Input: PRP2 value for PC=0 queues (0=none) */
 };
 
 /* Unregister queue address */
@@ -119,6 +124,19 @@ struct rocm_xio_mmio_bridge_shadow_req {
   __u16 bridge_bdf;  /* Input: PCI MMIO bridge BDF (0xBBDD format) */
   __u64 shadow_gpa;  /* Output: Shadow buffer Guest Physical Address */
   __u64 shadow_size; /* Output: Shadow buffer size in bytes */
+};
+
+/* Allocate physically contiguous queue memory via DMA API */
+struct rocm_xio_alloc_contig_req {
+  __u64 size;        /* Input: allocation size in bytes */
+  __u16 nvme_bdf;    /* Input: NVMe device BDF */
+  __u64 phys_addr;   /* Output: DMA/physical address */
+  __u32 mmap_offset; /* Output: page offset for mmap */
+};
+
+/* Free contiguous queue memory */
+struct rocm_xio_free_contig_req {
+  __u32 mmap_offset; /* Input: mmap_offset from alloc */
 };
 
 #endif /* ROCM_XIO_H */

--- a/scripts/build/extract-nvme-defines.sh
+++ b/scripts/build/extract-nvme-defines.sh
@@ -155,17 +155,21 @@ cat >> "$OUTPUT_FILE" << 'EOF'
  * Structure to hold queue creation results
  */
 struct nvme_queue_info {
-  void* sq_virt;     // Virtual address of submission queue (host pointer)
-  void* cq_virt;     // Virtual address of completion queue (host pointer)
-  void* sq_gpu;      // GPU-accessible pointer for submission queue
-  void* cq_gpu;      // GPU-accessible pointer for completion queue
-  uint64_t sq_phys;  // Physical address of submission queue
-  uint64_t cq_phys;  // Physical address of completion queue
-  uint64_t sq_size;  // Size of submission queue in bytes
-  uint64_t cq_size;  // Size of completion queue in bytes
-  uint64_t doorbell; // Physical address of doorbell register
-  int sq_dmabuf_fd;  // dmabuf file descriptor for SQ
-  int cq_dmabuf_fd;  // dmabuf file descriptor for CQ
+  void* sq_virt;          // Virtual address of SQ (host pointer)
+  void* cq_virt;          // Virtual address of CQ (host pointer)
+  void* sq_gpu;           // GPU-accessible pointer for SQ
+  void* cq_gpu;           // GPU-accessible pointer for CQ
+  uint64_t sq_phys;       // Physical address of SQ
+  uint64_t cq_phys;       // Physical address of CQ
+  uint64_t sq_size;       // Size of SQ in bytes
+  uint64_t cq_size;       // Size of CQ in bytes
+  uint64_t doorbell;      // Physical address of doorbell register
+  int sq_dmabuf_fd;       // dmabuf file descriptor for SQ
+  int cq_dmabuf_fd;       // dmabuf file descriptor for CQ
+  void* sq_prp_list;      // SQ PRP list buffer (for cleanup)
+  void* cq_prp_list;      // CQ PRP list buffer (for cleanup)
+  uint32_t sq_contig_id;  // SQ contiguous alloc ID (0=none)
+  uint32_t cq_contig_id;  // CQ contiguous alloc ID (0=none)
 };
 EOF
 

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -1027,6 +1027,53 @@ __host__ uint64_t getPhysAddr(void* virt_addr) {
   return phys_addr;
 }
 
+__host__ int getPagePhysAddrs(void* virt_addr, size_t size, uint64_t* phys_out,
+                              size_t max_pages) {
+  long page_sz_long = sysconf(_SC_PAGESIZE);
+  if (page_sz_long <= 0) {
+    return -EINVAL;
+  }
+  size_t page_sz = static_cast<size_t>(page_sz_long);
+  uintptr_t base = reinterpret_cast<uintptr_t>(virt_addr);
+  size_t num_pages = (size + page_sz - 1) / page_sz;
+
+  if (!virt_addr || size == 0 || !phys_out || num_pages > max_pages) {
+    return -EINVAL;
+  }
+
+  int fd = open("/proc/self/pagemap", O_RDONLY);
+  if (fd < 0)
+    return -errno;
+
+  for (size_t i = 0; i < num_pages; i++) {
+    uintptr_t page_va = base + i * page_sz;
+    uint64_t page_num = page_va / page_sz;
+    off_t off = page_num * sizeof(uint64_t);
+
+    if (lseek(fd, off, SEEK_SET) != static_cast<off_t>(off)) {
+      close(fd);
+      return -EIO;
+    }
+
+    uint64_t entry = 0;
+    if (read(fd, &entry, sizeof(entry)) != sizeof(entry)) {
+      close(fd);
+      return -EIO;
+    }
+
+    if (!(entry & (1ULL << 63))) {
+      close(fd);
+      return -EFAULT;
+    }
+
+    uint64_t pfn = entry & 0x7FFFFFFFFFFFFFULL;
+    phys_out[i] = pfn * page_sz;
+  }
+
+  close(fd);
+  return static_cast<int>(num_pages);
+}
+
 __host__ uint64_t getPhysAddr(void* buffer_ptr, size_t size, bool is_device,
                               uint16_t nvme_bdf,
                               const char* kernel_module_device,
@@ -1075,7 +1122,7 @@ __host__ uint64_t getPhysAddr(void* buffer_ptr, size_t size, bool is_device,
 
 __host__ int kmodRegQueue(int kmod_fd, void* virt_addr, uint64_t phys_addr,
                           size_t size, uint8_t queue_type, uint16_t nvme_bdf,
-                          const char* queue_name) {
+                          uint64_t prp2, const char* queue_name) {
   if (kmod_fd < 0 || !virt_addr || size == 0 || !queue_name) {
     return -EINVAL;
   }
@@ -1087,6 +1134,7 @@ __host__ int kmodRegQueue(int kmod_fd, void* virt_addr, uint64_t phys_addr,
   reg_req.size = size;
   reg_req.queue_type = queue_type;
   reg_req.nvme_bdf = nvme_bdf;
+  reg_req.prp2 = prp2;
 
   int ret = ioctl(kmod_fd, ROCM_XIO_REGISTER_QUEUE_ADDR, &reg_req);
   if (ret < 0) {
@@ -1250,6 +1298,145 @@ __host__ int setupQueueForGpu(size_t size, bool is_device, uint16_t nvme_bdf,
           "coherent=%d\n",
           queue_name, setup->virt, setup->gpu, (unsigned long long)setup->phys,
           setup->uses_coherent ? 1 : 0);
+
+  return 0;
+}
+
+__host__ int buildQueuePrpList(struct xioQueueSetup* setup, size_t queue_size,
+                               bool is_device, const char* queue_name) {
+  if (!setup || !setup->virt || queue_size == 0)
+    return -EINVAL;
+
+  long page_sz_long = sysconf(_SC_PAGESIZE);
+  if (page_sz_long <= 0) {
+    fprintf(stderr,
+            "ERROR: Failed to get system page size for queue %s; cannot build "
+            "PRP list\n",
+            queue_name);
+    return -EINVAL;
+  }
+  size_t page_sz = static_cast<size_t>(page_sz_long);
+  size_t num_pages = (queue_size + page_sz - 1) / page_sz;
+
+  setup->prp_list = nullptr;
+  setup->prp_list_phys = 0;
+  setup->prp2 = 0;
+
+  if (num_pages <= 1)
+    return 0;
+
+  // Ensure host queue memory is page-aligned before constructing a multi-page
+  // PRP list. If setup->virt came from a malloc-based fallback, it may not be
+  // aligned to the system page size, which would yield incorrect PRP entries.
+  if (!is_device) {
+    uintptr_t virt_addr = reinterpret_cast<uintptr_t>(setup->virt);
+    if ((virt_addr % page_sz) != 0) {
+      fprintf(stderr,
+              "ERROR: Queue %s virtual address %p is not page-aligned "
+              "(page size: %zu); cannot build PRP list\n",
+              queue_name, setup->virt, page_sz);
+      return -EINVAL;
+    }
+  }
+
+  if (is_device) {
+    fprintf(stderr,
+            "ERROR: PC=0 PRP list not supported "
+            "for device memory %s\n",
+            queue_name);
+    return -ENOTSUP;
+  }
+
+  const size_t max_pages = 1024;
+  uint64_t phys_addrs[max_pages];
+  int ret = getPagePhysAddrs(setup->virt, queue_size, phys_addrs, max_pages);
+  if (ret < 0) {
+    fprintf(stderr,
+            "ERROR: Failed to get page physical "
+            "addresses for %s: %s\n",
+            queue_name, strerror(-ret));
+    return ret;
+  }
+
+  fprintf(stdout,
+          "Info: %s spans %zu pages, building "
+          "PRP list (PC=0)\n",
+          queue_name, num_pages);
+  for (size_t i = 0; i < num_pages; i++) {
+    fprintf(stdout, "  page[%zu]: phys=0x%016llx\n", i,
+            (unsigned long long)phys_addrs[i]);
+  }
+
+  // PC=0 uses standard PRP semantics (NVMe spec 4.4):
+  // PRP1 = first page, PRP2 = second page (2 pages)
+  // or PRP2 = PRP list pointer (>2 pages).
+  if (num_pages == 2) {
+    setup->prp2 = phys_addrs[1];
+    fprintf(stdout,
+            "Info: %s PRP2 = 0x%016llx "
+            "(direct 2nd page)\n",
+            queue_name, (unsigned long long)setup->prp2);
+    return 0;
+  }
+
+  // >2 pages: build PRP list for pages 2..N
+  size_t prp_entries = num_pages - 1;
+  size_t prp_list_bytes = prp_entries * sizeof(uint64_t);
+
+  if (prp_list_bytes > page_sz) {
+    fprintf(stderr,
+            "ERROR: PRP list for %s requires "
+            "%zu bytes (max %zu). Reduce queue "
+            "size.\n",
+            queue_name, prp_list_bytes, page_sz);
+    return -E2BIG;
+  }
+
+  void* prp_list = nullptr;
+  int rc = posix_memalign(&prp_list, page_sz, page_sz);
+  if (rc != 0 || !prp_list) {
+    fprintf(stderr,
+            "ERROR: Failed to allocate PRP list "
+            "for %s\n",
+            queue_name);
+    return -ENOMEM;
+  }
+  memset(prp_list, 0, page_sz);
+
+  if (mlock(prp_list, page_sz) != 0) {
+    int err = errno;
+    fprintf(stderr,
+            "ERROR: mlock failed for PRP "
+            "list %s: %s\n",
+            queue_name, strerror(err));
+    free(prp_list);
+    return -err;
+  }
+
+  uint64_t* entries = reinterpret_cast<uint64_t*>(prp_list);
+  for (size_t i = 1; i < num_pages; i++) {
+    entries[i - 1] = phys_addrs[i];
+  }
+
+  uint64_t prp_list_phys = getPhysAddr(prp_list);
+  if (prp_list_phys == 0) {
+    fprintf(stderr,
+            "ERROR: Failed to get PRP list "
+            "physical address for %s\n",
+            queue_name);
+    munlock(prp_list, page_sz);
+    free(prp_list);
+    return -EIO;
+  }
+
+  setup->prp_list = prp_list;
+  setup->prp_list_phys = prp_list_phys;
+  setup->prp2 = prp_list_phys;
+
+  fprintf(stdout,
+          "Info: %s PRP list at virt=%p "
+          "phys=0x%016llx (%zu entries)\n",
+          queue_name, prp_list, (unsigned long long)prp_list_phys, prp_entries);
 
   return 0;
 }
@@ -1528,6 +1715,276 @@ __host__ int mapPciBar(uint16_t pci_bdf, uint8_t bar, void** bar_cpu,
   *bar_gpu = gpu_ptr;
 
   return 0;
+}
+
+__host__ int readNvmeCapCqr(uint16_t pci_bdf, bool* cqr_out) {
+  if (!cqr_out)
+    return -EINVAL;
+
+  uint8_t bus = (pci_bdf >> 8) & 0xFF;
+  uint8_t dev = (pci_bdf >> 3) & 0x1F;
+  uint8_t func = pci_bdf & 0x7;
+
+  char path[256];
+  snprintf(path, sizeof(path),
+           "/sys/bus/pci/devices/"
+           "0000:%02x:%02x.%x/resource0",
+           bus, dev, func);
+
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr,
+            "Warning: Cannot open %s to read "
+            "NVMe CAP register: %s\n",
+            path, strerror(errno));
+    return -errno;
+  }
+
+  long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0) {
+    // Fallback to a reasonable default page size if sysconf fails.
+    fprintf(stderr,
+            "Warning: sysconf(_SC_PAGESIZE) failed when reading "
+            "NVMe CAP register from %s: %s. Falling back to 4096.\n",
+            path, strerror(errno));
+    page_size = 4096;
+  }
+
+  size_t map_size = static_cast<size_t>(page_size);
+  void* mapped = mmap(nullptr, map_size, PROT_READ, MAP_SHARED, fd, 0);
+  if (mapped == MAP_FAILED) {
+    fprintf(stderr,
+            "Warning: Cannot mmap %s to read "
+            "NVMe CAP register: %s\n",
+            path, strerror(errno));
+    close(fd);
+    return -errno;
+  }
+
+  volatile uint32_t* regs = static_cast<volatile uint32_t*>(mapped);
+  uint64_t cap = static_cast<uint64_t>(regs[0]) |
+                 (static_cast<uint64_t>(regs[1]) << 32);
+
+  munmap(mapped, map_size);
+  close(fd);
+
+  *cqr_out = (cap >> 16) & 1;
+
+  fprintf(stdout,
+          "NVMe CAP register: CQR=%d "
+          "(%s queues %s)\n",
+          *cqr_out ? 1 : 0, *cqr_out ? "contiguous" : "non-contiguous",
+          *cqr_out ? "required" : "supported");
+
+  return 0;
+}
+
+__host__ int setupContigQueueForGpu(size_t size, uint16_t nvme_bdf,
+                                    const char* queue_name,
+                                    struct xioQueueSetup* setup,
+                                    const char* kernel_module_device) {
+  if (!setup || size == 0 || !queue_name)
+    return -EINVAL;
+
+  memset(setup, 0, sizeof(*setup));
+
+  const char* device_path = kernel_module_device ? kernel_module_device
+                                                 : ROCM_XIO_DEVICE_PATH;
+
+  int kmod_fd = openDeviceWithRetry(device_path, O_RDWR, "rocm-xio (contig)", 5,
+                                    100);
+  if (kmod_fd < 0) {
+    fprintf(stderr,
+            "Error: Cannot open kernel module "
+            "device %s for %s contig alloc\n",
+            device_path, queue_name);
+    return -EIO;
+  }
+
+  struct rocm_axiio_alloc_contig_req req;
+  memset(&req, 0, sizeof(req));
+  req.size = size;
+  req.nvme_bdf = nvme_bdf;
+
+  int ret = ioctl(kmod_fd, ROCM_XIO_ALLOC_CONTIG_QUEUE, &req);
+  if (ret < 0) {
+    fprintf(stderr,
+            "Error: ALLOC_CONTIG_QUEUE ioctl "
+            "failed for %s (%zu bytes): %s\n",
+            queue_name, size, strerror(errno));
+    close(kmod_fd);
+    return -errno;
+  }
+
+  fprintf(stdout,
+          "%s: contig alloc: phys=0x%llx "
+          "mmap_offset=%u size=%zu\n",
+          queue_name, (unsigned long long)req.phys_addr, req.mmap_offset, size);
+
+  static long page_sz = 0;
+  if (page_sz <= 0) {
+    long tmp = sysconf(_SC_PAGESIZE);
+    if (tmp <= 0) {
+      fprintf(stderr,
+              "Error: sysconf(_SC_PAGESIZE) failed for %s contig buffer: %s\n",
+              queue_name, strerror(errno));
+
+      struct rocm_axiio_free_contig_req freq;
+      memset(&freq, 0, sizeof(freq));
+      freq.mmap_offset = req.mmap_offset;
+      ioctl(kmod_fd, ROCM_XIO_FREE_CONTIG_QUEUE, &freq);
+      close(kmod_fd);
+
+      return (errno != 0) ? -errno : -1;
+    }
+    page_sz = tmp;
+  }
+
+  off_t mmap_off = (off_t)req.mmap_offset * page_sz;
+  void* mapped = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                      kmod_fd, mmap_off);
+
+  if (mapped == MAP_FAILED) {
+    fprintf(stderr,
+            "Error: mmap failed for %s contig "
+            "buffer: %s\n",
+            queue_name, strerror(errno));
+
+    struct rocm_axiio_free_contig_req freq;
+    memset(&freq, 0, sizeof(freq));
+    freq.mmap_offset = req.mmap_offset;
+    ioctl(kmod_fd, ROCM_XIO_FREE_CONTIG_QUEUE, &freq);
+    close(kmod_fd);
+
+    return -errno;
+  }
+
+  memset(mapped, 0, size);
+
+  fprintf(stdout, "%s: contig buffer mapped at %p\n", queue_name, mapped);
+
+  void* gpu_ptr = nullptr;
+  hipError_t hip_err = hipHostRegister(mapped, size, hipHostRegisterMapped);
+  if (hip_err == hipSuccess) {
+    hipError_t gp_err = hipHostGetDevicePointer(&gpu_ptr, mapped, 0);
+    if (gp_err != hipSuccess) {
+      fprintf(stdout,
+              "Warning: hipHostGetDevicePointer "
+              "failed for %s: %s\n",
+              queue_name, hipGetErrorString(gp_err));
+      (void)hipHostUnregister(mapped);
+      gpu_ptr = nullptr;
+    }
+  } else {
+    fprintf(stdout,
+            "Info: hipHostRegister failed for "
+            "%s (%s), trying "
+            "hsa_amd_memory_lock\n",
+            queue_name, hipGetErrorString(hip_err));
+  }
+
+  if (!gpu_ptr) {
+    struct rocm_axiio_free_contig_req free_req = {};
+    free_req.mmap_offset = req.mmap_offset;
+
+    hsa_status_t status = hsa_init();
+    if (status != HSA_STATUS_SUCCESS && status != (hsa_status_t)0x1001) {
+      fprintf(stderr,
+              "Error: hsa_init failed for %s: "
+              "%d\n",
+              queue_name, status);
+      munmap(mapped, size);
+      ioctl(kmod_fd, ROCM_XIO_FREE_CONTIG_QUEUE, &free_req);
+      close(kmod_fd);
+      return -EIO;
+    }
+
+    hsa_agent_t gpu_agent = {0};
+    hsa_iterate_agents(
+      [](hsa_agent_t agent, void* data) -> hsa_status_t {
+        hsa_device_type_t dev_type;
+        if (hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &dev_type) ==
+              HSA_STATUS_SUCCESS &&
+            dev_type == HSA_DEVICE_TYPE_GPU) {
+          *(hsa_agent_t*)data = agent;
+          return HSA_STATUS_INFO_BREAK;
+        }
+        return HSA_STATUS_SUCCESS;
+      },
+      &gpu_agent);
+
+    if (gpu_agent.handle == 0) {
+      fprintf(stderr,
+              "Error: No GPU agent found for "
+              "%s\n",
+              queue_name);
+      munmap(mapped, size);
+      ioctl(kmod_fd, ROCM_XIO_FREE_CONTIG_QUEUE, &free_req);
+      close(kmod_fd);
+      return -ENODEV;
+    }
+
+    status = hsa_amd_memory_lock(mapped, size, &gpu_agent, 1, &gpu_ptr);
+    if (status != HSA_STATUS_SUCCESS) {
+      fprintf(stderr,
+              "Error: hsa_amd_memory_lock "
+              "failed for %s: %d\n",
+              queue_name, status);
+      munmap(mapped, size);
+      ioctl(kmod_fd, ROCM_XIO_FREE_CONTIG_QUEUE, &free_req);
+      close(kmod_fd);
+      return -EIO;
+    }
+
+    fprintf(stdout,
+            "%s: registered via "
+            "hsa_amd_memory_lock\n",
+            queue_name);
+  }
+
+  fprintf(stdout, "%s: contig GPU ptr: %p (host: %p)\n", queue_name, gpu_ptr,
+          mapped);
+
+  setup->virt = mapped;
+  setup->gpu = gpu_ptr;
+  setup->phys = req.phys_addr;
+  setup->uses_coherent = false;
+  setup->prp_list = nullptr;
+  setup->prp_list_phys = 0;
+  setup->prp2 = 0;
+  setup->uses_contig = true;
+  setup->contig_id = req.mmap_offset;
+
+  if (kmod_fd >= 0) {
+    close(kmod_fd);
+  }
+
+  return 0;
+}
+
+__host__ void freeContigQueue(struct xioQueueSetup* setup, size_t size,
+                              const char* queue_name) {
+  if (!setup || !setup->uses_contig)
+    return;
+
+  (void)queue_name;
+
+  if (setup->gpu && setup->virt) {
+    hipError_t err = hipHostUnregister(setup->virt);
+    if (err != hipSuccess) {
+      hsa_amd_memory_unlock(setup->virt);
+    }
+  }
+
+  if (setup->virt) {
+    munmap(setup->virt, size);
+    setup->virt = nullptr;
+  }
+
+  setup->gpu = nullptr;
+  setup->phys = 0;
+  setup->uses_contig = false;
+  setup->contig_id = 0;
 }
 
 int ensureDeviceNode() {

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -277,30 +277,25 @@ __host__ int deleteQueue(int nvme_fd, uint16_t queue_id);
 extern "C" __host__ int nvme_ep_cleanup_queues(void* endpointConfig);
 
 /**
- * Send NVMe CREATE_CQ and CREATE_SQ commands to create queues
+ * Send NVMe CREATE_CQ and CREATE_SQ admin commands.
  *
- * Sends the NVMe admin commands to create both the Completion Queue (CQ) and
- * Submission Queue (SQ) for the specified queue ID. The CQ is created first,
- * then the SQ (which references the CQ).
+ * Creates both CQ and SQ for the specified queue ID.
+ * CQ is created first, then SQ (which references CQ).
+ * Physical addresses are injected by the kernel module
+ * kprobe, so virtual addresses are passed in the cmds.
  *
- * Physical addresses are injected by the kernel module kprobe, so virtual
- * addresses are passed in the commands.
- *
- * @param nvme_fd File descriptor for NVMe device (opened with open())
- * @param queue_id Queue ID to create (0=admin, 1+=IO queues)
- * @param queue_size Queue size in entries (must be power of 2)
- * @param sq_virt Virtual address of submission queue buffer
- * @param cq_virt Virtual address of completion queue buffer
- *
- * @return 0 on success, negative error code on failure
- *
- * @note This function sends the CREATE_CQ and CREATE_SQ admin commands via
- *       NVME_IOCTL_ADMIN_CMD. The kernel module kprobe will inject the
- *       physical addresses into the PRP1 fields automatically.
+ * @param nvme_fd File descriptor for NVMe device.
+ * @param queue_id Queue ID to create (1+ for IO).
+ * @param queue_size Queue size in entries (power of 2).
+ * @param sq_virt Virtual address of SQ buffer.
+ * @param cq_virt Virtual address of CQ buffer.
+ * @param sq_pc true for physically contiguous SQ.
+ * @param cq_pc true for physically contiguous CQ.
+ * @return 0 on success, negative error code on failure.
  */
 __host__ int createQueueCommands(int nvme_fd, uint16_t queue_id,
                                  uint16_t queue_size, void* sq_virt,
-                                 void* cq_virt);
+                                 void* cq_virt, bool sq_pc, bool cq_pc);
 
 /**
  * Read NVMe Submission Queue Entry (SQE) from memory
@@ -740,6 +735,7 @@ struct nvmeEpConfig {
   uint16_t queueId;       // Queue ID to use (0=admin, 1+=IO queues)
   uint16_t queueLength;   // Queue length in entries (must be power of 2)
   bool queuesCreated; // Flag indicating queues have been created (for cleanup)
+  struct nvme_queue_info queueInfo; // Queue info populated by createQueue()
 
   // Physical addresses (host-side only)
   uint64_t doorbellAddr; // Physical address of doorbell register
@@ -785,8 +781,8 @@ struct nvmeEpConfig {
   // validateConfig
   nvmeEpConfig()
     : controller(""), queueId(0), queueLength(64), queuesCreated(false),
-      doorbellAddr(0), sqBaseAddr(0), cqBaseAddr(0), sqSize(0), cqSize(0),
-      ioParams{"random", 512, 0, 0, 0, 0, 0, 1, 1, false},
+      queueInfo{}, doorbellAddr(0), sqBaseAddr(0), cqBaseAddr(0), sqSize(0),
+      cqSize(0), ioParams{"random", 512, 0, 0, 0, 0, 0, 1, 1, false},
       bufferParams{1024 * 1024},
       doorbellParams{false, 0x0020, 0x0030, nullptr, nullptr} {
   }

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -404,20 +404,14 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
       volatile sqeType* sqe_slot = &sqeAddr[sq_tail];
       nvme_ep::sqeWrite(sqeLocal, sqe_slot);
 
-      // Additional memory fence after write to ensure SQE is fully visible
-      // before incrementing tail and ringing doorbell
+      // Memory fence to ensure SQE is fully visible to
+      // the NVMe controller before incrementing tail and
+      // ringing the doorbell. On host memory paths this
+      // fence orders the GPU's PCIe writes but a
+      // read-back may still see stale write-combine data,
+      // so we do not verify here.
       __threadfence_system();
 
-      // Verify critical fields were written correctly (read-back check)
-      // This helps catch cases where the write didn't complete or was corrupted
-      volatile sqeType* verify_slot = sqe_slot;
-      if (verify_slot->opcode != sqeLocal.opcode ||
-          verify_slot->command_id != sqeLocal.command_id) {
-        // SQE write verification failed - trap to prevent corrupted command
-        __builtin_trap();
-      }
-
-      // Increment sq_tail after SQE is fully written and visible
       sq_tail = (sq_tail + 1) % ioParams.queueSize;
 
       // Ring doorbell
@@ -432,6 +426,13 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
 
       // Check completion status
       if (!nvme_ep::cqeOk(&cqe_new)) {
+        printf("NVMe CQE error: status=0x%04x "
+               "sc=0x%02x sct=0x%02x "
+               "cmd_id=%u sq_head=%u\n",
+               (unsigned)cqe_new.status,
+               (unsigned)nvme_ep::cqeStatusCode(&cqe_new),
+               (unsigned)nvme_ep::cqeStatusType(&cqe_new),
+               (unsigned)cqe_new.command_id, (unsigned)cqe_new.sq_head);
         __builtin_trap();
       }
 
@@ -903,6 +904,7 @@ __host__ hipError_t run(XioEndpointConfig* config) {
 
   // Mark queues as created for cleanup on SIGINT
   nvmeConfig->queuesCreated = true;
+  nvmeConfig->queueInfo = queue_info;
 
   // Update config with created queue addresses
   // Use GPU pointers for kernel launch (obtained via hipHostGetDevicePointer)
@@ -1641,7 +1643,7 @@ __host__ int deleteQueue(int nvme_fd, uint16_t queue_id) {
 
 __host__ int createQueueCommands(int nvme_fd, uint16_t queue_id,
                                  uint16_t queue_size, void* sq_virt,
-                                 void* cq_virt) {
+                                 void* cq_virt, bool sq_pc, bool cq_pc) {
   struct nvme_passthru_cmd cmd;
   int ret = 0;
 
@@ -1652,18 +1654,16 @@ __host__ int createQueueCommands(int nvme_fd, uint16_t queue_id,
   // Create Completion Queue first (CREATE_CQ)
   memset(&cmd, 0, sizeof(cmd));
   cmd.opcode = nvme_admin_create_cq;
-  cmd.nsid = 0;                                  // Admin commands use NSID 0
-  cmd.cdw10 = (queue_size - 1) << 16 | queue_id; // QSIZE | QID
-  cmd.cdw11 = 0x00000001; // PC=1 (physically contiguous), IEN=0, IV=0
-  // PRP1 will be injected by kprobe - pass virtual address as ubuffer
+  cmd.nsid = 0;
+  cmd.cdw10 = (queue_size - 1) << 16 | queue_id;
+  cmd.cdw11 = cq_pc ? 0x00000001 : 0x00000000;
   cmd.addr = reinterpret_cast<uint64_t>(cq_virt);
-  cmd.data_len = 0; // No data transfer for CREATE_CQ
+  cmd.data_len = 0;
 
-  // Debug: Print what we're sending to the controller
   fprintf(stdout,
-          "CREATE_CQ: queue_id=%u, queue_size=%u, cdw10=0x%08x "
-          "(QSIZE-1=0x%04x in bits 31:16, QID=0x%04x in bits 15:0)\n",
-          queue_id, queue_size, cmd.cdw10, (queue_size - 1), queue_id);
+          "CREATE_CQ: queue_id=%u, queue_size=%u, "
+          "cdw10=0x%08x, PC=%d\n",
+          queue_id, queue_size, cmd.cdw10, cq_pc ? 1 : 0);
 
   ret = ioctlEintrSafe(nvme_fd, NVME_IOCTL_ADMIN_CMD, &cmd);
   if (ret < 0) {
@@ -1720,20 +1720,16 @@ __host__ int createQueueCommands(int nvme_fd, uint16_t queue_id,
   // Create Submission Queue (CREATE_SQ)
   memset(&cmd, 0, sizeof(cmd));
   cmd.opcode = nvme_admin_create_sq;
-  cmd.nsid = 0;                                  // Admin commands use NSID 0
-  cmd.cdw10 = (queue_size - 1) << 16 | queue_id; // QSIZE | QID
-  cmd.cdw11 = (queue_id << 16) | 0x0001;         // CQID | QPRIO=0, PC=1
-  // PRP1 will be injected by kprobe - pass virtual address as ubuffer
+  cmd.nsid = 0;
+  cmd.cdw10 = (queue_size - 1) << 16 | queue_id;
+  cmd.cdw11 = (queue_id << 16) | (sq_pc ? 0x0001 : 0x0000);
   cmd.addr = reinterpret_cast<uint64_t>(sq_virt);
-  cmd.data_len = 0; // No data transfer for CREATE_SQ
+  cmd.data_len = 0;
 
-  // Debug: Print what we're sending to the controller
   fprintf(stdout,
-          "CREATE_SQ: queue_id=%u, queue_size=%u, cdw10=0x%08x "
-          "(QSIZE-1=0x%04x in bits 31:16, QID=0x%04x in bits 15:0), "
-          "cdw11=0x%08x (CQID=0x%04x in bits 31:16)\n",
-          queue_id, queue_size, cmd.cdw10, (queue_size - 1), queue_id,
-          cmd.cdw11, queue_id);
+          "CREATE_SQ: queue_id=%u, queue_size=%u, "
+          "cdw10=0x%08x, cdw11=0x%08x, PC=%d\n",
+          queue_id, queue_size, cmd.cdw10, cmd.cdw11, sq_pc ? 1 : 0);
 
   ret = ioctlEintrSafe(nvme_fd, NVME_IOCTL_ADMIN_CMD, &cmd);
   if (ret < 0) {
@@ -1773,6 +1769,40 @@ __host__ int createQueueCommands(int nvme_fd, uint16_t queue_id,
   return 0;
 }
 
+static void freeQueueSetup(struct xioQueueSetup* s, bool is_device,
+                           const char* name, size_t size = 0) {
+  if (!s || !s->virt)
+    return;
+  if (s->prp_list) {
+#ifndef __HIP_DEVICE_COMPILE__
+    long page_sz = sysconf(_SC_PAGESIZE);
+    if (page_sz > 0) {
+      int rc = munlock(s->prp_list, static_cast<size_t>(page_sz));
+      if (rc != 0) {
+        fprintf(stderr, "Warning: munlock failed for PRP list '%s': %s\n",
+                (name != nullptr) ? name : "unknown", strerror(errno));
+      }
+    } else {
+      fprintf(stderr,
+              "Warning: failed to get page size for munlock of PRP list '%s'\n",
+              (name != nullptr) ? name : "unknown");
+    }
+#endif // __HIP_DEVICE_COMPILE__
+    free(s->prp_list);
+    s->prp_list = nullptr;
+    s->prp_list_phys = 0;
+  }
+  if (s->uses_contig) {
+    freeContigQueue(s, size, name);
+  } else if (s->uses_coherent) {
+    (void)hipHostFree(s->virt);
+  } else {
+    freeQueue(s->virt, is_device, name);
+  }
+  s->virt = nullptr;
+  s->gpu = nullptr;
+}
+
 __host__ int createQueue(const char* nvme_device,
                          const char* kernel_module_device, uint16_t queue_id,
                          uint16_t queue_size, uint16_t nvme_bdf,
@@ -1785,44 +1815,41 @@ __host__ int createQueue(const char* nvme_device,
   bool sq_is_device = (memory_mode & XIO_MEM_MODE_SQ_DEVICE) != 0;
   bool cq_is_device = (memory_mode & XIO_MEM_MODE_CQ_DEVICE) != 0;
 
-  if (!nvme_device || !kernel_module_device || !info) {
+  if (!nvme_device || !kernel_module_device || !info)
     return -EINVAL;
-  }
 
-  // Validate queue_size is power of 2 and non-zero
-  if (queue_size == 0 || (queue_size & (queue_size - 1)) != 0) {
+  if (queue_size == 0 || (queue_size & (queue_size - 1)) != 0)
     return -EINVAL;
-  }
 
-  // Calculate queue sizes in bytes
   const size_t sq_size_bytes = queue_size * NVME_EP_SQE_SIZE;
   const size_t cq_size_bytes = queue_size * NVME_EP_CQE_SIZE;
 
-  // Zero-initialize output structure
   memset(info, 0, sizeof(*info));
   info->sq_size = sq_size_bytes;
   info->cq_size = cq_size_bytes;
 
-  // Open kernel module device
   kmod_fd = open(kernel_module_device, O_RDWR);
   if (kmod_fd < 0) {
-    fprintf(stdout, "Failed to open kernel module device %s: %s\n",
+    fprintf(stdout,
+            "Failed to open kernel module device "
+            "%s: %s\n",
             kernel_module_device, strerror(errno));
     return -errno;
   }
 
-  // Detect if NVMe device is emulated (QEMU) or a real
   bool is_emulated = false;
   int detect_ret = detectEmulatedNvme(nvme_device, &is_emulated);
   if (detect_ret != 0) {
-    fprintf(stderr, "Error: Failed to detect NVMe type for %s: %s.\n",
+    fprintf(stderr,
+            "Error: Failed to detect NVMe type "
+            "for %s: %s.\n",
             nvme_device, strerror(-detect_ret));
+    close(kmod_fd);
     return -detect_ret;
   }
   fprintf(stdout, "NVMe device %s detected as: %s.\n", nvme_device,
           is_emulated ? "EMULATED" : "REAL");
 
-  // Open NVMe device with retry (device may be temporarily busy)
   nvme_fd = openDeviceWithRetry(nvme_device, O_RDWR, "NVMe device", 5, 100);
   if (nvme_fd < 0) {
     fprintf(stderr, "Failed to open NVMe device %s: %s.\n", nvme_device,
@@ -1831,142 +1858,190 @@ __host__ int createQueue(const char* nvme_device,
     return -errno;
   }
 
-  // Setup SQ using unified helper
-  ret = setupQueueForGpu(sq_size_bytes, sq_is_device, nvme_bdf,
-                         kernel_module_device, is_emulated, "submission queue",
-                         &sq_setup);
-  if (ret < 0) {
-    goto cleanup;
+  // Read CQR before allocation so we can choose the
+  // right allocation path.
+  bool cqr = false;
+  {
+    int cqr_ret = readNvmeCapCqr(nvme_bdf, &cqr);
+    if (cqr_ret < 0) {
+      fprintf(stdout, "Warning: Could not read CQR, "
+                      "assuming contiguous required "
+                      "(PC=1).\n");
+      cqr = true;
+    }
   }
 
-  // Setup CQ using unified helper
-  ret = setupQueueForGpu(cq_size_bytes, cq_is_device, nvme_bdf,
-                         kernel_module_device, is_emulated, "completion queue",
-                         &cq_setup);
-  if (ret < 0) {
-    // Cleanup SQ setup
-    if (sq_setup.uses_coherent) {
-      (void)hipHostFree(sq_setup.virt);
-    } else {
-      freeQueue(sq_setup.virt, sq_is_device, "submission queue");
+  // HIP allocators (hipMalloc, hipHostMalloc) always return
+  // page-aligned memory, so size > NVME_PAGE_SIZE is sufficient
+  // to determine multi-page spanning.
+  bool sq_multi_page = !sq_is_device && sq_size_bytes > NVME_PAGE_SIZE;
+  bool cq_multi_page = !cq_is_device && cq_size_bytes > NVME_PAGE_SIZE;
+
+  // CQR=1 + multi-page: use contiguous DMA path
+  if (cqr && sq_multi_page) {
+    fprintf(stdout,
+            "CQR=1: using contiguous DMA for "
+            "submission queue (%zu bytes)\n",
+            sq_size_bytes);
+    ret = setupContigQueueForGpu(sq_size_bytes, nvme_bdf, "submission queue",
+                                 &sq_setup);
+    if (ret < 0) {
+      size_t max_sq = NVME_PAGE_SIZE / NVME_EP_SQE_SIZE;
+      fprintf(stderr,
+              "Error: Contiguous alloc failed for "
+              "SQ. Try --queue-length %zu or "
+              "smaller.\n",
+              max_sq);
+      goto cleanup;
     }
-    goto cleanup;
+  } else {
+    ret = setupQueueForGpu(sq_size_bytes, sq_is_device, nvme_bdf,
+                           kernel_module_device, is_emulated,
+                           "submission queue", &sq_setup);
+    if (ret < 0)
+      goto cleanup;
   }
 
-  // Register queue addresses with kernel module for kprobe injection
-  ret = kmodRegQueue(kmod_fd, sq_setup.virt, sq_setup.phys, sq_size_bytes, 0,
-                     nvme_bdf, "submission queue");
-  if (ret < 0) {
-    // Cleanup both setups
-    if (sq_setup.uses_coherent) {
-      (void)hipHostFree(sq_setup.virt);
-    } else {
-      freeQueue(sq_setup.virt, sq_is_device, "submission queue");
+  if (cqr && cq_multi_page) {
+    fprintf(stdout,
+            "CQR=1: using contiguous DMA for "
+            "completion queue (%zu bytes)\n",
+            cq_size_bytes);
+    ret = setupContigQueueForGpu(cq_size_bytes, nvme_bdf, "completion queue",
+                                 &cq_setup);
+    if (ret < 0) {
+      size_t max_cq = NVME_PAGE_SIZE / NVME_EP_CQE_SIZE;
+      fprintf(stderr,
+              "Error: Contiguous alloc failed for "
+              "CQ. Try --queue-length %zu or "
+              "smaller.\n",
+              max_cq);
+      freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                     sq_size_bytes);
+      goto cleanup;
     }
-    if (cq_setup.uses_coherent) {
-      (void)hipHostFree(cq_setup.virt);
-    } else {
-      freeQueue(cq_setup.virt, cq_is_device, "completion queue");
+  } else {
+    ret = setupQueueForGpu(cq_size_bytes, cq_is_device, nvme_bdf,
+                           kernel_module_device, is_emulated,
+                           "completion queue", &cq_setup);
+    if (ret < 0) {
+      freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                     sq_size_bytes);
+      goto cleanup;
     }
-    goto cleanup;
   }
 
-  ret = kmodRegQueue(kmod_fd, cq_setup.virt, cq_setup.phys, cq_size_bytes, 1,
-                     nvme_bdf, "completion queue");
-  if (ret < 0) {
-    // Cleanup both setups
-    if (sq_setup.uses_coherent) {
-      (void)hipHostFree(sq_setup.virt);
-    } else {
-      freeQueue(sq_setup.virt, sq_is_device, "submission queue");
+  // PC flags: contiguous allocs always use PC=1
+  {
+    bool sq_pc = cqr || !sq_multi_page;
+    bool cq_pc = cqr || !cq_multi_page;
+
+    fprintf(stdout,
+            "Queue PC flags: SQ PC=%d (%zu bytes, "
+            "%s%s), CQ PC=%d (%zu bytes, %s%s)\n",
+            sq_pc ? 1 : 0, sq_size_bytes, sq_is_device ? "device" : "host",
+            sq_setup.uses_contig ? ", contig" : "", cq_pc ? 1 : 0,
+            cq_size_bytes, cq_is_device ? "device" : "host",
+            cq_setup.uses_contig ? ", contig" : "");
+
+    // Build PRP lists for multi-page host queues
+    // (only when CQR=0 allows non-contiguous)
+    if (!cqr && sq_multi_page) {
+      ret = buildQueuePrpList(&sq_setup, sq_size_bytes, sq_is_device,
+                              "submission queue");
+      if (ret < 0) {
+        freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                       sq_size_bytes);
+        freeQueueSetup(&cq_setup, cq_is_device, "completion queue",
+                       cq_size_bytes);
+        goto cleanup;
+      }
     }
-    if (cq_setup.uses_coherent) {
-      (void)hipHostFree(cq_setup.virt);
-    } else {
-      freeQueue(cq_setup.virt, cq_is_device, "completion queue");
+    if (!cqr && cq_multi_page) {
+      ret = buildQueuePrpList(&cq_setup, cq_size_bytes, cq_is_device,
+                              "completion queue");
+      if (ret < 0) {
+        freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                       sq_size_bytes);
+        freeQueueSetup(&cq_setup, cq_is_device, "completion queue",
+                       cq_size_bytes);
+        goto cleanup;
+      }
     }
-    goto cleanup;
+
+    ret = kmodRegQueue(kmod_fd, sq_setup.virt, sq_setup.phys, sq_size_bytes, 0,
+                       nvme_bdf, sq_setup.prp2, "submission queue");
+    if (ret < 0) {
+      freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                     sq_size_bytes);
+      freeQueueSetup(&cq_setup, cq_is_device, "completion queue",
+                     cq_size_bytes);
+      goto cleanup;
+    }
+
+    ret = kmodRegQueue(kmod_fd, cq_setup.virt, cq_setup.phys, cq_size_bytes, 1,
+                       nvme_bdf, cq_setup.prp2, "completion queue");
+    if (ret < 0) {
+      freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                     sq_size_bytes);
+      freeQueueSetup(&cq_setup, cq_is_device, "completion queue",
+                     cq_size_bytes);
+      goto cleanup;
+    }
+
+    fprintf(stdout,
+            "Deleting existing queues (queue_id=%u) "
+            "if they exist...\n",
+            queue_id);
+    deleteQueue(nvme_fd, queue_id);
+    fprintf(stdout, "Queue deletion completed.\n");
+
+    fprintf(stdout, "Waiting 500ms before creating "
+                    "queues...\n");
+    usleep(500000);
+
+    fprintf(stdout,
+            "Creating NVMe queues (queue_id=%u, "
+            "queue_size=%u)...\n",
+            queue_id, queue_size);
+    ret = createQueueCommands(nvme_fd, queue_id, queue_size, sq_setup.virt,
+                              cq_setup.virt, sq_pc, cq_pc);
+    if (ret < 0) {
+      freeQueueSetup(&sq_setup, sq_is_device, "submission queue",
+                     sq_size_bytes);
+      freeQueueSetup(&cq_setup, cq_is_device, "completion queue",
+                     cq_size_bytes);
+      goto cleanup;
+    }
   }
 
-  // Delete existing queues if they exist
-  fprintf(stdout, "Deleting existing queues (queue_id=%u) if they exist...\n",
-          queue_id);
-  deleteQueue(nvme_fd, queue_id);
-  fprintf(stdout, "Queue deletion completed.\n");
-
-  // If controller was reset during deletion, wait a bit more before creating
-  // queues to ensure controller is fully ready
-  // Note: We can't easily detect reset from deleteQueue, but if DELETE_SQ
-  // timed out, we already waited. Add a small delay here as a safety measure.
-  fprintf(stdout, "Waiting 500ms before creating queues...\n");
-  usleep(500000); // 500ms delay
-
-  // Create queues via NVMe admin commands
-  fprintf(stdout, "Creating NVMe queues (queue_id=%u, queue_size=%u)...\n",
-          queue_id, queue_size);
-  ret = createQueueCommands(nvme_fd, queue_id, queue_size, sq_setup.virt,
-                            cq_setup.virt);
-  if (ret < 0) {
-    // Cleanup both setups
-    if (sq_setup.uses_coherent) {
-      (void)hipHostFree(sq_setup.virt);
-    } else {
-      freeQueue(sq_setup.virt, sq_is_device, "submission queue");
-    }
-    if (cq_setup.uses_coherent) {
-      (void)hipHostFree(cq_setup.virt);
-    } else {
-      freeQueue(cq_setup.virt, cq_is_device, "completion queue");
-    }
-    goto cleanup;
-  }
-
-  // Calculate doorbell address
-  // Doorbell base is typically at BAR0 + 0x1000
-  // SQ doorbell: DB_BASE + (2 * qid * doorbell_stride)
-  // For now, we'll set a placeholder - caller should get this from device info
-  info->doorbell = 0; // TODO: Get from device info
-
-  // Fill output structure
+  info->doorbell = 0;
   info->sq_virt = sq_setup.virt;
   info->cq_virt = cq_setup.virt;
-  info->sq_gpu = sq_setup.gpu; // GPU-accessible pointer for kernel launch
-  info->cq_gpu = cq_setup.gpu; // GPU-accessible pointer for kernel launch
+  info->sq_gpu = sq_setup.gpu;
+  info->cq_gpu = cq_setup.gpu;
   info->sq_phys = sq_setup.phys;
   info->cq_phys = cq_setup.phys;
-  info->sq_dmabuf_fd = -1; // Not currently used
-  info->cq_dmabuf_fd = -1; // Not currently used
+  info->sq_dmabuf_fd = -1;
+  info->cq_dmabuf_fd = -1;
+  info->sq_prp_list = sq_setup.prp_list;
+  info->cq_prp_list = cq_setup.prp_list;
+  info->sq_contig_id = sq_setup.contig_id;
+  info->cq_contig_id = cq_setup.contig_id;
 
   close(nvme_fd);
   close(kmod_fd);
   return 0;
 
 cleanup:
-  // Free queues - handle coherent allocation separately
-  if (sq_setup.virt) {
-    if (sq_setup.uses_coherent) {
-      // Free HIP coherent memory
-      (void)hipHostFree(sq_setup.virt);
-    } else {
-      // Free using standard free function
-      freeQueue(sq_setup.virt, sq_is_device, "submission queue");
-    }
-  }
-  if (cq_setup.virt) {
-    if (cq_setup.uses_coherent) {
-      // Free HIP coherent memory
-      (void)hipHostFree(cq_setup.virt);
-    } else {
-      // Free using standard free function
-      freeQueue(cq_setup.virt, cq_is_device, "completion queue");
-    }
-  }
-  if (nvme_fd >= 0) {
+  if (sq_setup.virt)
+    freeQueueSetup(&sq_setup, sq_is_device, "submission queue", sq_size_bytes);
+  if (cq_setup.virt)
+    freeQueueSetup(&cq_setup, cq_is_device, "completion queue", cq_size_bytes);
+  if (nvme_fd >= 0)
     close(nvme_fd);
-  }
-  if (kmod_fd >= 0) {
+  if (kmod_fd >= 0)
     close(kmod_fd);
-  }
   return ret;
 }
 
@@ -2015,6 +2090,62 @@ extern "C" __host__ int nvme_ep_cleanup_queues(void* endpointConfig) {
     fprintf(stderr, "Warning: Failed to delete NVMe queues: %s\n",
             strerror(-ret));
   }
+
+  // Host-side teardown of PRP lists and contiguous queue mappings.
+  // Idempotent: all pointers/IDs are cleared after use.
+#ifndef __HIP_DEVICE_COMPILE__
+  {
+    nvme_queue_info* qinfo = &nvmeConfig->queueInfo;
+    long page_sz = sysconf(_SC_PAGESIZE);
+
+    if (qinfo->sq_prp_list) {
+      if (page_sz > 0)
+        munlock(qinfo->sq_prp_list, static_cast<size_t>(page_sz));
+      free(qinfo->sq_prp_list);
+      qinfo->sq_prp_list = nullptr;
+    }
+    if (qinfo->cq_prp_list) {
+      if (page_sz > 0)
+        munlock(qinfo->cq_prp_list, static_cast<size_t>(page_sz));
+      free(qinfo->cq_prp_list);
+      qinfo->cq_prp_list = nullptr;
+    }
+
+    if (qinfo->sq_virt && qinfo->sq_contig_id) {
+      struct xioQueueSetup sq_setup = {};
+      sq_setup.virt = qinfo->sq_virt;
+      sq_setup.gpu = qinfo->sq_gpu;
+      sq_setup.phys = qinfo->sq_phys;
+      sq_setup.uses_contig = true;
+      sq_setup.contig_id = qinfo->sq_contig_id;
+      freeContigQueue(&sq_setup, qinfo->sq_size, "submission queue");
+      qinfo->sq_virt = nullptr;
+      qinfo->sq_gpu = nullptr;
+      qinfo->sq_contig_id = 0;
+    }
+    if (qinfo->cq_virt && qinfo->cq_contig_id) {
+      struct xioQueueSetup cq_setup = {};
+      cq_setup.virt = qinfo->cq_virt;
+      cq_setup.gpu = qinfo->cq_gpu;
+      cq_setup.phys = qinfo->cq_phys;
+      cq_setup.uses_contig = true;
+      cq_setup.contig_id = qinfo->cq_contig_id;
+      freeContigQueue(&cq_setup, qinfo->cq_size, "completion queue");
+      qinfo->cq_virt = nullptr;
+      qinfo->cq_gpu = nullptr;
+      qinfo->cq_contig_id = 0;
+    }
+
+    if (qinfo->sq_dmabuf_fd >= 0) {
+      close(qinfo->sq_dmabuf_fd);
+      qinfo->sq_dmabuf_fd = -1;
+    }
+    if (qinfo->cq_dmabuf_fd >= 0) {
+      close(qinfo->cq_dmabuf_fd);
+      qinfo->cq_dmabuf_fd = -1;
+    }
+  }
+#endif // __HIP_DEVICE_COMPILE__
 
   return ret;
 }

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -63,6 +63,7 @@ struct rocm_axiio_register_queue_addr_req {
   uint64_t size;
   uint8_t queue_type;
   uint16_t nvme_bdf;
+  uint64_t prp2;
 };
 
 struct rocm_axiio_register_buffer_req {
@@ -88,6 +89,22 @@ struct rocm_axiio_mmio_bridge_shadow_req {
   _IOW(ROCM_XIO_IOC_MAGIC, 8, struct rocm_axiio_register_buffer_req)
 #define ROCM_XIO_GET_MMIO_BRIDGE_SHADOW_BUFFER                                 \
   _IOWR(ROCM_XIO_IOC_MAGIC, 10, struct rocm_axiio_mmio_bridge_shadow_req)
+
+struct rocm_axiio_alloc_contig_req {
+  uint64_t size;
+  uint16_t nvme_bdf;
+  uint64_t phys_addr;
+  uint32_t mmap_offset;
+};
+
+struct rocm_axiio_free_contig_req {
+  uint32_t mmap_offset;
+};
+
+#define ROCM_XIO_ALLOC_CONTIG_QUEUE                                            \
+  _IOWR(ROCM_XIO_IOC_MAGIC, 11, struct rocm_axiio_alloc_contig_req)
+#define ROCM_XIO_FREE_CONTIG_QUEUE                                             \
+  _IOW(ROCM_XIO_IOC_MAGIC, 12, struct rocm_axiio_free_contig_req)
 
 // Memory mode flags (bits in memoryMode field)
 #define XIO_MEM_MODE_SQ_DEVICE 0x1
@@ -544,6 +561,21 @@ __host__ uint64_t getPhysAddr(void* buffer_ptr, size_t size, bool is_device,
                               bool is_emulated, const char* buffer_name);
 
 /**
+ * @brief Get physical addresses for each page of a buffer.
+ *
+ * Uses /proc/self/pagemap to resolve physical addresses.
+ * Only works for host memory; device memory uses DMA-BUF.
+ *
+ * @param virt_addr Page-aligned virtual address.
+ * @param size Size of the buffer in bytes.
+ * @param phys_out Output array for physical addresses.
+ * @param max_pages Maximum entries in phys_out.
+ * @return Number of pages on success, negative on failure.
+ */
+__host__ int getPagePhysAddrs(void* virt_addr, size_t size, uint64_t* phys_out,
+                              size_t max_pages);
+
+/**
  * @brief Register a queue address with the kernel module.
  *
  * Registers virtual and physical addresses for kprobe
@@ -555,11 +587,13 @@ __host__ uint64_t getPhysAddr(void* buffer_ptr, size_t size, bool is_device,
  * @param size Size of the queue in bytes.
  * @param queue_type 0 for SQ, 1 for CQ.
  * @param nvme_bdf NVMe controller BDF.
+ * @param prp2 PRP2 address for multi-page queues.
  * @param queue_name Name for logging.
  * @return 0 on success, negative error code on failure.
  */
 int kmodRegQueue(int kmod_fd, void* virt_addr, uint64_t phys_addr, size_t size,
-                 uint8_t queue_type, uint16_t nvme_bdf, const char* queue_name);
+                 uint8_t queue_type, uint16_t nvme_bdf, uint64_t prp2,
+                 const char* queue_name);
 
 /**
  * @brief Queue setup structure for unified initialization.
@@ -569,6 +603,11 @@ struct xioQueueSetup {
   void* gpu;
   uint64_t phys;
   bool uses_coherent;
+  void* prp_list;
+  uint64_t prp_list_phys;
+  uint64_t prp2;
+  bool uses_contig;
+  uint32_t contig_id;
 };
 
 /**
@@ -591,6 +630,57 @@ __host__ int setupQueueForGpu(size_t size, bool is_device, uint16_t nvme_bdf,
                               const char* kernel_module_device,
                               bool is_emulated, const char* queue_name,
                               struct xioQueueSetup* setup);
+
+/**
+ * @brief Build a PRP list for a multi-page queue (PC=0).
+ *
+ * For queues spanning >1 host memory page, resolves
+ * per-page physical addresses and builds a PRP list
+ * buffer. Sets setup->prp2, setup->prp_list, and
+ * setup->prp_list_phys. No-op for single-page queues.
+ *
+ * @param setup Queue setup (must have virt allocated).
+ * @param queue_size Queue size in bytes.
+ * @param is_device true for device memory.
+ * @param queue_name Name for logging.
+ * @return 0 on success, negative error code on failure.
+ */
+__host__ int buildQueuePrpList(struct xioQueueSetup* setup, size_t queue_size,
+                               bool is_device, const char* queue_name);
+
+/**
+ * @brief Allocate contiguous DMA memory via kernel module.
+ *
+ * Uses dma_alloc_coherent in the kernel module to obtain
+ * physically contiguous memory for CQR=1 controllers.
+ * Maps the result into userspace and registers with HIP
+ * for GPU access (same pattern as mapPciBar).
+ *
+ * @param size Queue size in bytes.
+ * @param nvme_bdf NVMe controller BDF (0xBBDD format).
+ * @param queue_name Name for logging.
+ * @param setup Output structure with pointers/handles.
+ * @param kernel_module_device Kernel module device path
+ *        (defaults to ROCM_XIO_DEVICE_PATH).
+ * @return 0 on success, negative error code on failure.
+ */
+__host__ int setupContigQueueForGpu(
+  size_t size, uint16_t nvme_bdf, const char* queue_name,
+  struct xioQueueSetup* setup,
+  const char* kernel_module_device = ROCM_XIO_DEVICE_PATH);
+
+/**
+ * @brief Free contiguous DMA queue memory.
+ *
+ * Unregisters from HIP, unmaps from userspace, and
+ * releases the kernel module allocation.
+ *
+ * @param setup Queue setup from setupContigQueueForGpu.
+ * @param size Queue size in bytes.
+ * @param queue_name Name for logging.
+ */
+__host__ void freeContigQueue(struct xioQueueSetup* setup, size_t size,
+                              const char* queue_name);
 
 /**
  * @brief Register memory with HIP for GPU access.
@@ -693,6 +783,19 @@ __host__ int registerMmioBridgeShadowBufferForGpu(void* shadow_virt,
  */
 __host__ int mapPciBar(uint16_t pci_bdf, uint8_t bar, void** bar_cpu,
                        void** bar_gpu, size_t bar_size);
+
+/**
+ * @brief Read the CQR bit from the NVMe CAP register.
+ *
+ * CQR (Contiguous Queues Required) indicates whether the
+ * controller requires physically contiguous I/O queues.
+ * Reads via sysfs BAR0 resource mmap.
+ *
+ * @param pci_bdf NVMe controller BDF (0xBBDD format).
+ * @param cqr_out Output: true if contiguous required.
+ * @return 0 on success, negative error code on failure.
+ */
+__host__ int readNvmeCapCqr(uint16_t pci_bdf, bool* cqr_out);
 
 /**
  * @brief Generate and submit a PCI MMIO bridge command.


### PR DESCRIPTION
NVMe controllers that set CQR=1 (Contiguous Queues Required) in the CAP register reject CREATE_SQ/CREATE_CQ when the queue buffer spans multiple non-contiguous host pages. Queues larger than one page were silently failing on real (non-emulated) hardware.

Fix this by reading the CQR bit at queue creation time and choosing the appropriate allocation strategy:

  - CQR=1 + multi-page: allocate physically contiguous memory via dma_alloc_coherent in the kernel module, exposed to userspace through new ALLOC_CONTIG_QUEUE / FREE_CONTIG_QUEUE ioctls and an extended mmap path (pgoff >= 1).

  - CQR=0 + multi-page: keep the existing host-memory allocation but build a PRP list so the controller can walk the non-contiguous pages. PRP2 is injected alongside PRP1 through the existing kprobe mechanism.

  - Single-page queues are unchanged (always PC=1, no PRP2).

Supporting changes:

  - Add getPagePhysAddrs() to resolve per-page physical addresses via /proc/self/pagemap for PRP list construction.
  - Add readNvmeCapCqr() to read the CQR bit from BAR0 via sysfs.
  - Extend xioQueueSetup and nvme_queue_info with PRP list and contiguous-alloc tracking fields.
  - Pass sq_pc / cq_pc flags through to createQueueCommands() so the PC bit in CDW11 matches the allocation strategy.
  - Replace the SQE read-back verification with a __threadfence_system() comment, since read-back on write-combine memory can return stale data.
  - Print NVMe CQE error details (status, SC, SCT) before trapping on completion errors to aid debugging.
  - Consolidate queue cleanup into freeQueueSetup() helper.
