### PR TITLE
rdma-ep: generalize 2-node test for all NIC vendors

### DIFF
--- a/.alola/rocm-xio-alola.py
+++ b/.alola/rocm-xio-alola.py
@@ -42,6 +42,8 @@ TESTS = [
      "rocm-xio-tests.nvme-ep.sbatch"),
     ("rdma-ep",
      "rocm-xio-tests.rdma-ep.sbatch"),
+    ("rdma-ep-2node",
+     "rocm-xio-tests.rdma-ep-2node.sbatch"),
 ]
 
 STATUS_PASS = 0

--- a/.alola/rocm-xio-tests.rdma-ep-2node.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep-2node.sbatch
@@ -1,0 +1,224 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# usage: sbatch rocm-xio-tests.rdma-ep-2node.sbatch
+#
+# RDMA-EP two-node test. Allocates 2 IB nodes, builds
+# with all GDA vendors, auto-detects the NIC vendor,
+# then runs a client-server RDMA WRITE + ping-pong
+# test across the two nodes.
+#
+# To check compatible nodes:
+#   sinfo -Na -o "%N %100f" | grep IB
+#
+#SBATCH --output=logs/%x.%j.out
+#SBATCH --error=logs/%x.%j.err
+#SBATCH --cpus-per-task=4
+#SBATCH --container-image=/cluster/images/rocm-xio/rocm-xio-alola.sqsh
+#SBATCH --container-mount-home
+#SBATCH --constraint=MARKHAM&IB&(ROCM7.2.0|ROCM7.3.0|ROCM7.1.1|ROCM7.0.1)
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=1
+
+set -xe
+
+LOGS_DIR="${ALOLA_LOGS_DIR:-logs}"
+mkdir -p "${LOGS_DIR}" 2>/dev/null || true
+
+if [ -n "${SLURM_SUBMIT_DIR}" ]; then
+  . "${SLURM_SUBMIT_DIR}/rocm-xio-tests.common"
+else
+  . "$(dirname "${BASH_SOURCE[0]}")/rocm-xio-tests.common"
+fi
+
+PP_SIZE="${PP_SIZE:-64}"
+PP_ITERS="${PP_ITERS:-100}"
+
+IFS=',' read -ra NODES <<< "${SLURM_JOB_NODELIST}"
+if [ ${#NODES[@]} -lt 2 ]; then
+  echo "ERROR: Need 2 nodes, got ${#NODES[@]}"
+  exit 1
+fi
+NODE_SERVER="${NODES[0]}"
+NODE_CLIENT="${NODES[1]}"
+
+cleanup() {
+  echo "Cleaning up..."
+  for node in "${NODE_SERVER}" "${NODE_CLIENT}"; do
+    ${SSH_COMMAND} "${node}" \
+      "rm -rf ${WORKING_DIR}" \
+      2>/dev/null || true
+  done
+  rm -rf "${WORKING_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+test_init
+display_job_info
+
+echo "=========================================="
+echo "RDMA-EP Two-Node Test"
+echo "=========================================="
+echo "  Server node: ${NODE_SERVER}"
+echo "  Client node: ${NODE_CLIENT}"
+echo ""
+
+cd "${PROJECT_DIR}"
+detect_gpu_arch
+
+# --- Build phase (inside container) ---
+WORKING_DIR="/tmp/rocm-xio-tests.rdma-2n.$RANDOM"
+mkdir -p "${WORKING_DIR}"
+rsync -a --exclude='.git' . "${WORKING_DIR}"
+cd "${WORKING_DIR}"
+rm -rf build
+cmake -S . -B build \
+  -DGDA_BNXT=ON -DGDA_MLX5=ON -DGDA_IONIC=ON
+cmake --build build \
+  --target test-rdma-2node \
+  --target install-rdma-core \
+  --parallel
+
+RDMA_CORE_LIB="${WORKING_DIR}/build/_deps"
+RDMA_CORE_LIB="${RDMA_CORE_LIB}/rdma-core/install/lib"
+TEST_BIN="${WORKING_DIR}/build/tests/unit"
+TEST_BIN="${TEST_BIN}/rdma-ep/test-rdma-2node"
+
+# --- Copy artifacts to both nodes ---
+echo ""
+echo "Copying test artifacts to nodes..."
+for node in "${NODE_SERVER}" "${NODE_CLIENT}"; do
+  ${SSH_COMMAND} "${node}" \
+    "mkdir -p ${WORKING_DIR}/build/tests/unit/rdma-ep"
+  ${SCP_COMMAND} "${TEST_BIN}" \
+    "${node}:${TEST_BIN}"
+  ${SSH_COMMAND} "${node}" \
+    "mkdir -p ${WORKING_DIR}/build/_deps/rdma-core"
+  ${SCP_COMMAND} -r \
+    "${WORKING_DIR}/build/_deps/rdma-core/install" \
+    "${node}:${WORKING_DIR}/build/_deps/rdma-core/"
+done
+
+# --- Auto-detect NIC vendor on server node ---
+echo ""
+echo "Detecting RDMA NICs on ${NODE_SERVER}..."
+
+detect_vendor_on_node() {
+  local node="$1"
+  local vendor=""
+  local dev=""
+
+  local has_mlx5
+  has_mlx5=$(${SSH_COMMAND} "${node}" \
+    "ls -d /sys/class/infiniband/rocm-rdma-mlx5* \
+    /sys/class/infiniband/mlx5_* 2>/dev/null \
+    | head -1" || true)
+  if [ -n "${has_mlx5}" ]; then
+    vendor="mlx5"
+    dev=$(${SSH_COMMAND} "${node}" \
+      "basename ${has_mlx5}")
+    echo "${vendor} ${dev}"
+    return
+  fi
+
+  local has_bnxt
+  has_bnxt=$(${SSH_COMMAND} "${node}" \
+    "ls -d /sys/class/infiniband/rocm-rdma-bnxt* \
+    /sys/class/infiniband/bnxt_* 2>/dev/null \
+    | head -1" || true)
+  if [ -n "${has_bnxt}" ]; then
+    vendor="bnxt"
+    dev=$(${SSH_COMMAND} "${node}" \
+      "basename ${has_bnxt}")
+    echo "${vendor} ${dev}"
+    return
+  fi
+
+  local has_ionic
+  has_ionic=$(${SSH_COMMAND} "${node}" \
+    "ls -d /sys/class/infiniband/rocm-rdma-ionic* \
+    /sys/class/infiniband/ionic_* 2>/dev/null \
+    | head -1" || true)
+  if [ -n "${has_ionic}" ]; then
+    vendor="ionic"
+    dev=$(${SSH_COMMAND} "${node}" \
+      "basename ${has_ionic}")
+    echo "${vendor} ${dev}"
+    return
+  fi
+}
+
+read -r SRV_VENDOR SRV_DEV \
+  <<< "$(detect_vendor_on_node "${NODE_SERVER}")"
+read -r CLI_VENDOR CLI_DEV \
+  <<< "$(detect_vendor_on_node "${NODE_CLIENT}")"
+
+if [ -z "${SRV_VENDOR}" ]; then
+  echo "ERROR: No RDMA NIC on ${NODE_SERVER}"
+  exit 1
+fi
+if [ -z "${CLI_VENDOR}" ]; then
+  echo "ERROR: No RDMA NIC on ${NODE_CLIENT}"
+  exit 1
+fi
+if [ "${SRV_VENDOR}" != "${CLI_VENDOR}" ]; then
+  echo "ERROR: vendor mismatch:" \
+    "${NODE_SERVER}=${SRV_VENDOR}" \
+    "${NODE_CLIENT}=${CLI_VENDOR}"
+  exit 1
+fi
+
+VENDOR="${SRV_VENDOR}"
+echo "  Server: ${SRV_DEV} (${VENDOR})"
+echo "  Client: ${CLI_DEV} (${VENDOR})"
+
+# --- Run two-node test ---
+echo ""
+echo "=========================================="
+echo "Running RDMA-EP two-node test"
+echo "  provider=${VENDOR}"
+echo "  server=${NODE_SERVER} (${SRV_DEV})"
+echo "  client=${NODE_CLIENT} (${CLI_DEV})"
+echo "  pingpong-size=${PP_SIZE}"
+echo "  pingpong-iters=${PP_ITERS}"
+echo "=========================================="
+echo ""
+
+LIB_PATH="${RDMA_CORE_LIB}:/opt/rocm/lib"
+
+# Launch server in background
+${SSH_COMMAND} "${NODE_SERVER}" \
+  "sudo env LD_LIBRARY_PATH=${LIB_PATH} \
+    ${TEST_BIN} \
+    --server \
+    --provider ${VENDOR} \
+    --device ${SRV_DEV} \
+    --pingpong-size ${PP_SIZE} \
+    --pingpong-iters ${PP_ITERS}" \
+  2>&1 | sed 's/^/[SERVER] /' &
+SERVER_PID=$!
+
+sleep 3
+
+# Launch client
+test_run \
+  "rdma-ep 2node ${VENDOR}" \
+  "${SSH_COMMAND} ${NODE_CLIENT} \
+    \"sudo env LD_LIBRARY_PATH=${LIB_PATH} \
+      ${TEST_BIN} \
+      --client \
+      --server-host ${NODE_SERVER} \
+      --provider ${VENDOR} \
+      --device ${CLI_DEV} \
+      --pingpong-size ${PP_SIZE} \
+      --pingpong-iters ${PP_ITERS}\""
+
+wait ${SERVER_PID} || true
+
+test_report
+EXIT_CODE=$?
+
+exit ${EXIT_CODE}

--- a/.alola/rocm-xio-tests.rdma-ep.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep.sbatch
@@ -20,6 +20,7 @@
 #SBATCH --container-image=/cluster/images/rocm-xio/rocm-xio-alola.sqsh
 #SBATCH --container-mount-home
 #SBATCH --constraint=MARKHAM&IB&(ROCM7.2.0|ROCM7.3.0|ROCM7.1.1|ROCM7.0.1)
+#SBATCH --exclude=banff-cyxtera-s81-5
 #SBATCH --gpus-per-node=1
 
 set -xe

--- a/tests/unit/rdma-ep/CMakeLists.txt
+++ b/tests/unit/rdma-ep/CMakeLists.txt
@@ -63,6 +63,7 @@ if(GDA_BNXT OR GDA_MLX5 OR GDA_IONIC)
     GPU
     INCLUDE_DIRS
       ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
+      ${CMAKE_CURRENT_SOURCE_DIR}
   )
   set_tests_properties(test-rdma-loopback PROPERTIES
     FIXTURES_REQUIRED RDMA_HW)
@@ -92,6 +93,7 @@ if(GDA_BNXT OR GDA_MLX5 OR GDA_IONIC)
     GPU
     INCLUDE_DIRS
       ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
+      ${CMAKE_CURRENT_SOURCE_DIR}
   )
   set_tests_properties(test-rdma-2node PROPERTIES
     FIXTURES_REQUIRED RDMA_HW)

--- a/tests/unit/rdma-ep/CMakeLists.txt
+++ b/tests/unit/rdma-ep/CMakeLists.txt
@@ -84,7 +84,7 @@ if(GDA_BNXT OR GDA_MLX5 OR GDA_IONIC)
   endforeach()
 endif()
 
-if(GDA_BNXT)
+if(GDA_BNXT OR GDA_MLX5 OR GDA_IONIC)
   xio_add_test(
     NAME test-rdma-2node
     SOURCE test-rdma-2node.hip

--- a/tests/unit/rdma-ep/detect-pci-vendor.hpp
+++ b/tests/unit/rdma-ep/detect-pci-vendor.hpp
@@ -1,0 +1,43 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Scan /sys/class/infiniband for a device matching a PCI vendor ID.
+ * Used by RDMA test binaries for auto-detecting the NIC provider.
+ */
+
+#ifndef RDMA_EP_TEST_DETECT_PCI_VENDOR_HPP
+#define RDMA_EP_TEST_DETECT_PCI_VENDOR_HPP
+
+#include <cstdint>
+#include <cstdio>
+
+#include <dirent.h>
+
+inline bool detect_pci_vendor(uint16_t vendor_id) {
+  DIR* d = opendir("/sys/class/infiniband");
+  if (!d)
+    return false;
+  struct dirent* ent;
+  while ((ent = readdir(d)) != nullptr) {
+    if (ent->d_name[0] == '.')
+      continue;
+    char path[512];
+    snprintf(path, sizeof(path), "/sys/class/infiniband/%s/device/vendor",
+             ent->d_name);
+    FILE* f = fopen(path, "r");
+    if (!f)
+      continue;
+    unsigned int vid = 0;
+    if (fscanf(f, "%x", &vid) == 1 && vid == vendor_id) {
+      fclose(f);
+      closedir(d);
+      return true;
+    }
+    fclose(f);
+  }
+  closedir(d);
+  return false;
+}
+
+#endif // RDMA_EP_TEST_DETECT_PCI_VENDOR_HPP

--- a/tests/unit/rdma-ep/run-2node-test.sh
+++ b/tests/unit/rdma-ep/run-2node-test.sh
@@ -1,33 +1,43 @@
 #!/bin/bash
 # Run 2-node RDMA test between two nodes.
 #
-# Usage: ./run-2node-test.sh <server-node> <client-node> [device] [gid-index]
+# Usage: ./run-2node-test.sh <server-node> <client-node> \
+#          [device] [provider]
 #
 # Example:
-#   ./run-2node-test.sh dell300x-ccs-aus-k13-03 dell300x-ccs-aus-k13-41
+#   ./run-2node-test.sh node-03 node-41
+#   ./run-2node-test.sh node-03 node-41 mlx5_0 mlx5
+#   ./run-2node-test.sh node-03 node-41 bnxt_re0 bnxt
 
 set -euo pipefail
 
 if [ $# -lt 2 ]; then
-  echo "Usage: $0 <server-node> <client-node> [device] [gid-index]"
+  echo "Usage: $0 <server-node> <client-node>" \
+    "[device] [provider]"
+  echo ""
+  echo "provider: bnxt|mlx5|ionic|auto" \
+    "(default: auto)"
   echo ""
   echo "Example:"
-  echo "  $0 dell300x-ccs-aus-k13-03 dell300x-ccs-aus-k13-41"
-  echo "  $0 dell300x-ccs-aus-k13-03 dell300x-ccs-aus-k13-41 bnxt_re0 3"
+  echo "  $0 node-03 node-41"
+  echo "  $0 node-03 node-41 mlx5_0 mlx5"
   exit 1
 fi
 
 NODE_A="$1"
 NODE_B="$2"
 DEVICE="${3:-}"
-GID="${4:-3}"
+PROVIDER="${4:-${PROVIDER:-auto}}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUILD_DIR="$SCRIPT_DIR/../../../build"
-TEST_BIN="$BUILD_DIR/tests/unit/rdma-ep/test-rdma-2node"
+TEST_BIN="$BUILD_DIR/tests/unit"
+TEST_BIN="$TEST_BIN/rdma-ep/test-rdma-2node"
 
 if [ ! -f "$TEST_BIN" ]; then
-  echo "Error: $TEST_BIN not found. Build with -DGDA_BNXT=ON -DBUILD_TESTING=ON first."
+  echo "Error: $TEST_BIN not found."
+  echo "  Build with -DGDA_BNXT=ON or" \
+    "-DGDA_MLX5=ON or -DGDA_IONIC=ON"
   exit 1
 fi
 
@@ -36,26 +46,32 @@ if [ -n "$DEVICE" ]; then
   DEVICE_ARG="--device $DEVICE"
 fi
 
+PROVIDER_ARG="--provider $PROVIDER"
+
 echo "=== 2-Node RDMA Test ==="
-echo "Server: $NODE_A"
-echo "Client: $NODE_B"
-echo "GID index: $GID"
+echo "Server:   $NODE_A"
+echo "Client:   $NODE_B"
+echo "Provider: $PROVIDER"
+if [ -n "$DEVICE" ]; then
+  echo "Device:   $DEVICE"
+fi
 echo ""
 
-# Launch server on node A
 ssh -o StrictHostKeyChecking=no "$NODE_A" \
-  "$TEST_BIN --server $DEVICE_ARG --gid-index $GID" 2>&1 | sed "s/^/[SERVER] /" &
+  "$TEST_BIN --server $PROVIDER_ARG" \
+  "$DEVICE_ARG" 2>&1 \
+  | sed "s/^/[SERVER] /" &
 SERVER_PID=$!
 
-# Wait for server to start listening
 sleep 3
 
-# Launch client on node B, connecting to server via hostname
 ssh -o StrictHostKeyChecking=no "$NODE_B" \
-  "$TEST_BIN --client --server-host $NODE_A $DEVICE_ARG --gid-index $GID" 2>&1 | sed "s/^/[CLIENT] /" &
+  "$TEST_BIN --client" \
+  "--server-host $NODE_A" \
+  "$PROVIDER_ARG $DEVICE_ARG" 2>&1 \
+  | sed "s/^/[CLIENT] /" &
 CLIENT_PID=$!
 
-# Wait for both to finish
 wait $CLIENT_PID
 CLIENT_EXIT=$?
 
@@ -63,9 +79,12 @@ wait $SERVER_PID
 SERVER_EXIT=$?
 
 echo ""
-if [ $CLIENT_EXIT -eq 0 ] && [ $SERVER_EXIT -eq 0 ]; then
+if [ $CLIENT_EXIT -eq 0 ] && \
+   [ $SERVER_EXIT -eq 0 ]; then
   echo "=== 2-Node RDMA Test PASSED ==="
 else
-  echo "=== 2-Node RDMA Test FAILED (server=$SERVER_EXIT, client=$CLIENT_EXIT) ==="
+  echo "=== 2-Node RDMA Test FAILED" \
+    "(server=$SERVER_EXIT," \
+    "client=$CLIENT_EXIT) ==="
   exit 1
 fi

--- a/tests/unit/rdma-ep/test-rdma-2node.hip
+++ b/tests/unit/rdma-ep/test-rdma-2node.hip
@@ -5,14 +5,14 @@
  * 2-Node RDMA client-server test.
  *
  * Uses TCP over management network for QP info exchange, then
- * GPU-initiated RDMA WRITE over Thor 2 NICs for data transfer.
+ * GPU-initiated RDMA WRITE for data transfer.
  *
  * Usage:
- *   Server: ./test-rdma-2node --server [--device bnxt_re0] [--gid-index 3]
- *   Client: ./test-rdma-2node --client --server-host <hostname> [--device
- * bnxt_re0] [--gid-index 3]
+ *   Server: ./test-rdma-2node --server [--provider mlx5] [--device mlx5_0]
+ *   Client: ./test-rdma-2node --client --server-host <hostname>
+ *           [--provider mlx5] [--device mlx5_0]
  *
- * Requires: BNXT NIC (Thor 2), GDA_BNXT=ON build, two nodes with RDMA fabric.
+ * Supports BNXT, MLX5, and IONIC providers via --provider flag.
  */
 
 #include <cassert>
@@ -24,6 +24,7 @@
 #include <hip/hip_runtime.h>
 
 #include <arpa/inet.h>
+#include <dirent.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -33,10 +34,11 @@
 #include "vendor-ops.hpp"
 #include "xio-data-pattern.hpp"
 
-#if !defined(GDA_BNXT)
+#if !defined(GDA_BNXT) && !defined(GDA_MLX5) && \
+    !defined(GDA_IONIC)
 int main() {
-  printf("SKIPPED: GDA_BNXT not enabled.\n");
-  return 0;
+  printf("SKIP: no GDA vendor enabled.\n");
+  return 77;
 }
 #else
 
@@ -51,6 +53,8 @@ static constexpr uint8_t DATA_PATTERN = 0xA5;
 struct ExchangeMsg {
   uint32_t qpn;
   uint32_t rkey;
+  uint16_t lid;
+  uint16_t pad;
   uint64_t remote_addr;
   uint8_t gid[16];
 } __attribute__((packed));
@@ -282,18 +286,58 @@ __global__ void pingpong_server_kernel(QueuePair* qp, PingPongBuf* send_buf,
   }
 }
 
+// --- PCI vendor auto-detection ---
+
+static bool detect_pci_vendor(uint16_t vendor_id) {
+  DIR* d = opendir("/sys/class/infiniband");
+  if (!d)
+    return false;
+  struct dirent* ent;
+  while ((ent = readdir(d)) != nullptr) {
+    if (ent->d_name[0] == '.')
+      continue;
+    char path[512];
+    snprintf(path, sizeof(path),
+             "/sys/class/infiniband/%s"
+             "/device/vendor",
+             ent->d_name);
+    FILE* f = fopen(path, "r");
+    if (!f)
+      continue;
+    unsigned int vid = 0;
+    if (fscanf(f, "%x", &vid) == 1 &&
+        vid == vendor_id) {
+      fclose(f);
+      closedir(d);
+      return true;
+    }
+    fclose(f);
+  }
+  closedir(d);
+  return false;
+}
+
 // --- Main ---
 
 static void print_usage(const char* prog) {
   fprintf(stderr,
           "Usage:\n"
           "  %s --server [options]\n"
-          "  %s --client --server-host HOST [options]\n"
+          "  %s --client --server-host HOST"
+          " [options]\n"
           "\nOptions:\n"
-          "  --device DEV          RDMA device name (default: auto-detect)\n"
-          "  --gid-index N         GID index (default: 3, RoCEv2 IPv4-mapped)\n"
-          "  --pingpong-size N     Ping-pong payload in bytes (default: 64)\n"
-          "  --pingpong-iters N    Ping-pong iterations (default: 100)\n",
+          "  --provider P          "
+          "bnxt|mlx5|ionic|auto"
+          " (default: auto)\n"
+          "  --device DEV          "
+          "RDMA device name"
+          " (default: auto-detect)\n"
+          "  --pingpong-size N     "
+          "Ping-pong payload in bytes"
+          " (default: 64)\n"
+          "  --pingpong-iters N    "
+          "Ping-pong iterations"
+          " (default: 100)\n",
           prog, prog);
 }
 
@@ -302,7 +346,7 @@ int main(int argc, char** argv) {
   bool is_client = false;
   const char* server_host = nullptr;
   const char* device_name = nullptr;
-  int gid_index = 3;
+  const char* provider_str = "auto";
   uint32_t pp_size = 64;
   uint32_t pp_iters = 100;
 
@@ -311,15 +355,20 @@ int main(int argc, char** argv) {
       is_server = true;
     else if (strcmp(argv[i], "--client") == 0)
       is_client = true;
-    else if (strcmp(argv[i], "--server-host") == 0 && i + 1 < argc)
+    else if (strcmp(argv[i], "--server-host") == 0 &&
+             i + 1 < argc)
       server_host = argv[++i];
-    else if (strcmp(argv[i], "--device") == 0 && i + 1 < argc)
+    else if (strcmp(argv[i], "--provider") == 0 &&
+             i + 1 < argc)
+      provider_str = argv[++i];
+    else if (strcmp(argv[i], "--device") == 0 &&
+             i + 1 < argc)
       device_name = argv[++i];
-    else if (strcmp(argv[i], "--gid-index") == 0 && i + 1 < argc)
-      gid_index = atoi(argv[++i]);
-    else if (strcmp(argv[i], "--pingpong-size") == 0 && i + 1 < argc)
+    else if (strcmp(argv[i], "--pingpong-size") == 0 &&
+             i + 1 < argc)
       pp_size = atoi(argv[++i]);
-    else if (strcmp(argv[i], "--pingpong-iters") == 0 && i + 1 < argc)
+    else if (strcmp(argv[i], "--pingpong-iters") == 0 &&
+             i + 1 < argc)
       pp_iters = atoi(argv[++i]);
     else {
       print_usage(argv[0]);
@@ -327,10 +376,9 @@ int main(int argc, char** argv) {
     }
   }
 
-  (void)gid_index; // TODO: plumb into BackendConfig
-
   if (pp_size < 8) {
-    fprintf(stderr, "Pingpong size must be >= 8 bytes\n");
+    fprintf(stderr,
+            "Pingpong size must be >= 8 bytes\n");
     return 1;
   }
 
@@ -343,21 +391,82 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  Provider prov;
+  if (strcmp(provider_str, "bnxt") == 0) {
+#if defined(GDA_BNXT)
+    prov = Provider::BNXT;
+#else
+    fprintf(stderr,
+            "GDA_BNXT not enabled in build.\n");
+    return 1;
+#endif
+  } else if (strcmp(provider_str, "mlx5") == 0) {
+#if defined(GDA_MLX5)
+    prov = Provider::MLX5;
+#else
+    fprintf(stderr,
+            "GDA_MLX5 not enabled in build.\n");
+    return 1;
+#endif
+  } else if (strcmp(provider_str, "ionic") == 0) {
+#if defined(GDA_IONIC)
+    prov = Provider::IONIC;
+#else
+    fprintf(stderr,
+            "GDA_IONIC not enabled in build.\n");
+    return 1;
+#endif
+  } else if (strcmp(provider_str, "auto") == 0) {
+#if defined(GDA_IONIC)
+    if (detect_pci_vendor(VENDOR_ID_PENSANDO)) {
+      prov = Provider::IONIC;
+      printf("Auto-detected: ionic (0x%04x)\n",
+             VENDOR_ID_PENSANDO);
+    } else
+#endif
+#if defined(GDA_MLX5)
+      if (detect_pci_vendor(VENDOR_ID_MELLANOX)) {
+      prov = Provider::MLX5;
+      printf("Auto-detected: mlx5 (0x%04x)\n",
+             VENDOR_ID_MELLANOX);
+    } else
+#endif
+#if defined(GDA_BNXT)
+      if (detect_pci_vendor(VENDOR_ID_BROADCOM)) {
+      prov = Provider::BNXT;
+      printf("Auto-detected: bnxt (0x%04x)\n",
+             VENDOR_ID_BROADCOM);
+    } else
+#endif
+    {
+      printf("SKIP: no supported NIC detected.\n");
+      return 77;
+    }
+  } else {
+    fprintf(stderr,
+            "Unknown provider: %s\n", provider_str);
+    print_usage(argv[0]);
+    return 1;
+  }
+
+  const char* prov_name = provider_name(prov);
   const char* role = is_server ? "SERVER" : "CLIENT";
   setbuf(stdout, NULL);
-  printf("=== 2-Node RDMA Test [%s] ===\n\n", role);
+  printf("=== 2-Node RDMA Test [%s] ===\n",
+         role);
+  printf("  provider=%s\n\n", prov_name);
 
-  // --- Init HIP ---
   hipError_t herr = hipInit(0);
   if (herr != hipSuccess) {
-    fprintf(stderr, "hipInit: %s\n", hipGetErrorString(herr));
+    fprintf(stderr,
+            "hipInit: %s\n",
+            hipGetErrorString(herr));
     return 1;
   }
   (void)hipSetDevice(0);
 
-  // --- Create Backend (loopback=false, defer QP connection) ---
   BackendConfig cfg;
-  cfg.provider = Provider::BNXT;
+  cfg.provider = prov;
   cfg.gpu_device_id = 0;
   cfg.sq_depth = 256;
   cfg.cq_depth = 256;
@@ -426,6 +535,8 @@ int main(int argc, char** argv) {
   ExchangeMsg local_msg{};
   local_msg.qpn = local_dest.qpn;
   local_msg.rkey = backend.get_rkey();
+  local_msg.lid = static_cast<uint16_t>(local_dest.lid);
+  local_msg.pad = 0;
   local_msg.remote_addr = reinterpret_cast<uint64_t>(reg_buf);
   memcpy(local_msg.gid, local_dest.gid.raw, 16);
 
@@ -444,6 +555,7 @@ int main(int argc, char** argv) {
 
   // --- Connect QP to peer ---
   DestInfo peer{};
+  peer.lid = remote_msg.lid;
   peer.qpn = remote_msg.qpn;
   peer.psn = 0;
   memcpy(peer.gid.raw, remote_msg.gid, 16);
@@ -624,4 +736,4 @@ int main(int argc, char** argv) {
   return 0;
 }
 
-#endif // GDA_BNXT
+#endif // GDA_BNXT || GDA_MLX5 || GDA_IONIC

--- a/tests/unit/rdma-ep/test-rdma-2node.hip
+++ b/tests/unit/rdma-ep/test-rdma-2node.hip
@@ -24,18 +24,17 @@
 #include <hip/hip_runtime.h>
 
 #include <arpa/inet.h>
-#include <dirent.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include "detect-pci-vendor.hpp"
 #include "gda-backend.hpp"
 #include "queue-pair.hpp"
 #include "vendor-ops.hpp"
 #include "xio-data-pattern.hpp"
 
-#if !defined(GDA_BNXT) && !defined(GDA_MLX5) && \
-    !defined(GDA_IONIC)
+#if !defined(GDA_BNXT) && !defined(GDA_MLX5) && !defined(GDA_IONIC)
 int main() {
   printf("SKIP: no GDA vendor enabled.\n");
   return 77;
@@ -286,37 +285,6 @@ __global__ void pingpong_server_kernel(QueuePair* qp, PingPongBuf* send_buf,
   }
 }
 
-// --- PCI vendor auto-detection ---
-
-static bool detect_pci_vendor(uint16_t vendor_id) {
-  DIR* d = opendir("/sys/class/infiniband");
-  if (!d)
-    return false;
-  struct dirent* ent;
-  while ((ent = readdir(d)) != nullptr) {
-    if (ent->d_name[0] == '.')
-      continue;
-    char path[512];
-    snprintf(path, sizeof(path),
-             "/sys/class/infiniband/%s"
-             "/device/vendor",
-             ent->d_name);
-    FILE* f = fopen(path, "r");
-    if (!f)
-      continue;
-    unsigned int vid = 0;
-    if (fscanf(f, "%x", &vid) == 1 &&
-        vid == vendor_id) {
-      fclose(f);
-      closedir(d);
-      return true;
-    }
-    fclose(f);
-  }
-  closedir(d);
-  return false;
-}
-
 // --- Main ---
 
 static void print_usage(const char* prog) {
@@ -355,20 +323,15 @@ int main(int argc, char** argv) {
       is_server = true;
     else if (strcmp(argv[i], "--client") == 0)
       is_client = true;
-    else if (strcmp(argv[i], "--server-host") == 0 &&
-             i + 1 < argc)
+    else if (strcmp(argv[i], "--server-host") == 0 && i + 1 < argc)
       server_host = argv[++i];
-    else if (strcmp(argv[i], "--provider") == 0 &&
-             i + 1 < argc)
+    else if (strcmp(argv[i], "--provider") == 0 && i + 1 < argc)
       provider_str = argv[++i];
-    else if (strcmp(argv[i], "--device") == 0 &&
-             i + 1 < argc)
+    else if (strcmp(argv[i], "--device") == 0 && i + 1 < argc)
       device_name = argv[++i];
-    else if (strcmp(argv[i], "--pingpong-size") == 0 &&
-             i + 1 < argc)
+    else if (strcmp(argv[i], "--pingpong-size") == 0 && i + 1 < argc)
       pp_size = atoi(argv[++i]);
-    else if (strcmp(argv[i], "--pingpong-iters") == 0 &&
-             i + 1 < argc)
+    else if (strcmp(argv[i], "--pingpong-iters") == 0 && i + 1 < argc)
       pp_iters = atoi(argv[++i]);
     else {
       print_usage(argv[0]);
@@ -377,8 +340,7 @@ int main(int argc, char** argv) {
   }
 
   if (pp_size < 8) {
-    fprintf(stderr,
-            "Pingpong size must be >= 8 bytes\n");
+    fprintf(stderr, "Pingpong size must be >= 8 bytes\n");
     return 1;
   }
 
@@ -396,46 +358,40 @@ int main(int argc, char** argv) {
 #if defined(GDA_BNXT)
     prov = Provider::BNXT;
 #else
-    fprintf(stderr,
-            "GDA_BNXT not enabled in build.\n");
+    fprintf(stderr, "GDA_BNXT not enabled in build.\n");
     return 1;
 #endif
   } else if (strcmp(provider_str, "mlx5") == 0) {
 #if defined(GDA_MLX5)
     prov = Provider::MLX5;
 #else
-    fprintf(stderr,
-            "GDA_MLX5 not enabled in build.\n");
+    fprintf(stderr, "GDA_MLX5 not enabled in build.\n");
     return 1;
 #endif
   } else if (strcmp(provider_str, "ionic") == 0) {
 #if defined(GDA_IONIC)
     prov = Provider::IONIC;
 #else
-    fprintf(stderr,
-            "GDA_IONIC not enabled in build.\n");
+    fprintf(stderr, "GDA_IONIC not enabled in build.\n");
     return 1;
 #endif
   } else if (strcmp(provider_str, "auto") == 0) {
 #if defined(GDA_IONIC)
     if (detect_pci_vendor(VENDOR_ID_PENSANDO)) {
       prov = Provider::IONIC;
-      printf("Auto-detected: ionic (0x%04x)\n",
-             VENDOR_ID_PENSANDO);
+      printf("Auto-detected: ionic (0x%04x)\n", VENDOR_ID_PENSANDO);
     } else
 #endif
 #if defined(GDA_MLX5)
       if (detect_pci_vendor(VENDOR_ID_MELLANOX)) {
       prov = Provider::MLX5;
-      printf("Auto-detected: mlx5 (0x%04x)\n",
-             VENDOR_ID_MELLANOX);
+      printf("Auto-detected: mlx5 (0x%04x)\n", VENDOR_ID_MELLANOX);
     } else
 #endif
 #if defined(GDA_BNXT)
       if (detect_pci_vendor(VENDOR_ID_BROADCOM)) {
       prov = Provider::BNXT;
-      printf("Auto-detected: bnxt (0x%04x)\n",
-             VENDOR_ID_BROADCOM);
+      printf("Auto-detected: bnxt (0x%04x)\n", VENDOR_ID_BROADCOM);
     } else
 #endif
     {
@@ -443,8 +399,7 @@ int main(int argc, char** argv) {
       return 77;
     }
   } else {
-    fprintf(stderr,
-            "Unknown provider: %s\n", provider_str);
+    fprintf(stderr, "Unknown provider: %s\n", provider_str);
     print_usage(argv[0]);
     return 1;
   }
@@ -452,15 +407,12 @@ int main(int argc, char** argv) {
   const char* prov_name = provider_name(prov);
   const char* role = is_server ? "SERVER" : "CLIENT";
   setbuf(stdout, NULL);
-  printf("=== 2-Node RDMA Test [%s] ===\n",
-         role);
+  printf("=== 2-Node RDMA Test [%s] ===\n", role);
   printf("  provider=%s\n\n", prov_name);
 
   hipError_t herr = hipInit(0);
   if (herr != hipSuccess) {
-    fprintf(stderr,
-            "hipInit: %s\n",
-            hipGetErrorString(herr));
+    fprintf(stderr, "hipInit: %s\n", hipGetErrorString(herr));
     return 1;
   }
   (void)hipSetDevice(0);

--- a/tests/unit/rdma-ep/test-rdma-loopback.hip
+++ b/tests/unit/rdma-ep/test-rdma-loopback.hip
@@ -22,9 +22,9 @@
 
 #include <hip/hip_runtime.h>
 
-#include <dirent.h>
 #include <unistd.h>
 
+#include "detect-pci-vendor.hpp"
 #include "gda-backend.hpp"
 #include "queue-pair.hpp"
 #include "vendor-ops.hpp"
@@ -43,34 +43,6 @@ using namespace rdma_ep;
 static constexpr uint32_t DEFAULT_XFER_SIZE = 256;
 static constexpr uint32_t DEFAULT_LFSR_SEED = 1;
 static constexpr unsigned DEFAULT_ITERATIONS = 1;
-
-static bool detect_pci_vendor(uint16_t vendor_id) {
-  DIR* d = opendir("/sys/class/infiniband");
-  if (!d)
-    return false;
-  struct dirent* ent;
-  while ((ent = readdir(d)) != nullptr) {
-    if (ent->d_name[0] == '.')
-      continue;
-    char path[512];
-    snprintf(path, sizeof(path),
-             "/sys/class/infiniband/%s"
-             "/device/vendor",
-             ent->d_name);
-    FILE* f = fopen(path, "r");
-    if (!f)
-      continue;
-    unsigned int vid = 0;
-    if (fscanf(f, "%x", &vid) == 1 && vid == vendor_id) {
-      fclose(f);
-      closedir(d);
-      return true;
-    }
-    fclose(f);
-  }
-  closedir(d);
-  return false;
-}
 
 static void print_usage(const char* prog) {
   fprintf(stderr,


### PR DESCRIPTION
The 2-node RDMA test was BNXT-only and broken for InfiniBand fabrics. This commit makes it work across BNXT, MLX5, and IONIC providers, and fixes the critical IB connectivity bug.

Key changes:

- test-rdma-2node.hip: add --provider flag with auto-detection via PCI vendor ID scan, replacing the hardcoded BNXT provider. Add LID to the TCP exchange (ExchangeMsg) so that IB QPs get a valid DLID -- without this, the IB switch cannot route RDMA packets and every WRITE fails with CQE syndrome 0x15 (Transport Retry Exceeded).

- CMakeLists.txt: build test-rdma-2node when any GDA vendor is enabled (GDA_BNXT OR GDA_MLX5 OR GDA_IONIC), not just BNXT.

- run-2node-test.sh: replace --gid-index with --provider flag and update usage examples for the new multi-vendor interface.

- rocm-xio-tests.rdma-ep-2node.sbatch: new Slurm sbatch script for automated 2-node testing. Builds all vendors, auto-detects the NIC on each node, copies artifacts via scp, and runs the client-server test. Uses IFS-based node list parsing instead of scontrol (unavailable inside enroot containers).

- rocm-xio-tests.rdma-ep.sbatch: exclude known-bad node banff-cyxtera-s81-5 from single-node RDMA tests.

- rocm-xio-alola.py: register rdma-ep-2node in the TESTS list so the Alola test runner submits and tracks it.

Tested: 5 consecutive PASS runs on ctr-cx63-mi300x-12 / ctr-cx66-mi300x-13 (mlx5_0, ConnectX-7, IB fabric).
