### PR TITLE
nvme-ep: add --batch-size for doorbell batching

### DIFF
--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -135,7 +135,7 @@ test_run "NVMe-EP memory-mode 0" \
   "run_on_host '${WORKING_DIR}/build/xio-tester \
 nvme-ep --controller ${NON_ROOTFS_CTRL} \
 --access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io -23 \
+--lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
 --queue-length 128'"
 
 sleep 3
@@ -148,7 +148,7 @@ test_run "NVMe-EP memory-mode 3" \
   "run_on_host '${WORKING_DIR}/build/xio-tester \
 nvme-ep --controller ${NON_ROOTFS_CTRL} \
 --access-pattern random --memory-mode 3 --less-timing \
---lbas-per-io 1 --lfsr-seed 32 --read-io -573 \
+--lbas-per-io 1 --lfsr-seed 32 --read-io 573 \
 --queue-length 128'"
 
 sleep 3
@@ -157,7 +157,7 @@ test_run "NVMe-EP memory-mode 11" \
   "run_on_host '${WORKING_DIR}/build/xio-tester \
 nvme-ep --controller ${NON_ROOTFS_CTRL} \
 --access-pattern random --memory-mode 11 --less-timing \
---lbas-per-io 1 --lfsr-seed 32 --read-io -573 \
+--lbas-per-io 1 --lfsr-seed 32 --read-io 573 \
 --queue-length 128'"
 
 else

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -29,6 +29,7 @@ PRP
 prp
 slba
 SQE
+SQEs
 sqe
 sqePoll
 sqeRead

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,8 +32,8 @@ Run a quick NVMe test (requires an NVMe device):
 
 ```
 export HSA_FORCE_FINE_GRAIN_PCIE=1
-sudo ./build/xio-tester nvme-ep --controller /dev/nvme0 \
-  --read-io 50 --write-io 50 --verbose
+sudo ./build/xio-tester nvme-ep \
+  --controller /dev/nvme0 --read-io 50 --verbose
 ```
 
 ## Building rocm-xio

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -23,21 +23,40 @@ A software-only endpoint for validating the XIO framework. No hardware required.
 nvme-ep -- NVMe Endpoint
 -------------------------
 
-Implements NVMe command submission (SQE) and completion (CQE) handling.
-Supports Read and Write commands with configurable IO patterns.
+Implements NVMe command submission (SQE) and completion
+(CQE) handling. Supports Read and Write commands with
+configurable IO patterns and doorbell batching.
 
 .. code-block:: bash
 
    export HSA_FORCE_FINE_GRAIN_PCIE=1
    sudo ./build/xio-tester nvme-ep \
      --controller /dev/nvme0 \
-     --read-io 50 --write-io 50 --verbose
+     --read-io 8 --verbose
 
 Key features:
 
 - Direct GPU-to-NVMe submission via memory-mapped queues
 - Sequential and pseudo-random LBA access patterns
-- Configurable queue depth, IO size, and iteration count
+- Configurable queue depth, IO size, and batch size
+- ``--batch-size`` controls SQEs per doorbell ring:
+  ``1`` (default) submits one SQE at a time,
+  ``0`` submits all at once,
+  any other value ``N`` batches ``N`` SQEs per
+  doorbell
+
+.. code-block:: bash
+
+   # 16 reads, 4 SQEs per doorbell (4 rounds)
+   sudo ./build/xio-tester nvme-ep \
+     --controller /dev/nvme0 \
+     --read-io 16 --batch-size 4
+
+   # Infinite reads, 8 SQEs per doorbell
+   sudo ./build/xio-tester nvme-ep \
+     --controller /dev/nvme0 \
+     --read-io 1 --batch-size 8 \
+     --infinite --less-timing
 
 rdma-ep -- RDMA Endpoint
 -------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Quick Start
    export HSA_FORCE_FINE_GRAIN_PCIE=1
    sudo ./build/xio-tester nvme-ep \
      --controller /dev/nvme0 \
-     --read-io 50 --write-io 50 --verbose
+     --read-io 50 --verbose
 
 .. toctree::
    :maxdepth: 2

