### PR TITLE
build: add CMake DKMS targets for bnxt_re kernel module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,9 +223,9 @@ if(GDA_BNXT OR GDA_IONIC OR GDA_ERNIC)
 endif()
 
 # Vendor kernel module (DKMS) targets
-# BNXT kernel module is managed via standalone
-# setup script (kernel/bnxt/setup-bnxt-dv-dkms.sh)
-# without a CMake module.
+if(GDA_BNXT)
+  include(XIOBnxtKernelModule)
+endif()
 if(GDA_IONIC)
   include(XIOIonicKernelModule)
 endif()

--- a/cmake/XIOBnxtKernelModule.cmake
+++ b/cmake/XIOBnxtKernelModule.cmake
@@ -1,0 +1,51 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# XIOBnxtKernelModule.cmake
+#
+# Builds the bnxt_re.ko RDMA kernel module with
+# v11 uapi-extension patches via DKMS. Driver
+# source is downloaded from kernel.org and patched
+# by the setup script.
+#
+# Included from the top-level CMakeLists.txt
+# when GDA_BNXT=ON.
+
+option(BNXT_BUILD_KMOD
+  "Setup bnxt_re DKMS module" OFF)
+
+set(BNXT_DKMS_SETUP_SCRIPT
+  "${CMAKE_SOURCE_DIR}/kernel/bnxt/setup-bnxt-re-dkms.sh")
+
+if(BNXT_BUILD_KMOD)
+  message(STATUS
+    "bnxt: DKMS kmod targets enabled"
+    " (kernel/bnxt/setup-bnxt-re-dkms.sh)")
+
+  add_custom_target(build-bnxt-re-dkms
+    COMMAND ${BNXT_DKMS_SETUP_SCRIPT}
+      --build-only
+    COMMENT
+      "Building bnxt_re DKMS module"
+      " (no install)"
+    VERBATIM
+  )
+
+  add_custom_target(install-bnxt-re-dkms
+    COMMAND ${BNXT_DKMS_SETUP_SCRIPT}
+    COMMENT
+      "Building and installing bnxt_re"
+      " DKMS module"
+    VERBATIM
+  )
+
+  add_custom_target(remove-bnxt-re-dkms
+    COMMAND ${BNXT_DKMS_SETUP_SCRIPT}
+      --uninstall
+    COMMENT
+      "Removing bnxt_re DKMS module"
+    VERBATIM
+  )
+endif()


### PR DESCRIPTION
Add cmake/XIOBnxtKernelModule.cmake following the existing Ionic and ERNIC pattern. The new module wraps
kernel/bnxt/setup-bnxt-re-dkms.sh and exposes three targets gated behind -DBNXT_BUILD_KMOD=ON:

  build-bnxt-re-dkms    build only (no install)
  install-bnxt-re-dkms  build and install via DKMS
  remove-bnxt-re-dkms   uninstall the DKMS module

Update CMakeLists.txt to include the new module when GDA_BNXT=ON and remove the stale comment that said BNXT DKMS was managed without CMake integration (which also referenced a non-existent setup-bnxt-dv-dkms.sh script).
