### PR TITLE
cmake: add docs-serve target and fix XIO_DOCS_ONLY mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,11 +551,13 @@ endif() # NOT XIO_DOCS_ONLY
 # Documentation (optional, requires -DXIO_BUILD_DOCS=ON)
 include(XIODocumentation)
 
-# Utility targets
-include(XIOUtilityTargets)
+if(NOT XIO_DOCS_ONLY)
+  # Utility targets
+  include(XIOUtilityTargets)
 
-# VM-based testing (launch-test-vm target)
-include(XIOVirtualMachine)
+  # VM-based testing (launch-test-vm target)
+  include(XIOVirtualMachine)
 
-# VM test targets (vm-test-ep, vm-rdma-ep, vm-nvme-ep)
-include(XIOVMTests)
+  # VM test targets (vm-test-ep, vm-rdma-ep, vm-nvme-ep)
+  include(XIOVMTests)
+endif()

--- a/cmake/XIODocumentation.cmake
+++ b/cmake/XIODocumentation.cmake
@@ -101,4 +101,19 @@ if(XIO_BUILD_DOCS)
     COMMENT "Building Sphinx HTML documentation"
     VERBATIM
   )
+
+  # ── Serve target: launch a local HTTP server ────────────
+  # Usage: cmake --build build --target docs-serve
+  # Then browse http://<hostname>:8080
+  set(XIO_DOCS_PORT "8080" CACHE STRING
+    "Port for the docs-serve HTTP server")
+  add_custom_target(docs-serve
+    COMMAND ${Python3_EXECUTABLE} -m http.server
+      ${XIO_DOCS_PORT} --bind 0.0.0.0
+    DEPENDS sphinx-html
+    WORKING_DIRECTORY ${XIO_DOC_PATH}/html
+    COMMENT "Serving docs at http://0.0.0.0:${XIO_DOCS_PORT}"
+    USES_TERMINAL
+    VERBATIM
+  )
 endif()


### PR DESCRIPTION
Add a `docs-serve` CMake target that builds the Sphinx HTML docs and launches a Python HTTP server (default port 8080, configurable via XIO_DOCS_PORT). Usage:

  cmake --build build --target docs-serve

Guard the utility, VM testing, and VM test modules behind `if(NOT XIO_DOCS_ONLY)` so that `XIO_DOCS_ONLY=ON` no longer triggers QEMU version warnings and GPU detection noise when only building documentation.