--- a/scripts/test/test-nvme-ep-data-verification.sh
+++ b/scripts/test/test-nvme-ep-data-verification.sh
@@ -327,6 +327,7 @@ test_device() {
     write_cmd="$write_cmd --base-lba $BASE_LBA"
     write_cmd="$write_cmd --lbas-per-io $BLOCKS_PER_CMD"
     write_cmd="$write_cmd --access-pattern sequential"
+    write_cmd="$write_cmd --batch-size 0"
     write_cmd="$write_cmd -m $MEMORY_MODE"
     
     echo "Command: $write_cmd"

--- a/scripts/test/test-nvme-ep-random-write-verify.sh
+++ b/scripts/test/test-nvme-ep-random-write-verify.sh
@@ -101,7 +101,7 @@ echo ""
 
 echo "Step 1: Writing $NUM_WRITES random LBAs..."
 write_cmd="$XIO_TESTER nvme-ep"
-write_cmd="$write_cmd --write-io -${NUM_WRITES}"
+write_cmd="$write_cmd --write-io ${NUM_WRITES}"
 write_cmd="$write_cmd --controller $NVME_DEVICE"
 write_cmd="$write_cmd --access-pattern random"
 write_cmd="$write_cmd --lbas-per-io 1"
@@ -162,8 +162,9 @@ def get_random_lba(op_index, cmd_id,
 def generate_expected_block(lba_size, lfsr_seed):
     """Reproduces dataPattern() from nvme-ep.h.
 
-    In sequential mode buffer_offset=0 for all writes,
-    so offset=0 => lba=0, base_seed=0, seed=lfsr_seed.
+    With batch-size 1 (default), buffer_offset=0 for
+    all writes, so offset=0 => lba=0, base_seed=0,
+    seed=lfsr_seed.
     """
     M32 = 0xFFFFFFFF
     pattern = bytearray(lba_size)

--- a/src/endpoints/common/xio-endpoint.hip
+++ b/src/endpoints/common/xio-endpoint.hip
@@ -260,21 +260,14 @@ public:
 
   __host__ unsigned getIterations(void* endpointConfig) const override {
     if (endpointConfig) {
-      nvme_ep::nvmeEpConfig* nvmeConfig = static_cast<nvme_ep::nvmeEpConfig*>(
-        endpointConfig);
-      if (nvmeConfig->ioParams.readIo < 0 && nvmeConfig->ioParams.writeIo < 0) {
-        // Sequential mode: both negative, return sum of absolute values
-        return -nvmeConfig->ioParams.readIo + -nvmeConfig->ioParams.writeIo;
+      auto* nvmeConfig = static_cast<nvme_ep::nvmeEpConfig*>(endpointConfig);
+      if (nvmeConfig->ioParams.infiniteMode) {
+        return 0;
       }
-      if (nvmeConfig->ioParams.writeIo < 0) {
-        // Sequential mode: use absolute value of writeIo
-        return -nvmeConfig->ioParams.writeIo;
-      }
-      if (nvmeConfig->ioParams.readIo < 0) {
-        // Sequential mode: use absolute value of readIo
-        return -nvmeConfig->ioParams.readIo;
-      }
-      return nvmeConfig->ioParams.readIo + nvmeConfig->ioParams.writeIo;
+      // After validateConfig, readIo and writeIo are
+      // always non-negative.
+      return (unsigned)(nvmeConfig->ioParams.readIo +
+                        nvmeConfig->ioParams.writeIo);
     }
     return 0;
   }

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -64,13 +64,14 @@ struct nvmeIoParams {
   uint64_t baseLba;      // Starting LBA for I/O operations
   uint64_t lbaRangeLbas; // LBA range limit (0 = no limit)
   bool useRandomAccess;  // true for random access, false for sequential
-  int readIo;            // Number of read operations (negative = sequential)
-  int writeIo;           // Number of write operations (negative = sequential)
+  int readIo;            // Number of read operations
+  int writeIo;           // Number of write operations
   uint32_t lfsrSeed;     // Seed for LFSR test pattern (0 = derive from LBA)
   uint16_t queueSize;    // Queue size in entries
   uint32_t nsid;         // Namespace ID (must be > 0)
   uint32_t lbasPerIo;    // Number of LBAs per I/O operation (default: 1)
   bool infiniteMode;     // Infinite mode: run forever
+  uint32_t batchSize;    // SQEs per doorbell (1=sequential, 0=all)
 };
 
 /**
@@ -104,36 +105,28 @@ struct nvmeBufferParams {
 /**
  * Drive NVMe endpoint I/O operations from GPU device code
  *
- * This function executes NVMe read/write operations directly from GPU kernels,
- * supporting both batch mode (multiple operations queued) and sequential mode
- * (one operation at a time with completion waiting). The function handles
- * queue management, doorbell ringing, completion polling, and data pattern
- * generation/verification.
+ * Executes NVMe read/write operations directly from GPU kernels
+ * using a unified batched loop. The batchSize parameter controls
+ * how many SQEs are submitted before ringing the doorbell:
+ *   batchSize 1 — one SQE per doorbell (sequential)
+ *   batchSize 0 — all ops at once (fills queue)
+ *   batchSize N — N SQEs per doorbell ring
  *
- * @param config Base endpoint configuration containing queue pointers,
- *               timing arrays, and common parameters. The submissionQueue
- *               and completionQueue fields must be valid GPU-accessible
- *               pointers.
- * @param ioParams NVMe-specific I/O parameters including LBA configuration,
- *                 operation counts, access pattern, and test pattern seed.
- *                 Negative readIo/writeIo values indicate sequential mode.
- * @param doorbellParams Doorbell configuration for notifying the NVMe
- *                       controller. Supports both PCI MMIO bridge mode and
- *                       direct BAR0 access. At least one mode must be
- *                       configured (shadowBufferVirt for MMIO bridge or
- *                       nvmeBar0Gpu for direct access).
- * @param bufferParams Data buffer configuration for read/write operations.
- *                     Buffers must be GPU-accessible. DMA addresses are used
- *                     for PRP (Physical Region Page) entries in NVMe commands.
- *                     Buffers can be nullptr if not used for a given operation
- *                     type.
+ * @param config Base endpoint configuration containing queue
+ *               pointers, timing arrays, and common parameters.
+ * @param ioParams NVMe-specific I/O parameters including LBA
+ *                 configuration, operation counts, access pattern,
+ *                 test pattern seed, and batchSize.
+ * @param doorbellParams Doorbell configuration for notifying the
+ *                       NVMe controller. Supports PCI MMIO bridge
+ *                       and direct BAR0 access.
+ * @param bufferParams Data buffer configuration for read/write
+ *                     operations. Each SQE in a batch uses a
+ *                     separate buffer region (offset b*xfer_size)
+ *                     to avoid data races between in-flight I/Os.
  *
- * @note This is a device function and must be called from GPU kernels.
- * @note Sequential mode: if readIo < 0 or writeIo < 0, operations are issued
- *       one at a time with completion waiting. Writes execute before reads
- *       when both are negative.
- * @note Batch mode: operations are queued and completed asynchronously.
- * @note The function uses config.iterations for batch mode operation count.
+ * @note Device function — must be called from GPU kernels.
+ * @note Writes execute before reads when both are requested.
  */
 __device__ void driveEndpoint(const XioEndpointConfig& config,
                               const nvmeIoParams& ioParams,
@@ -751,11 +744,12 @@ struct nvmeEpConfig {
     uint64_t baseLba;      // Starting LBA for I/O operations (default: 0)
     uint64_t lbaRangeLbas; // LBA range limit (0 = no limit, default: 0)
     uint32_t lfsrSeed;     // Seed for LFSR pattern (0 = derive from LBA)
-    int readIo;    // Number of read I/O operations (negative for sequential)
-    int writeIo;   // Number of write I/O operations (negative for sequential)
-    uint32_t nsid; // Namespace ID (default: 1, must be > 0)
-    uint32_t lbasPerIo; // Number of LBAs per I/O operation (default: 1)
-    bool infiniteMode;  // Infinite mode: run forever.
+    int readIo;            // Number of read I/O operations
+    int writeIo;           // Number of write I/O operations
+    uint32_t nsid;         // Namespace ID (default: 1, must be > 0)
+    uint32_t lbasPerIo;    // Number of LBAs per I/O (default: 1)
+    bool infiniteMode;     // Infinite mode: run forever
+    uint32_t batchSize;    // SQEs per doorbell (1=seq, 0=all)
   } ioParams;
 
   // Data buffer configuration (mirrors nvmeBufferParams POD struct)
@@ -782,7 +776,7 @@ struct nvmeEpConfig {
   nvmeEpConfig()
     : controller(""), queueId(0), queueLength(64), queuesCreated(false),
       queueInfo{}, doorbellAddr(0), sqBaseAddr(0), cqBaseAddr(0), sqSize(0),
-      cqSize(0), ioParams{"random", 512, 0, 0, 0, 0, 0, 1, 1, false},
+      cqSize(0), ioParams{"random", 512, 0, 0, 0, 0, 0, 1, 1, false, 1},
       bufferParams{1024 * 1024},
       doorbellParams{false, 0x0020, 0x0030, nullptr, nullptr} {
   }

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -190,7 +190,10 @@ static __host__ __device__ uint64_t getRandomLba(unsigned op_index,
     seed ^= seed >> 13;
     seed *= 0x9e3779b9;
     seed ^= seed >> 16;
-    return ioParams.baseLba + (seed % ioParams.lbaRangeLbas);
+    uint64_t max_lba = (ioParams.lbaRangeLbas > blocks)
+                         ? (ioParams.lbaRangeLbas - blocks)
+                         : 1;
+    return ioParams.baseLba + (seed % max_lba);
   } else {
     // Sequential access mode
     if (ioParams.lbaRangeLbas > 0) {
@@ -205,58 +208,35 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
                               const nvmeIoParams& ioParams,
                               const nvmeDoorbellParams& doorbellParams,
                               const nvmeBufferParams& bufferParams) {
-  // Extract queue pointers from config
   sqeType* sqeAddr = static_cast<sqeType*>(config.submissionQueue);
   cqeType* cqeAddr = static_cast<cqeType*>(config.completionQueue);
 
-  const bool sequential_mode = (ioParams.readIo < 0 || ioParams.writeIo < 0 ||
-                                ioParams.infiniteMode);
-  bool sequential_is_read = false;
-  unsigned num_ops;
-  unsigned num_read_ops = 0;
-  unsigned num_write_ops = 0;
-  if (sequential_mode) {
-    if (ioParams.infiniteMode) {
-      // Infinite mode: determine operation type from which is negative
-      if (ioParams.readIo < 0) {
-        sequential_is_read = true;
-        num_read_ops = 0;
-        num_write_ops = 0;
-        num_ops = 0;
-      } else {
-        sequential_is_read = false;
-        num_read_ops = 0;
-        num_write_ops = 0;
-        num_ops = 0;
-      }
-    } else if (ioParams.readIo < 0 && ioParams.writeIo < 0) {
-      num_read_ops = -ioParams.readIo;
-      num_write_ops = -ioParams.writeIo;
-      num_ops = num_read_ops + num_write_ops;
-    } else if (ioParams.readIo < 0) {
-      num_ops = -ioParams.readIo;
-      sequential_is_read = true;
-      num_read_ops = num_ops;
-    } else {
-      num_ops = -ioParams.writeIo;
-      sequential_is_read = false;
-      num_write_ops = num_ops;
-    }
-  } else {
-    num_ops = config.iterations;
+  const unsigned num_read_ops = (unsigned)ioParams.readIo;
+  const unsigned num_write_ops = (unsigned)ioParams.writeIo;
+  const unsigned total_ops = num_read_ops + num_write_ops;
+  const bool infinite_is_read = (num_read_ops > 0);
+
+  // Resolve effective batch size: 0 means "all at once"
+  uint32_t batch_size = ioParams.batchSize;
+  if (batch_size == 0) {
+    batch_size = ioParams.infiniteMode ? (uint32_t)(ioParams.queueSize - 1)
+                                       : total_ops;
+  }
+  if (batch_size > (uint32_t)(ioParams.queueSize - 1)) {
+    batch_size = ioParams.queueSize - 1;
+  }
+  if (!ioParams.infiniteMode && batch_size > total_ops) {
+    batch_size = total_ops;
   }
 
   const uint32_t nsid = ioParams.nsid;
   const uint32_t blocks = ioParams.lbasPerIo;
-  const size_t transfer_size = blocks * ioParams.lbaSize;
+  const size_t transfer_size = (size_t)blocks * ioParams.lbaSize;
 
   const bool has_write_buffer = (bufferParams.writeBuffer != nullptr &&
                                  bufferParams.bufferSize > 0);
   const bool has_read_buffer = (bufferParams.readBuffer != nullptr &&
                                 bufferParams.bufferSize > 0);
-  const bool write_only_mode = has_write_buffer && !has_read_buffer;
-  const bool read_only_mode = has_read_buffer && !has_write_buffer;
-  const bool alternate_mode = has_write_buffer && has_read_buffer;
 
   if (has_write_buffer) {
     dataPatternParams patternParams;
@@ -269,122 +249,122 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
     dataPattern(false, patternParams);
   }
 
-  // Initialize phase tracking for completion polling
+  // Initialize CQ phase tracking.
+  // The CQ is zeroed on creation (phase=0).  The NVMe
+  // controller writes CQEs with phase=1 on the first
+  // pass and toggles each time the CQ wraps.
   uint16_t cq_head = 0;
-  volatile cqeType* initial_cqe = &cqeAddr[cq_head];
-  nvme_ep::cqeType initial_cqe_data = nvme_ep::cqeRead(
-    (volatile nvme_ep::cqeType*)initial_cqe);
-  uint8_t expected_phase = NVME_CQE_STATUS_PHASE(initial_cqe_data.status) ^ 1;
-  (void)expected_phase; // Used in batch mode, set here for consistency
+  uint8_t expected_phase = 1;
 
-  // Track submission queue tail
   uint16_t sq_tail = 0;
-  uint16_t last_sq_head = 0;
-  // Track last CQE for polling (update after each completion)
-  nvme_ep::cqeType cqe_last = initial_cqe_data;
 
-  if (sequential_mode) {
-    unsigned i = 0;
-    while ((ioParams.infiniteMode || i < num_ops) &&
-           (config.stopRequested == nullptr || !*config.stopRequested)) {
-      // Wrap command ID to avoid overflow (NVMe command IDs are 16-bit)
-      // Use modulo 65535 + 1 to avoid cmd_id = 0
-      uint16_t cmd_id = (uint16_t)((i % 65535) + 1);
+  // Per-batch start times for less-timing / infinite mode
+  unsigned long long int batchStartTimes[256];
+  const bool useBatchTiming = (config.timingStats != nullptr);
+
+  unsigned ops_done = 0;
+  while ((ioParams.infiniteMode || ops_done < total_ops) &&
+         (config.stopRequested == nullptr || !*config.stopRequested)) {
+    unsigned batch_count = batch_size;
+    if (!ioParams.infiniteMode && ops_done + batch_count > total_ops) {
+      batch_count = total_ops - ops_done;
+    }
+
+    // === Submit batch_count SQEs ===
+    for (unsigned b = 0; b < batch_count; b++) {
+      unsigned op_idx = ops_done + b;
+      uint16_t cmd_id = (uint16_t)((op_idx % 65535) + 1);
 
       bool is_read_op;
       if (ioParams.infiniteMode) {
-        is_read_op = sequential_is_read;
-      } else if (num_read_ops > 0 && num_write_ops > 0) {
-        if (i < num_write_ops) {
-          is_read_op = false;
-        } else {
-          is_read_op = true;
-        }
+        is_read_op = infinite_is_read;
+      } else if (num_write_ops > 0 && num_read_ops > 0) {
+        is_read_op = (op_idx >= num_write_ops);
       } else {
-        is_read_op = sequential_is_read;
+        is_read_op = (num_read_ops > 0);
       }
 
-      // Calculate LBA
-      uint64_t lba = getRandomLba(i, cmd_id, blocks, ioParams);
+      uint64_t lba = getRandomLba(op_idx, cmd_id, blocks, ioParams);
 
-      // Setup read or write command
-      nvme_ep::sqeType sqeLocal = {};
+      sqeType sqeLocal = {};
       sqeType* sqe = &sqeLocal;
       sqe->opcode = is_read_op ? nvme_cmd_read : nvme_cmd_write;
       sqe->command_id = cmd_id;
       sqe->nsid = nsid;
 
-      // Calculate PRPs based on command type (read or write)
+      // Each SQE in the batch uses its own buffer
+      // region to avoid data races between in-flight
+      // I/Os
+      uint64_t buf_off = (uint64_t)b * transfer_size;
       bool prp_valid = false;
+
       if (is_read_op && has_read_buffer) {
-        // For sequential reads, reuse the same buffer for every I/O
-        uint64_t buffer_offset = 0;
-        if (buffer_offset + transfer_size <= bufferParams.bufferSize) {
-          // Must use DMA address - virtual address won't work for NVMe
-          if (bufferParams.readBufferDma == 0) {
-            __builtin_trap(); // DMA address must be set
-          }
-          uint64_t buffer_addr = bufferParams.readBufferDma + buffer_offset;
-          calculatePrps(buffer_addr, transfer_size, sqe);
+        if (buf_off + transfer_size <= bufferParams.bufferSize) {
+          uint64_t addr = bufferParams.readBufferDma
+                            ? (bufferParams.readBufferDma + buf_off)
+                            : (uint64_t)(bufferParams.readBuffer + buf_off);
+          calculatePrps(addr, transfer_size, sqe);
           prp_valid = true;
         }
       } else if (!is_read_op && has_write_buffer) {
-        // For sequential writes, reuse the same buffer for every I/O
-        // (same as reads) to support infinite mode
-        uint64_t buffer_offset = 0;
-        if (buffer_offset + transfer_size <= bufferParams.bufferSize) {
-          // Must use DMA address - virtual address won't work for NVMe
-          if (bufferParams.writeBufferDma == 0) {
-            __builtin_trap(); // DMA address must be set
-          }
-          uint64_t buffer_addr = bufferParams.writeBufferDma + buffer_offset;
-          calculatePrps(buffer_addr, transfer_size, sqe);
+        if (buf_off + transfer_size <= bufferParams.bufferSize) {
+          uint64_t addr = bufferParams.writeBufferDma
+                            ? (bufferParams.writeBufferDma + buf_off)
+                            : (uint64_t)(bufferParams.writeBuffer + buf_off);
+          calculatePrps(addr, transfer_size, sqe);
           prp_valid = true;
         }
       }
 
-      // Fail if PRPs could not be calculated
       if (!prp_valid) {
         __builtin_trap();
       }
       sqeSetup(sqe, lba, blocks);
 
-      // Record start time (full timing mode) or start tracking (less-timing)
-      // Note: In infinite mode, we only use timingStats (not startTimes array)
-      unsigned long long int startTime = 0;
+      // Record start time
       if (!ioParams.infiniteMode && config.startTimes != nullptr) {
-        config.startTimes[i] = wall_clock64();
-      } else if (config.timingStats != nullptr) {
-        startTime = wall_clock64();
+        config.startTimes[op_idx] = wall_clock64();
+      } else if (useBatchTiming && b < 256) {
+        batchStartTimes[b] = wall_clock64();
       }
 
-      // Write SQE to queue slot
-      // sqeWrite includes memory fence for device code to ensure write
-      // completes
-      volatile sqeType* sqe_slot = &sqeAddr[sq_tail];
-      nvme_ep::sqeWrite(sqeLocal, sqe_slot);
-
-      // Memory fence to ensure SQE is fully visible to
-      // the NVMe controller before incrementing tail and
-      // ringing the doorbell. On host memory paths this
-      // fence orders the GPU's PCIe writes but a
-      // read-back may still see stale write-combine data,
-      // so we do not verify here.
-      __threadfence_system();
-
+      nvme_ep::sqeWrite(sqeLocal, &sqeAddr[sq_tail]);
       sq_tail = (sq_tail + 1) % ioParams.queueSize;
+    }
 
-      // Ring doorbell
-      nvme_ep::ringDoorbell(sq_tail, doorbellParams);
+    // Fence + doorbell once for the whole batch
+    __threadfence_system();
+    nvme_ep::ringDoorbell(sq_tail, doorbellParams);
 
-      // Wait for completion using cqePoll
+    // === Poll for batch_count completions ===
+    // Use the NVMe phase bit to detect new CQEs.
+    // The controller toggles the phase each time it
+    // wraps the CQ.  A CQE whose phase matches
+    // expected_phase is a new completion; stale or
+    // zeroed slots will have the opposite phase.
+    for (unsigned b = 0; b < batch_count; b++) {
+      unsigned op_idx = ops_done + b;
+
       volatile cqeType* cqe_entry = &cqeAddr[cq_head];
-      uint16_t new_sq_head = 0;
-      nvme_ep::cqeType cqe_new = nvme_ep::cqePoll(cqe_last, cqe_entry,
-                                                  last_sq_head, &new_sq_head,
-                                                  config.stopRequested);
 
-      // Check completion status
+      nvme_ep::cqeType cqe_new;
+      unsigned poll_count = 0;
+      while (true) {
+        if (config.stopRequested != nullptr && poll_count % 100 == 0 &&
+            *config.stopRequested) {
+          return;
+        }
+        cqe_new = nvme_ep::cqeRead(cqe_entry);
+        uint8_t phase = NVME_CQE_STATUS_PHASE(cqe_new.status);
+        if (phase == expected_phase) {
+          break;
+        }
+        poll_count++;
+        if (poll_count >= NVME_EP_MAX_POLLS) {
+          return;
+        }
+      }
+
       if (!nvme_ep::cqeOk(&cqe_new)) {
         printf("NVMe CQE error: status=0x%04x "
                "sc=0x%02x sct=0x%02x "
@@ -396,176 +376,26 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
         __builtin_trap();
       }
 
-      // Update last CQE for next iteration
-      cqe_last = cqe_new;
-
-      // Update tracking variables
-      if (!ioParams.infiniteMode && config.endTimes != nullptr && cmd_id >= 1 &&
-          cmd_id <= num_ops) {
-        unsigned idx = cmd_id - 1;
-        config.endTimes[idx] = wall_clock64();
-      } else if (config.timingStats != nullptr && startTime > 0) {
+      // Record end time
+      if (!ioParams.infiniteMode && config.endTimes != nullptr) {
+        config.endTimes[op_idx] = wall_clock64();
+      } else if (useBatchTiming && b < 256) {
         unsigned long long int endTime = wall_clock64();
-        if (endTime > startTime) {
-          unsigned long long int duration = endTime - startTime;
-          updateTimingStats(config.timingStats, duration);
+        if (endTime > batchStartTimes[b]) {
+          updateTimingStats(config.timingStats, endTime - batchStartTimes[b]);
         }
       }
+
       cq_head = (cq_head + 1) % ioParams.queueSize;
-      // Update CQ doorbell to notify controller we consumed the completion
-      // CQ doorbell is at SQ doorbell offset + doorBellStride (4 bytes)
+      if (cq_head == 0) {
+        expected_phase ^= 1;
+      }
       nvme_ep::ringDoorbell(cq_head, doorbellParams,
                             doorbellParams.doorbellOffset +
                               nvme_ep::doorBellStride);
-      uint8_t phase = NVME_CQE_STATUS_PHASE(cqe_new.status);
-      expected_phase = phase ^ 1;
-      last_sq_head = new_sq_head;
-      i++; // Increment loop counter
-    }
-  } else {
-    // Batch mode: enqueue some number of SQEs, then ring doorbell,
-    // then poll for completions
-
-    sqeType sqeLocal = {};
-    sqeType* sqe = &sqeLocal;
-
-    // For less-timing mode in batch, we need to store start times locally
-    // Allocate on stack (batch size is typically small, max iterations)
-    unsigned long long int batchStartTimes[256]; // Max 256 ops per batch
-    bool useBatchTiming = (config.timingStats != nullptr);
-
-    // Issue a batch of commands
-    for (unsigned i = 0; i < num_ops; i++) {
-      // Wrap command ID to avoid overflow (NVMe command IDs are 16-bit)
-      // Use modulo 65535 + 1 to avoid cmd_id = 0 (which may be reserved)
-      uint16_t cmd_id = (uint16_t)((i % 65535) + 1);
-
-      // Calculate LBA
-      uint64_t lba = getRandomLba(i, cmd_id, blocks, ioParams);
-
-      // Determine command type
-      bool is_read_command = false;
-      if (write_only_mode) {
-        is_read_command = false;
-      } else if (read_only_mode) {
-        is_read_command = true;
-      } else if (alternate_mode) {
-        is_read_command = (i % 2 == 0);
-      } else {
-        is_read_command = (i % 2 == 0);
-      }
-
-      bool is_write = !is_read_command;
-
-      // Setup command
-      sqe->opcode = is_write ? nvme_cmd_write : nvme_cmd_read;
-      sqe->command_id = cmd_id;
-      sqe->nsid = nsid;
-
-      // Calculate PRPs
-      bool prp_valid = false;
-      if (is_read_command && has_read_buffer) {
-        uint64_t buffer_offset = read_only_mode ? (i * transfer_size)
-                                                : ((i / 2) * transfer_size);
-        if (buffer_offset + transfer_size <= bufferParams.bufferSize) {
-          uint64_t buffer_addr =
-            bufferParams.readBufferDma
-              ? (bufferParams.readBufferDma + buffer_offset)
-              : (uint64_t)(bufferParams.readBuffer + buffer_offset);
-          calculatePrps(buffer_addr, transfer_size, sqe);
-          prp_valid = true;
-        }
-      } else if (is_write && has_write_buffer) {
-        uint64_t buffer_offset = write_only_mode ? (i * transfer_size)
-                                                 : ((i / 2) * transfer_size);
-        if (buffer_offset + transfer_size <= bufferParams.bufferSize) {
-          uint64_t buffer_addr =
-            bufferParams.writeBufferDma
-              ? (bufferParams.writeBufferDma + buffer_offset)
-              : (uint64_t)(bufferParams.writeBuffer + buffer_offset);
-          calculatePrps(buffer_addr, transfer_size, sqe);
-          prp_valid = true;
-        }
-      }
-
-      // Fail if PRPs could not be calculated
-      if (!prp_valid) {
-        __builtin_trap();
-      }
-
-      sqeSetup(sqe, lba, blocks);
-
-      // Record start time (full timing mode) or start tracking (less-timing)
-      unsigned long long int startTime = 0;
-      if (config.startTimes != nullptr) {
-        config.startTimes[i] = wall_clock64();
-      } else if (useBatchTiming && i < 256) {
-        startTime = wall_clock64();
-        batchStartTimes[i] = startTime;
-      }
-
-      // Write SQE
-      nvme_ep::sqeWrite(sqeLocal, &sqeAddr[sq_tail]);
-      sq_tail = (sq_tail + 1) % ioParams.queueSize;
     }
 
-    // Memory fence before doorbell
-    __threadfence_system();
-
-    // Ring doorbell once for all commands
-    nvme_ep::ringDoorbell(sq_tail, doorbellParams);
-
-    // Poll for all completions using cqePoll
-    uint16_t completed_count = 0;
-    nvme_ep::cqeType cqe_last = initial_cqe_data;
-
-    while (completed_count < num_ops &&
-           (config.stopRequested == nullptr || !*config.stopRequested)) {
-      volatile cqeType* cqe_entry = &cqeAddr[cq_head];
-      uint16_t new_sq_head = 0;
-      nvme_ep::cqeType cqe_new = nvme_ep::cqePoll(cqe_last, cqe_entry,
-                                                  last_sq_head, &new_sq_head,
-                                                  config.stopRequested);
-
-      if (new_sq_head > last_sq_head && new_sq_head <= num_ops) {
-        uint16_t new_completions = new_sq_head - last_sq_head;
-        uint64_t end_time = wall_clock64();
-        if (config.endTimes != nullptr) {
-          for (uint16_t i = 0; i < new_completions; i++) {
-            uint16_t completed_cmd_id = last_sq_head + 1 + i;
-            if (completed_cmd_id >= 1 && completed_cmd_id <= num_ops) {
-              unsigned idx = completed_cmd_id - 1;
-              config.endTimes[idx] = end_time;
-            }
-          }
-        } else if (useBatchTiming) {
-          // Update timing stats for each completed command
-          for (uint16_t i = 0; i < new_completions; i++) {
-            uint16_t completed_cmd_id = last_sq_head + 1 + i;
-            if (completed_cmd_id >= 1 && completed_cmd_id <= num_ops) {
-              unsigned idx = completed_cmd_id - 1;
-              if (idx < 256 && batchStartTimes[idx] > 0 &&
-                  end_time > batchStartTimes[idx]) {
-                unsigned long long int duration = end_time -
-                                                  batchStartTimes[idx];
-                updateTimingStats(config.timingStats, duration);
-              }
-            }
-          }
-        }
-        completed_count += new_completions;
-        last_sq_head = new_sq_head;
-        cq_head = (cq_head + 1) % ioParams.queueSize;
-        // Update CQ doorbell to notify controller we consumed the completion
-        // CQ doorbell is at SQ doorbell offset + doorBellStride (4 bytes)
-        nvme_ep::ringDoorbell(cq_head, doorbellParams,
-                              doorbellParams.doorbellOffset +
-                                nvme_ep::doorBellStride);
-        uint8_t phase = NVME_CQE_STATUS_PHASE(cqe_new.status);
-        expected_phase = phase ^ 1;
-        cqe_last = cqe_new;
-      }
-    }
+    ops_done += batch_count;
   }
 }
 
@@ -654,10 +484,10 @@ __host__ void registerCliOptions(CLI::App& app, nvme_ep::nvmeEpConfig* config) {
     ->default_val(0)
     ->group(nvme_group);
   app
-    .add_option(
-      "--read-io", config->ioParams.readIo,
-      "Number of read IO to perform. If negative, issues one SQE at a "
-      "time waiting for completion before issuing the next.")
+    .add_option("--read-io", config->ioParams.readIo,
+                "Number of read I/O to perform. Negative values "
+                "accepted for backward compatibility (converted "
+                "to positive).")
     ->default_val(0)
     ->group(nvme_group);
   app
@@ -702,17 +532,24 @@ __host__ void registerCliOptions(CLI::App& app, nvme_ep::nvmeEpConfig* config) {
     ->check(CLI::PositiveNumber)
     ->group(nvme_group);
   app
-    .add_option(
-      "--write-io", config->ioParams.writeIo,
-      "Number of write IO to perform. If negative, issues one SQE at a "
-      "time waiting for completion before issuing the next.")
+    .add_option("--write-io", config->ioParams.writeIo,
+                "Number of write I/O to perform. Negative values "
+                "accepted for backward compatibility (converted "
+                "to positive).")
     ->default_val(0)
     ->group(nvme_group);
   app
     .add_flag("--infinite", config->ioParams.infiniteMode,
-              "Infinite mode: run forever in sequential mode. Requires "
-              "exactly one of --read-io or --write-io to be negative, "
-              "the other must be 0.")
+              "Infinite mode: run forever. Requires exactly one "
+              "of --read-io or --write-io to be non-zero.")
+    ->group(nvme_group);
+  app
+    .add_option("--batch-size", config->ioParams.batchSize,
+                "Number of SQEs to submit per doorbell ring. "
+                "1 = sequential (one I/O at a time), "
+                "0 = all at once, N = N SQEs per doorbell.")
+    ->default_val(1)
+    ->check(CLI::NonNegativeNumber)
     ->group(nvme_group);
 }
 
@@ -748,28 +585,32 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
     return "Access pattern must be 'sequential' or 'random'";
   }
 
+  // Backward compatibility: convert negative readIo/writeIo
+  // to positive. Negative values previously meant "sequential
+  // mode" which is now the default (batch-size 1).
+  if (config->ioParams.readIo < 0) {
+    config->ioParams.readIo = -config->ioParams.readIo;
+  }
+  if (config->ioParams.writeIo < 0) {
+    config->ioParams.writeIo = -config->ioParams.writeIo;
+  }
+
   // Validate infinite mode requirements
   if (config->ioParams.infiniteMode) {
-    bool read_negative = (config->ioParams.readIo < 0);
-    bool write_negative = (config->ioParams.writeIo < 0);
-    if (read_negative && write_negative) {
-      return "--infinite mode requires exactly one of --read-io or "
-             "--write-io to be negative, not both";
+    bool has_read = (config->ioParams.readIo != 0);
+    bool has_write = (config->ioParams.writeIo != 0);
+    if (has_read && has_write) {
+      return "--infinite requires exactly one of --read-io "
+             "or --write-io to be non-zero, not both";
     }
-    if (!read_negative && !write_negative) {
-      return "--infinite mode requires exactly one of --read-io or "
-             "--write-io to be negative";
-    }
-    if ((read_negative && config->ioParams.writeIo != 0) ||
-        (write_negative && config->ioParams.readIo != 0)) {
-      return "--infinite mode requires the non-negative --read-io or "
-             "--write-io to be exactly 0";
+    if (!has_read && !has_write) {
+      return "--infinite requires exactly one of --read-io "
+             "or --write-io to be non-zero";
     }
   } else {
-    // Validate that at least one I/O count is != 0)
     if (config->ioParams.readIo == 0 && config->ioParams.writeIo == 0) {
-      return "At least one of --read-io or --write-io must be specified with "
-             "value != 0 (use negative values for sequential mode)";
+      return "At least one of --read-io or --write-io "
+             "must be non-zero";
     }
   }
 
@@ -1041,10 +882,12 @@ __host__ hipError_t run(XioEndpointConfig* config) {
           nvmeConfig->bufferParams.bufferSize);
   fprintf(stdout,
           "Kernel parameters: lbaSize=%u, blocks=%u, "
-          "expected transfer_size=%u, writeBufferDma=0x%llx\n",
+          "expected transfer_size=%u, "
+          "writeBufferDma=0x%llx, batchSize=%u\n",
           nvmeConfig->ioParams.lbaSize, nvmeConfig->ioParams.lbasPerIo,
           nvmeConfig->ioParams.lbasPerIo * nvmeConfig->ioParams.lbaSize,
-          (unsigned long long)writeBufferInfo.dmaAddr);
+          (unsigned long long)writeBufferInfo.dmaAddr,
+          nvmeConfig->ioParams.batchSize);
 
   // Build parameter structs for kernel launch
   nvme_ep::nvmeIoParams ioParams;
@@ -1059,6 +902,34 @@ __host__ hipError_t run(XioEndpointConfig* config) {
   ioParams.lbasPerIo = nvmeConfig->ioParams.lbasPerIo;
   ioParams.queueSize = queue_size;
   ioParams.infiniteMode = nvmeConfig->ioParams.infiniteMode;
+  ioParams.batchSize = nvmeConfig->ioParams.batchSize;
+
+  // Validate that batch_size * transfer_size fits in the
+  // data buffer. Each in-flight SQE in a batch uses its own
+  // buffer region.
+  {
+    uint32_t eff_batch = ioParams.batchSize;
+    if (eff_batch == 0) {
+      eff_batch = ioParams.infiniteMode
+                    ? (uint32_t)(queue_size - 1)
+                    : (uint32_t)(ioParams.readIo + ioParams.writeIo);
+    }
+    if (eff_batch > (uint32_t)(queue_size - 1)) {
+      eff_batch = queue_size - 1;
+    }
+    uint64_t xfer = (uint64_t)ioParams.lbasPerIo * ioParams.lbaSize;
+    uint64_t needed = (uint64_t)eff_batch * xfer;
+    if (needed > nvmeConfig->bufferParams.bufferSize) {
+      fprintf(stderr,
+              "Error: batch-size %u * transfer-size %llu "
+              "= %llu exceeds data-buffer-size %zu. "
+              "Increase --data-buffer-size or reduce "
+              "--batch-size.\n",
+              eff_batch, (unsigned long long)xfer, (unsigned long long)needed,
+              nvmeConfig->bufferParams.bufferSize);
+      return hipErrorInvalidValue;
+    }
+  }
 
   nvme_ep::nvmeDoorbellParams doorbellParams;
   doorbellParams.doorbellOffset = doorbell_offset;

--- a/src/tester/xio-tester.cpp
+++ b/src/tester/xio-tester.cpp
@@ -65,8 +65,10 @@ int main(int argc, char** argv) {
   // Common options (will be inherited by subcommands via fallthrough)
   // We'll use a single config that gets copied to the selected endpoint
   XioEndpointConfig commonConfig;
-  // Note: iterations is now endpoint-specific (test-ep has --iterations,
-  // nvme-ep uses --read-io + --write-io)
+  // Note: iterations are endpoint-specific (test-ep
+  // has --iterations, nvme-ep derives count from
+  // --read-io + --write-io and controls doorbell
+  // batching via --batch-size)
 
   app
     .add_option("-t,--threads", commonConfig.numThreads,


### PR DESCRIPTION
Replace the overloaded positive/negative --read-io and --write-io convention with an explicit --batch-size option that controls how many SQEs are submitted before ringing the doorbell:

  --batch-size 1  one SQE per doorbell (default, sequential)
  --batch-size 0  all SQEs at once (fills the queue)
  --batch-size N  N SQEs per doorbell ring

The kernel's separate sequential and batch code paths are unified into a single loop: submit batch_count SQEs, fence, doorbell, poll batch_count completions, repeat.  This enables new combinations that were not previously possible, such as infinite mode with batched doorbells (--infinite --read-io 1 --batch-size 8).

Completion polling now uses the NVMe phase bit instead of the command_id / sq_head heuristics in cqePoll.  The old approach compared a CQE from slot N against the content of slot N+1; a zeroed (stale) slot has a different command_id, so cqePoll returned it immediately as a "new" completion.  This caused the kernel to race ahead of the controller, overwriting SQ entries before they could be fetched.  Phase-bit polling is the spec-mandated detection mechanism: the CQ is zeroed with phase=0, the controller writes CQEs with phase=1 on the first pass and toggles on each CQ wrap, so only genuine completions match the expected phase.

Negative --read-io / --write-io values are still accepted for backward compatibility; validateConfig converts them to positive and the default batch-size of 1 preserves the old sequential behaviour.

Buffer validation ensures batch_size * transfer_size fits in the data buffer; each in-flight SQE in a batch uses a separate buffer region (offset b * transfer_size) to avoid data races.

Updated files:
- nvme-ep.h: add batchSize to nvmeIoParams and nvmeEpConfig
- nvme-ep.hip: add CLI option, update validateConfig, unify driveEndpoint, phase-bit CQ polling, buffer validation in run()
- xio-endpoint.hip: simplify NvmeEndpoint::getIterations
- xio-tester.cpp: update comment
- docs/endpoints.rst: document --batch-size with examples
- docs/index.rst, INSTALL.md: simplify quick-start examples
- .alola sbatch, test scripts: convert negative counts to positive; add --batch-size 0 where all-at-once layout is required for data verification
- .wordlist.txt: add SQEs
