### PR TITLE
nvme-ep: add unit tests, fix cqeWrite, reject --threads > 1

### DIFF
--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -106,6 +106,9 @@ cd "${PROJECT_DIR}"
 detect_gpu_arch
 setup_and_build_workdir "nvme-ep"
 
+test_run "ctest nvme-ep unit tests" \
+  "ctest --test-dir build -L nvme -LE hardware"
+
 echo "Building and loading kernel module on host..."
 build_and_load_kernel_module_on_host
 
@@ -121,6 +124,14 @@ ${SCP_COMMAND} \
   ${WORKING_DIR}/${VERIFY_SCRIPT} \
   localhost:${WORKING_DIR}/${VERIFY_SCRIPT}
 
+# Copy hardware unit test binary to host
+HW_TEST_DIR="build/tests/unit/nvme-ep"
+${SSH_LOCALHOST} \
+  "mkdir -p ${WORKING_DIR}/${HW_TEST_DIR}"
+${SCP_COMMAND} \
+  ${WORKING_DIR}/${HW_TEST_DIR}/test-nvme-hardware \
+  localhost:${WORKING_DIR}/${HW_TEST_DIR}/test-nvme-hardware
+
 # Run tests
 echo "=========================================="
 echo "Running NVMe-EP unit tests"
@@ -130,6 +141,16 @@ if [ -n "${NVME_NAMESPACE}" ]; then
   echo "NVMe Namespace: ${NVME_NAMESPACE}"
 fi
 echo ""
+
+test_run "nvme-ep hardware unit tests" \
+  "run_on_host \
+'${WORKING_DIR}/${HW_TEST_DIR}/test-nvme-hardware \
+--controller ${NON_ROOTFS_CTRL}'"
+
+test_run "nvme-ep reject --threads > 1 (expect fail)" \
+  "! run_on_host '${WORKING_DIR}/build/xio-tester \
+nvme-ep --controller ${NON_ROOTFS_CTRL} \
+--threads 2 -n 1'"
 
 test_run "NVMe-EP memory-mode 0" \
   "run_on_host '${WORKING_DIR}/build/xio-tester \

--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -11,6 +11,7 @@
 #SBATCH --container-image=/cluster/images/rocm-xio/rocm-xio-alola.sqsh
 #SBATCH --container-mount-home
 #SBATCH --constraint=MARKHAM
+#SBATCH --exclude=ctr-halo-b47-02
 #SBATCH --gpus-per-node=1
 
 set -xe
@@ -40,6 +41,9 @@ test_init
 cd "${PROJECT_DIR}"
 detect_gpu_arch
 setup_and_build_workdir "single-gpu"
+
+test_run "ctest unit tests" \
+  "ctest --test-dir build --preset unit"
 
 test_run "test-ep --emulate" \
   "./build/xio-tester test-ep --emulate -n ${ITERATIONS}"

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -64,8 +64,13 @@ __host__ __device__ void sqeWrite(sqeType sqeData,
 #endif // __HIP_DEVICE_COMPILE__
 }
 
-__host__ __device__ void cqeWrite(cqeType cqeData, cqeType* cqeAddress) {
-  *cqeAddress = cqeData;
+__host__ __device__ void cqeWrite(cqeType cqeData,
+                                  volatile cqeType* cqeAddress) {
+  const uint8_t* src = reinterpret_cast<const uint8_t*>(&cqeData);
+  volatile uint8_t* dst = reinterpret_cast<volatile uint8_t*>(cqeAddress);
+  for (size_t i = 0; i < sizeof(cqeType); i++) {
+    dst[i] = src[i];
+  }
 }
 
 // Poll for new SQE - waits for command ID to change
@@ -190,8 +195,9 @@ static __host__ __device__ uint64_t getRandomLba(unsigned op_index,
     seed ^= seed >> 13;
     seed *= 0x9e3779b9;
     seed ^= seed >> 16;
-    uint64_t max_lba = (ioParams.lbaRangeLbas > blocks)
-                         ? (ioParams.lbaRangeLbas - blocks)
+    uint64_t max_lba = (blocks > 0 && ioParams.lbaRangeLbas >= blocks)
+                         ? (static_cast<uint64_t>(ioParams.lbaRangeLbas) -
+                            static_cast<uint64_t>(blocks) + 1U)
                          : 1;
     return ioParams.baseLba + (seed % max_lba);
   } else {
@@ -258,9 +264,16 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
 
   uint16_t sq_tail = 0;
 
-  // Per-batch start times for less-timing / infinite mode
-  unsigned long long int batchStartTimes[256];
+  // Per-batch start times for less-timing / infinite mode.
+  // Stack-allocated, so capped at 256 entries.  Clamp the
+  // effective batch size when timing stats are active so
+  // every operation in the batch is accounted for.
+  constexpr unsigned kMaxTimedBatch = 256;
+  unsigned long long int batchStartTimes[kMaxTimedBatch];
   const bool useBatchTiming = (config.timingStats != nullptr);
+  if (useBatchTiming && batch_size > kMaxTimedBatch) {
+    batch_size = kMaxTimedBatch;
+  }
 
   unsigned ops_done = 0;
   while ((ioParams.infiniteMode || ops_done < total_ops) &&
@@ -324,7 +337,7 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
       // Record start time
       if (!ioParams.infiniteMode && config.startTimes != nullptr) {
         config.startTimes[op_idx] = wall_clock64();
-      } else if (useBatchTiming && b < 256) {
+      } else if (useBatchTiming && b < kMaxTimedBatch) {
         batchStartTimes[b] = wall_clock64();
       }
 
@@ -361,7 +374,10 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
         }
         poll_count++;
         if (poll_count >= NVME_EP_MAX_POLLS) {
-          return;
+          printf("NVMe CQ poll timeout after %u polls "
+                 "(cq_head=%u expected_phase=%u)\n",
+                 poll_count, (unsigned)cq_head, (unsigned)expected_phase);
+          __builtin_trap();
         }
       }
 
@@ -379,7 +395,7 @@ __device__ void driveEndpoint(const XioEndpointConfig& config,
       // Record end time
       if (!ioParams.infiniteMode && config.endTimes != nullptr) {
         config.endTimes[op_idx] = wall_clock64();
-      } else if (useBatchTiming && b < 256) {
+      } else if (useBatchTiming && b < kMaxTimedBatch) {
         unsigned long long int endTime = wall_clock64();
         if (endTime > batchStartTimes[b]) {
           updateTimingStats(config.timingStats, endTime - batchStartTimes[b]);
@@ -676,6 +692,14 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     fprintf(stderr,
             "Error: NVMe device not specified. --controller is required.\n");
     return hipErrorInvalidValue;
+  }
+
+  if (config->numThreads > 1) {
+    fprintf(stderr, "Error: nvme-ep does not support "
+                    "--threads > 1 at this time. "
+                    "Each thread would share the same "
+                    "NVMe queue pair, causing corruption.\n");
+    return hipErrorNotSupported;
   }
 
   // Create NVMe queues - MUST succeed before proceeding

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -8,3 +8,4 @@
 add_subdirectory(common)
 add_subdirectory(test-ep)
 add_subdirectory(rdma-ep)
+add_subdirectory(nvme-ep)

--- a/tests/unit/nvme-ep/CMakeLists.txt
+++ b/tests/unit/nvme-ep/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# CPU-only unit tests for the nvme-ep endpoint.
+
+xio_add_test(
+  NAME test-nvme-config
+  SOURCE test-nvme-config.hip
+  LABELS unit nvme
+  TIMEOUT 30
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/nvme-ep
+)
+
+xio_add_test(
+  NAME test-nvme-helpers
+  SOURCE test-nvme-helpers.hip
+  LABELS unit nvme
+  TIMEOUT 30
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/nvme-ep
+)
+
+# Hardware integration tests (require real NVMe device)
+xio_add_test(
+  NAME test-nvme-hardware
+  SOURCE test-nvme-hardware.hip
+  LABELS hardware nvme
+  TIMEOUT 60
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/nvme-ep
+)
+set_tests_properties(test-nvme-hardware PROPERTIES
+  SKIP_RETURN_CODE 77)

--- a/tests/unit/nvme-ep/test-nvme-config.hip
+++ b/tests/unit/nvme-ep/test-nvme-config.hip
@@ -1,0 +1,238 @@
+/* Copyright (c) Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for nvme-ep configuration, struct sizes,
+ * magic constants, and queue-length validation.
+ */
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <hip/hip_runtime.h>
+
+#include "nvme-ep.h"
+
+using namespace xio::nvme_ep;
+
+#define ASSERT_EQ(a, b)                                                        \
+  do {                                                                         \
+    if ((a) != (b)) {                                                          \
+      printf("ASSERT_EQ failed: %s:%d: "                                       \
+             "%s != %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_TRUE(x)                                                         \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      printf("ASSERT_TRUE failed: %s:%d: %s\n", __FILE__, __LINE__, #x);       \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+int test_struct_sizes() {
+  ASSERT_EQ(sizeof(struct nvme_sqe), 64u);
+  ASSERT_EQ(sizeof(struct nvme_cqe), 16u);
+  ASSERT_EQ(sizeof(struct nvme_smart_log), 512u);
+  ASSERT_EQ(sizeof(struct nvme_id_ns), 4096u);
+  ASSERT_EQ(sizeof(struct nvme_lbaf), 4u);
+  return 0;
+}
+
+int test_queue_entry_size_macros() {
+  ASSERT_EQ(NVME_EP_SQE_SIZE, 64);
+  ASSERT_EQ(NVME_EP_CQE_SIZE, 16);
+  ASSERT_EQ(NVME_NVM_IOSQES, 6);
+  ASSERT_EQ(NVME_NVM_IOCQES, 4);
+  ASSERT_EQ(1 << NVME_NVM_IOSQES, NVME_EP_SQE_SIZE);
+  ASSERT_EQ(1 << NVME_NVM_IOCQES, NVME_EP_CQE_SIZE);
+  return 0;
+}
+
+int test_sqe_field_access() {
+  struct nvme_sqe sqe = {};
+  sqe.opcode = nvme_cmd_read;
+  sqe.flags = 0x42;
+  sqe.command_id = 0xBEEF;
+  sqe.nsid = 1;
+  sqe.cdw10 = 0x11111111;
+  sqe.cdw11 = 0x22222222;
+  sqe.cdw12 = 7;
+  sqe.cdw13 = 0x33333333;
+  sqe.cdw14 = 0x44444444;
+  sqe.cdw15 = 0x55555555;
+  sqe.dptr.prp.prp1 = 0xDEAD000000000000ULL;
+  sqe.dptr.prp.prp2 = 0xCAFE000000000000ULL;
+
+  ASSERT_EQ(sqe.opcode, (uint8_t)nvme_cmd_read);
+  ASSERT_EQ(sqe.flags, 0x42);
+  ASSERT_EQ(sqe.command_id, 0xBEEF);
+  ASSERT_EQ(sqe.nsid, 1u);
+  ASSERT_EQ(sqe.cdw10, 0x11111111u);
+  ASSERT_EQ(sqe.cdw11, 0x22222222u);
+  ASSERT_EQ(sqe.cdw12, 7u);
+  ASSERT_EQ(sqe.dptr.prp.prp1, 0xDEAD000000000000ULL);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0xCAFE000000000000ULL);
+  return 0;
+}
+
+int test_cqe_field_access() {
+  struct nvme_cqe cqe = {};
+  cqe.result = 0x123456789ABCDEF0ULL;
+  cqe.sq_head = 42;
+  cqe.sq_id = 5;
+  cqe.command_id = 0x1234;
+  cqe.status = NVME_STATUS_MAKE(1, 0, 0);
+
+  ASSERT_EQ(cqe.result, 0x123456789ABCDEF0ULL);
+  ASSERT_EQ(cqe.sq_head, 42);
+  ASSERT_EQ(cqe.sq_id, 5);
+  ASSERT_EQ(cqe.command_id, 0x1234);
+  ASSERT_EQ(NVME_CQE_STATUS_PHASE(cqe.status), 1u);
+  ASSERT_EQ(NVME_CQE_STATUS_SC(cqe.status), 0u);
+  ASSERT_EQ(NVME_CQE_STATUS_SCT(cqe.status), 0u);
+  return 0;
+}
+
+int test_cqe_cdw0_union() {
+  struct nvme_cqe cqe = {};
+  cqe.cdw0 = 0xAABBCCDD;
+  cqe.rsvd = 0x11223344;
+  ASSERT_EQ(cqe.cdw0, 0xAABBCCDD);
+  ASSERT_EQ(cqe.rsvd, 0x11223344u);
+  uint64_t expected = (uint64_t)0x11223344 << 32 | 0xAABBCCDD;
+  ASSERT_EQ(cqe.result, expected);
+  return 0;
+}
+
+int test_config_defaults() {
+  nvmeEpConfig cfg;
+
+  ASSERT_TRUE(cfg.controller.empty());
+  ASSERT_EQ(cfg.queueId, 0);
+  ASSERT_EQ(cfg.queueLength, 64);
+  ASSERT_TRUE(!cfg.queuesCreated);
+  ASSERT_EQ(cfg.doorbellAddr, 0u);
+  ASSERT_EQ(cfg.sqBaseAddr, 0u);
+  ASSERT_EQ(cfg.cqBaseAddr, 0u);
+  ASSERT_EQ(cfg.sqSize, 0u);
+  ASSERT_EQ(cfg.cqSize, 0u);
+
+  ASSERT_TRUE(cfg.ioParams.accessPattern == "random");
+  ASSERT_EQ(cfg.ioParams.lbaSize, 512u);
+  ASSERT_EQ(cfg.ioParams.baseLba, 0u);
+  ASSERT_EQ(cfg.ioParams.lbaRangeLbas, 0u);
+  ASSERT_EQ(cfg.ioParams.lfsrSeed, 0u);
+  ASSERT_EQ(cfg.ioParams.readIo, 0);
+  ASSERT_EQ(cfg.ioParams.writeIo, 0);
+  ASSERT_EQ(cfg.ioParams.nsid, 1u);
+  ASSERT_EQ(cfg.ioParams.lbasPerIo, 1u);
+  ASSERT_TRUE(!cfg.ioParams.infiniteMode);
+  ASSERT_EQ(cfg.ioParams.batchSize, 1u);
+
+  ASSERT_EQ(cfg.bufferParams.bufferSize, (size_t)(1024 * 1024));
+
+  ASSERT_TRUE(!cfg.doorbellParams.usePciMmioBridge);
+  ASSERT_EQ(cfg.doorbellParams.mmioBridgeBdf, 0x0020);
+  ASSERT_EQ(cfg.doorbellParams.nvmeTargetBdf, 0x0030);
+  ASSERT_EQ(cfg.doorbellParams.shadowBufferVirt, nullptr);
+  ASSERT_EQ(cfg.doorbellParams.nvmeBar0Gpu, nullptr);
+  return 0;
+}
+
+int test_doorbell_constants() {
+  ASSERT_EQ(doorbellBase, 0x1000u);
+  ASSERT_EQ(doorBellStride, 4u);
+  return 0;
+}
+
+int test_admin_response_size() {
+  ASSERT_EQ(nvmeAdminRespSize, 4096u);
+  ASSERT_EQ(nvmeLogPageSize, 512u);
+  return 0;
+}
+
+int test_command_opcodes() {
+  ASSERT_EQ(nvme_cmd_read, 0x02);
+  ASSERT_EQ(nvme_cmd_write, 0x01);
+  ASSERT_EQ(nvme_cmd_flush, 0x00);
+  ASSERT_EQ(nvme_admin_identify, 0x06);
+  ASSERT_EQ(nvme_admin_create_sq, 0x01);
+  ASSERT_EQ(nvme_admin_create_cq, 0x05);
+  ASSERT_EQ(nvme_admin_delete_sq, 0x00);
+  ASSERT_EQ(nvme_admin_delete_cq, 0x04);
+  return 0;
+}
+
+static bool is_power_of_2(uint32_t v) {
+  return v != 0 && (v & (v - 1)) == 0;
+}
+
+int test_queue_length_validation() {
+  ASSERT_TRUE(!is_power_of_2(0));
+  ASSERT_TRUE(is_power_of_2(1));
+  ASSERT_TRUE(is_power_of_2(2));
+  ASSERT_TRUE(!is_power_of_2(3));
+  ASSERT_TRUE(is_power_of_2(4));
+  ASSERT_TRUE(!is_power_of_2(63));
+  ASSERT_TRUE(is_power_of_2(64));
+  ASSERT_TRUE(!is_power_of_2(100));
+  ASSERT_TRUE(is_power_of_2(1024));
+  ASSERT_TRUE(!is_power_of_2(4095));
+  ASSERT_TRUE(is_power_of_2(4096));
+  ASSERT_TRUE(is_power_of_2(65536));
+  ASSERT_TRUE(!is_power_of_2(65537));
+
+  ASSERT_TRUE(1 >= 1 && 1 <= 65536 && is_power_of_2(1));
+  ASSERT_TRUE(64 >= 1 && 64 <= 65536 && is_power_of_2(64));
+  ASSERT_TRUE(65536 >= 1 && 65536 <= 65536 && is_power_of_2(65536));
+  ASSERT_TRUE(!(65537 >= 1 && 65537 <= 65536));
+  return 0;
+}
+
+int test_nvme_page_size() {
+  ASSERT_EQ(NVME_PAGE_SIZE, 4096);
+  return 0;
+}
+
+int test_status_code_constants() {
+  ASSERT_EQ(NVME_SCT_GENERIC, 0x0);
+  ASSERT_EQ(NVME_SCT_CMD_SPECIFIC, 0x1);
+  ASSERT_EQ(NVME_SCT_MEDIA_ERROR, 0x2);
+  ASSERT_EQ(NVME_SCT_VENDOR, 0x7);
+  ASSERT_EQ(NVME_SC_SUCCESS, 0x0);
+  ASSERT_EQ(NVME_SC_INVALID_OPCODE, 0x1);
+  ASSERT_EQ(NVME_SC_INVALID_FIELD, 0x2);
+  ASSERT_EQ(NVME_SC_LBA_RANGE, 0x80);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_struct_sizes();
+  failures += test_queue_entry_size_macros();
+  failures += test_sqe_field_access();
+  failures += test_cqe_field_access();
+  failures += test_cqe_cdw0_union();
+  failures += test_config_defaults();
+  failures += test_doorbell_constants();
+  failures += test_admin_response_size();
+  failures += test_command_opcodes();
+  failures += test_queue_length_validation();
+  failures += test_nvme_page_size();
+  failures += test_status_code_constants();
+
+  if (failures == 0) {
+    printf("All nvme-ep config tests passed.\n");
+    return 0;
+  }
+  printf("%d nvme-ep config test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/nvme-ep/test-nvme-hardware.hip
+++ b/tests/unit/nvme-ep/test-nvme-hardware.hip
@@ -1,0 +1,220 @@
+/* Copyright (c) Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Hardware integration tests for nvme-ep.
+ * Requires a real NVMe controller.
+ * Skips with exit code 77 if no device is available.
+ *
+ * Usage:
+ *   test-nvme-hardware --controller /dev/nvme2
+ *   NVME_DEVICE=/dev/nvme2 test-nvme-hardware
+ *   test-nvme-hardware  (auto-detects /dev/nvme0)
+ */
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include <hip/hip_runtime.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "nvme-ep.h"
+
+using namespace xio::nvme_ep;
+
+#define ASSERT_EQ(a, b)                                                        \
+  do {                                                                         \
+    if ((a) != (b)) {                                                          \
+      printf("ASSERT_EQ failed: %s:%d: "                                       \
+             "%s != %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_TRUE(x)                                                         \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      printf("ASSERT_TRUE failed: %s:%d: %s\n", __FILE__, __LINE__, #x);       \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_GE(a, b)                                                        \
+  do {                                                                         \
+    if (!((a) >= (b))) {                                                       \
+      printf("ASSERT_GE failed: %s:%d: "                                       \
+             "%s < %s\n",                                                      \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_LE(a, b)                                                        \
+  do {                                                                         \
+    if (!((a) <= (b))) {                                                       \
+      printf("ASSERT_LE failed: %s:%d: "                                       \
+             "%s > %s\n",                                                      \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_GT(a, b)                                                        \
+  do {                                                                         \
+    if (!((a) > (b))) {                                                        \
+      printf("ASSERT_GT failed: %s:%d: "                                       \
+             "%s <= %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+static std::string g_controller;
+
+static bool is_power_of_2(unsigned v) {
+  return v != 0 && (v & (v - 1)) == 0;
+}
+
+int test_queryLbaSize() {
+  unsigned lba_size = 0;
+  int ret = queryLbaSize(g_controller.c_str(), 1, &lba_size);
+  ASSERT_EQ(ret, 0);
+  ASSERT_TRUE(is_power_of_2(lba_size));
+  ASSERT_GE(lba_size, 512u);
+  ASSERT_LE(lba_size, 4096u);
+  printf("  LBA size: %u bytes\n", lba_size);
+  return 0;
+}
+
+int test_queryNamespaceCapacity() {
+  uint64_t capacity = 0;
+  int ret = queryNamespaceCapacity(g_controller.c_str(), 1, &capacity);
+  ASSERT_EQ(ret, 0);
+  ASSERT_GT(capacity, 0u);
+  printf("  Namespace capacity: %llu LBAs\n", (unsigned long long)capacity);
+  return 0;
+}
+
+int test_queryMaxQueueId() {
+  uint16_t max_qid = 0;
+  int ret = queryMaxQueueId(g_controller.c_str(), &max_qid);
+  ASSERT_EQ(ret, 0);
+  ASSERT_GE(max_qid, 1u);
+  printf("  Max queue ID: %u\n", max_qid);
+  return 0;
+}
+
+int test_checkRootfs() {
+  int ret = checkRootfs(g_controller.c_str());
+  ASSERT_EQ(ret, 0);
+  printf("  Device is not rootfs (safe)\n");
+  return 0;
+}
+
+static uint64_t read_le128_low64(const uint8_t* p) {
+  uint64_t val = 0;
+  for (int i = 7; i >= 0; i--) {
+    val = (val << 8) | p[i];
+  }
+  return val;
+}
+
+int test_readSmartLog() {
+  struct nvme_smart_log smart = {};
+  int ret = readSmartLog(g_controller.c_str(), &smart);
+  ASSERT_EQ(ret, 0);
+
+  ASSERT_LE(smart.percent_used, 100u);
+
+  uint64_t data_read = read_le128_low64(smart.data_units_read);
+  uint64_t data_written = read_le128_low64(smart.data_units_written);
+
+  printf("  SMART: critical_warning=%u, "
+         "percent_used=%u%%, "
+         "data_read=%llu, data_written=%llu\n",
+         smart.critical_warning, smart.percent_used,
+         (unsigned long long)data_read, (unsigned long long)data_written);
+  return 0;
+}
+
+int test_validateConfig() {
+  nvmeEpConfig cfg;
+  cfg.controller = g_controller;
+  cfg.ioParams.readIo = 10;
+  cfg.ioParams.writeIo = 0;
+  cfg.ioParams.batchSize = 1;
+
+  std::string err = validateConfig(&cfg);
+  if (!err.empty()) {
+    printf("  validateConfig error: %s\n", err.c_str());
+  }
+  ASSERT_TRUE(err.empty());
+
+  ASSERT_TRUE(cfg.ioParams.lbaSize >= 512);
+  ASSERT_TRUE(is_power_of_2(cfg.ioParams.lbaSize));
+
+  ASSERT_GT(cfg.queueId, 0u);
+
+  printf("  validateConfig: OK (lbaSize=%u, "
+         "queueId=%u)\n",
+         cfg.ioParams.lbaSize, cfg.queueId);
+  return 0;
+}
+
+static std::string find_controller(int argc, char** argv) {
+  for (int i = 1; i < argc - 1; i++) {
+    if (strcmp(argv[i], "--controller") == 0) {
+      return argv[i + 1];
+    }
+  }
+
+  const char* env = getenv("NVME_DEVICE");
+  if (env && env[0] != '\0') {
+    return env;
+  }
+
+  if (access("/dev/nvme0", F_OK) == 0) {
+    return "/dev/nvme0";
+  }
+
+  return "";
+}
+
+int main(int argc, char** argv) {
+  g_controller = find_controller(argc, argv);
+  if (g_controller.empty()) {
+    printf("SKIP: no NVMe device available "
+           "(use --controller or NVME_DEVICE)\n");
+    return 77;
+  }
+
+  if (access(g_controller.c_str(), F_OK) != 0) {
+    printf("SKIP: NVMe device %s not found\n", g_controller.c_str());
+    return 77;
+  }
+
+  printf("Testing NVMe device: %s\n", g_controller.c_str());
+
+  int failures = 0;
+  failures += test_queryLbaSize();
+  failures += test_queryNamespaceCapacity();
+  failures += test_queryMaxQueueId();
+  failures += test_checkRootfs();
+  failures += test_readSmartLog();
+  failures += test_validateConfig();
+
+  if (failures == 0) {
+    printf("All nvme-ep hardware tests passed.\n");
+    return 0;
+  }
+  printf("%d nvme-ep hardware test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/nvme-ep/test-nvme-helpers.hip
+++ b/tests/unit/nvme-ep/test-nvme-helpers.hip
@@ -1,0 +1,672 @@
+/* Copyright (c) Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for nvme-ep helper functions:
+ * sqeSetup, calculatePrps, cqeOk, cqeStatusCode,
+ * cqeStatusType, sqeRead/sqeWrite, cqeRead/cqeWrite,
+ * NVME_CQE_STATUS_* macros, NVME_STATUS_MAKE
+ * round-trip, and dataPattern.
+ */
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <hip/hip_runtime.h>
+
+#include "nvme-ep.h"
+
+using namespace xio::nvme_ep;
+
+#define ASSERT_EQ(a, b)                                                        \
+  do {                                                                         \
+    if ((a) != (b)) {                                                          \
+      printf("ASSERT_EQ failed: %s:%d: "                                       \
+             "%s != %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_TRUE(x)                                                         \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      printf("ASSERT_TRUE failed: %s:%d: %s\n", __FILE__, __LINE__, #x);       \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_NE(a, b)                                                        \
+  do {                                                                         \
+    if ((a) == (b)) {                                                          \
+      printf("ASSERT_NE failed: %s:%d: "                                       \
+             "%s == %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+/* ---- sqeSetup tests ---- */
+
+int test_sqeSetup_basic() {
+  struct nvme_sqe sqe = {};
+  sqe.opcode = nvme_cmd_read;
+  sqe.command_id = 1;
+  sqe.nsid = 1;
+  sqe.dptr.prp.prp1 = 0x1000;
+
+  sqeSetup(&sqe, 100, 8);
+
+  ASSERT_EQ(sqe.cdw10, 100u);
+  ASSERT_EQ(sqe.cdw11, 0u);
+  ASSERT_EQ(sqe.cdw12, 7u);
+  ASSERT_EQ(sqe.flags, 0);
+  ASSERT_EQ(sqe.cdw2, 0u);
+  ASSERT_EQ(sqe.cdw3, 0u);
+  ASSERT_EQ(sqe.metadata, 0u);
+  ASSERT_EQ(sqe.cdw13, 0u);
+  ASSERT_EQ(sqe.cdw14, 0u);
+  ASSERT_EQ(sqe.cdw15, 0u);
+  ASSERT_EQ(sqe.dptr.prp.prp1, 0x1000u);
+  return 0;
+}
+
+int test_sqeSetup_large_lba() {
+  struct nvme_sqe sqe = {};
+  sqe.opcode = nvme_cmd_write;
+  sqe.command_id = 2;
+  sqe.nsid = 1;
+
+  uint64_t lba = 0x0000000100000042ULL;
+  sqeSetup(&sqe, lba, 1);
+
+  ASSERT_EQ(sqe.cdw10, 0x00000042u);
+  ASSERT_EQ(sqe.cdw11, 0x00000001u);
+  ASSERT_EQ(sqe.cdw12, 0u);
+  return 0;
+}
+
+int test_sqeSetup_zero_preserves() {
+  struct nvme_sqe sqe = {};
+  sqe.cdw10 = 0xAAAAAAAA;
+  sqe.cdw11 = 0xBBBBBBBB;
+  sqe.cdw12 = 0xCCCCCCCC;
+
+  sqeSetup(&sqe, 0, 0);
+
+  ASSERT_EQ(sqe.cdw10, 0xAAAAAAAAu);
+  ASSERT_EQ(sqe.cdw11, 0xBBBBBBBBu);
+  ASSERT_EQ(sqe.cdw12, 0xCCCCCCCCu);
+  ASSERT_EQ(sqe.flags, 0);
+  ASSERT_EQ(sqe.cdw13, 0u);
+  return 0;
+}
+
+int test_sqeSetup_nlb_one() {
+  struct nvme_sqe sqe = {};
+  sqeSetup(&sqe, 50, 1);
+  ASSERT_EQ(sqe.cdw12, 0u);
+  ASSERT_EQ(sqe.cdw10, 50u);
+  return 0;
+}
+
+/* ---- calculatePrps tests ---- */
+
+int test_prp_single_page_aligned() {
+  struct nvme_sqe sqe = {};
+  calculatePrps(0x10000, 512, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, 0x10000u);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0u);
+  return 0;
+}
+
+int test_prp_single_page_fits() {
+  struct nvme_sqe sqe = {};
+  calculatePrps(0x10000, NVME_PAGE_SIZE, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, 0x10000u);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0u);
+  return 0;
+}
+
+int test_prp_crosses_page_boundary() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x10F00;
+  uint32_t size = 4096;
+  calculatePrps(addr, size, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0x11000u);
+  return 0;
+}
+
+int test_prp_unaligned_within_page() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x10200;
+  uint32_t size = 256;
+  calculatePrps(addr, size, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0u);
+  return 0;
+}
+
+int test_prp_at_page_boundary() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x11000;
+  uint32_t size = NVME_PAGE_SIZE;
+  calculatePrps(addr, size, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0u);
+  return 0;
+}
+
+int test_prp_two_full_pages() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x20000;
+  uint32_t size = 2 * NVME_PAGE_SIZE;
+  calculatePrps(addr, size, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0x21000u);
+  return 0;
+}
+
+/* ---- cqeOk / cqeStatusCode / cqeStatusType ---- */
+
+int test_cqeOk_success() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(0, NVME_SC_SUCCESS, NVME_SCT_GENERIC);
+  ASSERT_TRUE(cqeOk(&cqe));
+  return 0;
+}
+
+int test_cqeOk_success_with_phase() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(1, NVME_SC_SUCCESS, NVME_SCT_GENERIC);
+  ASSERT_TRUE(cqeOk(&cqe));
+  return 0;
+}
+
+int test_cqeOk_error_sc() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(0, NVME_SC_LBA_RANGE, NVME_SCT_GENERIC);
+  ASSERT_TRUE(!cqeOk(&cqe));
+  return 0;
+}
+
+int test_cqeOk_error_sct() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(0, NVME_SC_SUCCESS, NVME_SCT_CMD_SPECIFIC);
+  ASSERT_TRUE(!cqeOk(&cqe));
+  return 0;
+}
+
+int test_cqeOk_vendor_error() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(0, 0x42, NVME_SCT_VENDOR);
+  ASSERT_TRUE(!cqeOk(&cqe));
+  return 0;
+}
+
+int test_cqeStatusCode_extraction() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(0, 0x80, NVME_SCT_GENERIC);
+  ASSERT_EQ(cqeStatusCode(&cqe), 0x80u);
+  ASSERT_EQ(cqeStatusType(&cqe), (uint8_t)NVME_SCT_GENERIC);
+  return 0;
+}
+
+int test_cqeStatusType_extraction() {
+  struct nvme_cqe cqe = {};
+  cqe.status = NVME_STATUS_MAKE(1, 0x02, NVME_SCT_MEDIA_ERROR);
+  ASSERT_EQ(cqeStatusCode(&cqe), 0x02u);
+  ASSERT_EQ(cqeStatusType(&cqe), (uint8_t)NVME_SCT_MEDIA_ERROR);
+  return 0;
+}
+
+/* ---- NVME_CQE_STATUS_* macro tests ---- */
+
+int test_status_macros() {
+  uint16_t status = 0xFFFF;
+  ASSERT_EQ(NVME_CQE_STATUS_PHASE(status), 1u);
+  ASSERT_EQ(NVME_CQE_STATUS_SC(status), 0xFFu);
+  ASSERT_EQ(NVME_CQE_STATUS_SCT(status), 0x7u);
+  ASSERT_EQ(NVME_CQE_STATUS_CRD(status), 0x3u);
+  ASSERT_EQ(NVME_CQE_STATUS_MORE(status), 0x1u);
+  ASSERT_EQ(NVME_CQE_STATUS_DNR(status), 0x1u);
+
+  status = 0x0000;
+  ASSERT_EQ(NVME_CQE_STATUS_PHASE(status), 0u);
+  ASSERT_EQ(NVME_CQE_STATUS_SC(status), 0u);
+  ASSERT_EQ(NVME_CQE_STATUS_SCT(status), 0u);
+  ASSERT_EQ(NVME_CQE_STATUS_CRD(status), 0u);
+  ASSERT_EQ(NVME_CQE_STATUS_MORE(status), 0u);
+  ASSERT_EQ(NVME_CQE_STATUS_DNR(status), 0u);
+
+  status = 0x0001;
+  ASSERT_EQ(NVME_CQE_STATUS_PHASE(status), 1u);
+  ASSERT_EQ(NVME_CQE_STATUS_SC(status), 0u);
+
+  status = (uint16_t)(0x42 << 1);
+  ASSERT_EQ(NVME_CQE_STATUS_SC(status), 0x42u);
+  ASSERT_EQ(NVME_CQE_STATUS_SCT(status), 0u);
+  return 0;
+}
+
+/* ---- NVME_STATUS_MAKE round-trip ---- */
+
+int test_status_make_roundtrip() {
+  uint8_t phases[] = {0, 1};
+  uint8_t scs[] = {0x00, 0x01, 0x42, 0x7F, 0x80, 0xFF};
+  uint8_t scts[] = {0, NVME_SCT_CMD_SPECIFIC, NVME_SCT_MEDIA_ERROR,
+                    NVME_SCT_VENDOR};
+
+  for (unsigned pi = 0; pi < sizeof(phases) / sizeof(phases[0]); pi++) {
+    for (unsigned si = 0; si < sizeof(scs) / sizeof(scs[0]); si++) {
+      for (unsigned ti = 0; ti < sizeof(scts) / sizeof(scts[0]); ti++) {
+        uint8_t p = phases[pi];
+        uint8_t sc = scs[si];
+        uint8_t sct = scts[ti];
+        uint16_t status = NVME_STATUS_MAKE(p, sc, sct);
+
+        ASSERT_EQ(NVME_CQE_STATUS_PHASE(status), p);
+        ASSERT_EQ(NVME_CQE_STATUS_SC(status), sc);
+        ASSERT_EQ(NVME_CQE_STATUS_SCT(status), sct);
+      }
+    }
+  }
+  return 0;
+}
+
+/* ---- sqeRead / sqeWrite round-trip ---- */
+
+int test_sqe_read_write_roundtrip() {
+  struct nvme_sqe original = {};
+  original.opcode = nvme_cmd_write;
+  original.flags = 0x12;
+  original.command_id = 0xABCD;
+  original.nsid = 3;
+  original.cdw2 = 0x11111111;
+  original.cdw3 = 0x22222222;
+  original.metadata = 0x3333333333333333ULL;
+  original.dptr.prp.prp1 = 0x4444444444444444ULL;
+  original.dptr.prp.prp2 = 0x5555555555555555ULL;
+  original.cdw10 = 0x66666666;
+  original.cdw11 = 0x77777777;
+  original.cdw12 = 0x88888888;
+  original.cdw13 = 0x99999999;
+  original.cdw14 = 0xAAAAAAAA;
+  original.cdw15 = 0xBBBBBBBB;
+
+  volatile struct nvme_sqe slot = {};
+  sqeWrite(original, &slot);
+
+  struct nvme_sqe readback = sqeRead(&slot);
+
+  ASSERT_EQ(readback.opcode, original.opcode);
+  ASSERT_EQ(readback.flags, original.flags);
+  ASSERT_EQ(readback.command_id, original.command_id);
+  ASSERT_EQ(readback.nsid, original.nsid);
+  ASSERT_EQ(readback.cdw2, original.cdw2);
+  ASSERT_EQ(readback.cdw3, original.cdw3);
+  ASSERT_EQ(readback.metadata, original.metadata);
+  ASSERT_EQ(readback.dptr.prp.prp1, original.dptr.prp.prp1);
+  ASSERT_EQ(readback.dptr.prp.prp2, original.dptr.prp.prp2);
+  ASSERT_EQ(readback.cdw10, original.cdw10);
+  ASSERT_EQ(readback.cdw11, original.cdw11);
+  ASSERT_EQ(readback.cdw12, original.cdw12);
+  ASSERT_EQ(readback.cdw13, original.cdw13);
+  ASSERT_EQ(readback.cdw14, original.cdw14);
+  ASSERT_EQ(readback.cdw15, original.cdw15);
+  ASSERT_EQ(memcmp(&readback, &original, sizeof(struct nvme_sqe)), 0);
+  return 0;
+}
+
+/* ---- sqeWrite/sqeRead stress ---- */
+
+int test_sqe_roundtrip_stress() {
+  volatile struct nvme_sqe slot = {};
+
+  /* All zeros */
+  struct nvme_sqe zero = {};
+  memset(&zero, 0, sizeof(zero));
+  sqeWrite(zero, &slot);
+  struct nvme_sqe rb = sqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &zero, sizeof(zero)), 0);
+
+  /* All 0xFF */
+  struct nvme_sqe ones = {};
+  memset(&ones, 0xFF, sizeof(ones));
+  sqeWrite(ones, &slot);
+  rb = sqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &ones, sizeof(ones)), 0);
+
+  /* Alternating 0xAA */
+  struct nvme_sqe alt_aa = {};
+  memset(&alt_aa, 0xAA, sizeof(alt_aa));
+  sqeWrite(alt_aa, &slot);
+  rb = sqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &alt_aa, sizeof(alt_aa)), 0);
+
+  /* Alternating 0x55 */
+  struct nvme_sqe alt_55 = {};
+  memset(&alt_55, 0x55, sizeof(alt_55));
+  sqeWrite(alt_55, &slot);
+  rb = sqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &alt_55, sizeof(alt_55)), 0);
+
+  /* Distinct non-trivial fields */
+  struct nvme_sqe distinct = {};
+  distinct.opcode = 0xDE;
+  distinct.flags = 0xAD;
+  distinct.command_id = 0xBEEF;
+  distinct.nsid = 0xCAFEBABE;
+  distinct.cdw2 = 0x01020304;
+  distinct.cdw3 = 0x05060708;
+  distinct.metadata = 0x090A0B0C0D0E0F10ULL;
+  distinct.dptr.prp.prp1 = 0x1112131415161718ULL;
+  distinct.dptr.prp.prp2 = 0x191A1B1C1D1E1F20ULL;
+  distinct.cdw10 = 0x21222324;
+  distinct.cdw11 = 0x25262728;
+  distinct.cdw12 = 0x292A2B2C;
+  distinct.cdw13 = 0x2D2E2F30;
+  distinct.cdw14 = 0x31323334;
+  distinct.cdw15 = 0x35363738;
+  sqeWrite(distinct, &slot);
+  rb = sqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &distinct, sizeof(distinct)), 0);
+  return 0;
+}
+
+/* ---- cqeRead / cqeWrite round-trip ---- */
+
+int test_cqe_read_write_roundtrip() {
+  struct nvme_cqe original = {};
+  original.result = 0xFEDCBA9876543210ULL;
+  original.sq_head = 0x1234;
+  original.sq_id = 0x5678;
+  original.command_id = 0x9ABC;
+  original.status = 0xDEF0;
+
+  volatile struct nvme_cqe slot = {};
+  cqeWrite(original, &slot);
+
+  struct nvme_cqe readback = cqeRead(&slot);
+
+  ASSERT_EQ(readback.result, original.result);
+  ASSERT_EQ(readback.sq_head, original.sq_head);
+  ASSERT_EQ(readback.sq_id, original.sq_id);
+  ASSERT_EQ(readback.command_id, original.command_id);
+  ASSERT_EQ(readback.status, original.status);
+  ASSERT_EQ(memcmp(&readback, &original, sizeof(struct nvme_cqe)), 0);
+  return 0;
+}
+
+/* ---- cqeWrite/cqeRead stress ---- */
+
+int test_cqe_roundtrip_stress() {
+  volatile struct nvme_cqe slot = {};
+
+  struct nvme_cqe zero = {};
+  memset(&zero, 0, sizeof(zero));
+  cqeWrite(zero, &slot);
+  struct nvme_cqe rb = cqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &zero, sizeof(zero)), 0);
+
+  struct nvme_cqe ones = {};
+  memset(&ones, 0xFF, sizeof(ones));
+  cqeWrite(ones, &slot);
+  rb = cqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &ones, sizeof(ones)), 0);
+
+  struct nvme_cqe alt_aa = {};
+  memset(&alt_aa, 0xAA, sizeof(alt_aa));
+  cqeWrite(alt_aa, &slot);
+  rb = cqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &alt_aa, sizeof(alt_aa)), 0);
+
+  struct nvme_cqe alt_55 = {};
+  memset(&alt_55, 0x55, sizeof(alt_55));
+  cqeWrite(alt_55, &slot);
+  rb = cqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &alt_55, sizeof(alt_55)), 0);
+
+  struct nvme_cqe distinct = {};
+  distinct.result = 0x0102030405060708ULL;
+  distinct.sq_head = 0x090A;
+  distinct.sq_id = 0x0B0C;
+  distinct.command_id = 0x0D0E;
+  distinct.status = 0x0F10;
+  cqeWrite(distinct, &slot);
+  rb = cqeRead(&slot);
+  ASSERT_EQ(memcmp(&rb, &distinct, sizeof(distinct)), 0);
+  return 0;
+}
+
+/* ---- dataPattern generate & verify ---- */
+
+int test_dataPattern_generate_verify() {
+  const size_t sz = 512;
+  uint8_t buf[sz];
+  memset(buf, 0, sz);
+
+  dataPatternParams params = {};
+  params.buffer = buf;
+  params.size = sz;
+  params.offset = 0;
+  params.lbaSize = 512;
+  params.lfsrSeed = 0x1234;
+  params.errorOffset = nullptr;
+
+  bool ok = dataPattern(false, params);
+  ASSERT_TRUE(ok);
+
+  bool all_zero = true;
+  for (size_t i = 0; i < sz; i++) {
+    if (buf[i] != 0) {
+      all_zero = false;
+      break;
+    }
+  }
+  ASSERT_TRUE(!all_zero);
+
+  ok = dataPattern(true, params);
+  ASSERT_TRUE(ok);
+  return 0;
+}
+
+int test_dataPattern_corruption_detected() {
+  const size_t sz = 512;
+  uint8_t buf[sz];
+
+  dataPatternParams params = {};
+  params.buffer = buf;
+  params.size = sz;
+  params.offset = 0;
+  params.lbaSize = 512;
+  params.lfsrSeed = 0x5678;
+  params.errorOffset = nullptr;
+
+  dataPattern(false, params);
+
+  buf[100] ^= 0xFF;
+
+  size_t err_off = 0;
+  params.errorOffset = &err_off;
+  bool ok = dataPattern(true, params);
+  ASSERT_TRUE(!ok);
+  ASSERT_EQ(err_off, 100u);
+  return 0;
+}
+
+int test_dataPattern_determinism() {
+  const size_t sz = 1024;
+  uint8_t buf1[sz], buf2[sz];
+
+  dataPatternParams p1 = {};
+  p1.buffer = buf1;
+  p1.size = sz;
+  p1.offset = 0;
+  p1.lbaSize = 512;
+  p1.lfsrSeed = 0xABCD;
+  p1.errorOffset = nullptr;
+  dataPattern(false, p1);
+
+  dataPatternParams p2 = {};
+  p2.buffer = buf2;
+  p2.size = sz;
+  p2.offset = 0;
+  p2.lbaSize = 512;
+  p2.lfsrSeed = 0xABCD;
+  p2.errorOffset = nullptr;
+  dataPattern(false, p2);
+
+  ASSERT_EQ(memcmp(buf1, buf2, sz), 0);
+  return 0;
+}
+
+int test_dataPattern_different_seeds() {
+  const size_t sz = 512;
+  uint8_t buf1[sz], buf2[sz];
+
+  dataPatternParams p = {};
+  p.size = sz;
+  p.offset = 0;
+  p.lbaSize = 512;
+  p.errorOffset = nullptr;
+
+  p.buffer = buf1;
+  p.lfsrSeed = 0x1111;
+  dataPattern(false, p);
+
+  p.buffer = buf2;
+  p.lfsrSeed = 0x2222;
+  dataPattern(false, p);
+
+  ASSERT_NE(memcmp(buf1, buf2, sz), 0);
+  return 0;
+}
+
+/* ---- dataPattern cross-LBA boundary ---- */
+
+int test_dataPattern_cross_lba() {
+  const uint32_t lba_size = 512;
+  const size_t sz = 3 * lba_size;
+  uint8_t buf[sz];
+
+  dataPatternParams p = {};
+  p.buffer = buf;
+  p.size = sz;
+  p.offset = 0;
+  p.lbaSize = lba_size;
+  p.lfsrSeed = 0xBEEF;
+  p.errorOffset = nullptr;
+  dataPattern(false, p);
+
+  bool ok = dataPattern(true, p);
+  ASSERT_TRUE(ok);
+
+  uint8_t buf_copy[sz];
+  memcpy(buf_copy, buf, sz);
+  p.buffer = buf_copy;
+  p.size = sz;
+  p.offset = 0;
+  dataPattern(false, p);
+  ASSERT_EQ(memcmp(buf, buf_copy, sz), 0);
+  return 0;
+}
+
+int test_dataPattern_different_offsets() {
+  const uint32_t lba_size = 512;
+  const size_t sz = lba_size;
+  uint8_t buf_off0[sz], buf_off1[sz];
+
+  dataPatternParams p = {};
+  p.size = sz;
+  p.lbaSize = lba_size;
+  p.lfsrSeed = 0xCAFE;
+  p.errorOffset = nullptr;
+
+  p.buffer = buf_off0;
+  p.offset = 0;
+  dataPattern(false, p);
+
+  p.buffer = buf_off1;
+  p.offset = lba_size;
+  dataPattern(false, p);
+
+  ASSERT_NE(memcmp(buf_off0, buf_off1, sz), 0);
+  return 0;
+}
+
+int test_dataPattern_corruption_at_lba_boundary() {
+  const uint32_t lba_size = 512;
+  const size_t sz = 2 * lba_size;
+  uint8_t buf[sz];
+
+  dataPatternParams p = {};
+  p.buffer = buf;
+  p.size = sz;
+  p.offset = 0;
+  p.lbaSize = lba_size;
+  p.lfsrSeed = 0xFACE;
+  p.errorOffset = nullptr;
+  dataPattern(false, p);
+
+  buf[lba_size] ^= 0xFF;
+
+  size_t err_off = 0;
+  p.errorOffset = &err_off;
+  bool ok = dataPattern(true, p);
+  ASSERT_TRUE(!ok);
+  ASSERT_EQ(err_off, (size_t)lba_size);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+
+  failures += test_sqeSetup_basic();
+  failures += test_sqeSetup_large_lba();
+  failures += test_sqeSetup_zero_preserves();
+  failures += test_sqeSetup_nlb_one();
+
+  failures += test_prp_single_page_aligned();
+  failures += test_prp_single_page_fits();
+  failures += test_prp_crosses_page_boundary();
+  failures += test_prp_unaligned_within_page();
+  failures += test_prp_at_page_boundary();
+  failures += test_prp_two_full_pages();
+
+  failures += test_cqeOk_success();
+  failures += test_cqeOk_success_with_phase();
+  failures += test_cqeOk_error_sc();
+  failures += test_cqeOk_error_sct();
+  failures += test_cqeOk_vendor_error();
+  failures += test_cqeStatusCode_extraction();
+  failures += test_cqeStatusType_extraction();
+
+  failures += test_status_macros();
+  failures += test_status_make_roundtrip();
+
+  failures += test_sqe_read_write_roundtrip();
+  failures += test_sqe_roundtrip_stress();
+  failures += test_cqe_read_write_roundtrip();
+  failures += test_cqe_roundtrip_stress();
+
+  failures += test_dataPattern_generate_verify();
+  failures += test_dataPattern_corruption_detected();
+  failures += test_dataPattern_determinism();
+  failures += test_dataPattern_different_seeds();
+  failures += test_dataPattern_cross_lba();
+  failures += test_dataPattern_different_offsets();
+  failures += test_dataPattern_corruption_at_lba_boundary();
+
+  if (failures == 0) {
+    printf("All nvme-ep helper tests passed.\n");
+    return 0;
+  }
+  printf("%d nvme-ep helper test(s) failed.\n", failures);
+  return 1;
+}


### PR DESCRIPTION
Add CPU-only and hardware unit tests for the nvme-ep endpoint:

  test-nvme-config   12 tests covering struct sizes (SQE, CQE,
                     SMART, id_ns), field access, config defaults
                     (including batchSize), doorbell constants,
                     command opcodes, queue-length power-of-2
                     validation, and status code constants.

  test-nvme-helpers  27 tests covering sqeSetup (LBA encoding,
                     nlb-1, zero-preserve), calculatePrps (single
                     page, cross-boundary, unaligned, two pages),
                     cqeOk / cqeStatusCode / cqeStatusType,
                     NVME_CQE_STATUS_* macro extraction,
                     NVME_STATUS_MAKE round-trip across edge
                     values, sqeWrite/sqeRead stress (all-zero,
                     all-0xFF, 0xAA/0x55, distinct fields),
                     cqeWrite/cqeRead stress, and dataPattern
                     generate/verify/determinism/cross-LBA/
                     corruption detection.

  test-nvme-hardware 6 tests exercising queryLbaSize,
                     queryNamespaceCapacity, queryMaxQueueId,
                     checkRootfs, readSmartLog, and validateConfig
                     against a real NVMe controller.  Skips with
                     exit 77 when no device is available.

Fix cqeWrite implementation to match the header declaration: the header declares `volatile cqeType*` but the implementation used `cqeType*`, causing a linker mismatch.  Now uses byte-wise copy like sqeWrite for correct volatile semantics.

Reject --threads > 1 in nvme-ep run() since all threads would share the same queue pair without synchronization.
