### PR TITLE
Dev/stebates/cmake library ctests

### DIFF
--- a/.alola/rocm-xio-alola.py
+++ b/.alola/rocm-xio-alola.py
@@ -44,6 +44,8 @@ ALL_TESTS = [
      "rocm-xio-tests.rdma-ep.sbatch"),
     ("rdma-ep-2node",
      "rocm-xio-tests.rdma-ep-2node.sbatch"),
+    ("integration",
+     "rocm-xio-tests.integration.sbatch"),
 ]
 
 ALL_TEST_NAMES = [t[0] for t in ALL_TESTS]

--- a/.alola/rocm-xio-tests.integration.sbatch
+++ b/.alola/rocm-xio-tests.integration.sbatch
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Install-integration tests: install the library to a temp
+# prefix, then configure, build, and run standalone example
+# programs against it via CTest.
+#
+# usage: sbatch rocm-xio-tests.integration.sbatch
+#
+#SBATCH --output=logs/%x.%j.out
+#SBATCH --error=logs/%x.%j.err
+#SBATCH --cpus-per-task=4
+#SBATCH --container-image=/cluster/images/rocm-xio/rocm-xio-alola.sqsh
+#SBATCH --container-mount-home
+#SBATCH --constraint=MARKHAM
+#SBATCH --gpus-per-node=1
+
+set -xe
+
+# Use timestamped logs directory if provided, otherwise use logs/
+LOGS_DIR="${ALOLA_LOGS_DIR:-logs}"
+mkdir -p "${LOGS_DIR}" 2>/dev/null || true
+
+if [ -n "${SLURM_SUBMIT_DIR}" ]; then
+  . "${SLURM_SUBMIT_DIR}/rocm-xio-tests.common"
+else
+  . "$(dirname "${BASH_SOURCE[0]}")/rocm-xio-tests.common"
+fi
+
+display_job_info
+test_init
+
+cd "${PROJECT_DIR}"
+detect_gpu_arch
+setup_and_build_workdir "integration"
+
+# Run the full CTest integration suite.
+# The fixture installs the library to build/_install_test,
+# then each example is configured, built, and run against
+# the installed prefix.
+test_run "ctest integration suite" \
+  "ctest --test-dir build -V -L integration \
+  --output-on-failure --timeout 300"
+
+cd "$HOME"
+rm -rf "${WORKING_DIR}"
+
+test_report
+EXIT_CODE=$?
+
+exit ${EXIT_CODE}

--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -10,8 +10,7 @@
 #SBATCH --cpus-per-task=4
 #SBATCH --container-image=/cluster/images/rocm-xio/rocm-xio-alola.sqsh
 #SBATCH --container-mount-home
-#SBATCH --constraint=MARKHAM
-#SBATCH --exclude=ctr-halo-b47-02
+#SBATCH --constraint=MARKHAM&(GFX942|GFX950)
 #SBATCH --gpus-per-node=1
 
 set -xe

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,6 +15,7 @@ on:
       - '**.cc'
       - 'CMakeLists.txt'
       - 'cmake/**'
+      - 'examples/**'
       - 'scripts/**'
       - 'Makefile'
 
@@ -72,3 +73,7 @@ jobs:
       run: |
         cd build
         cmake --install . --prefix /tmp/rocm-xio-test
+    - name: Run integration tests (install + examples).
+      run: |
+        ctest --test-dir build -V -L "integration" \
+          --parallel --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,10 @@ target_compile_options(rocm-xio PRIVATE
 # HIP-specific compilation flags (relocatable device code)
 target_compile_options(rocm-xio PRIVATE -fgpu-rdc)
 
+# GNUInstallDirs must be included before the INSTALL_INTERFACE
+# generator expression below so CMAKE_INSTALL_INCLUDEDIR is set.
+include(GNUInstallDirs)
+
 # Include directories
 # PUBLIC for headers that consumers need, PRIVATE for internal headers
 target_include_directories(rocm-xio
@@ -455,9 +459,6 @@ endif()
 #-----------------------------------------------------------------------------
 # Install configuration
 #-----------------------------------------------------------------------------
-
-# Include GNUInstallDirs to get CMAKE_INSTALL_INCLUDEDIR, CMAKE_INSTALL_LIBDIR, etc.
-include(GNUInstallDirs)
 
 # Install static library
 install(TARGETS rocm-xio

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,6 +93,20 @@
       }
     },
     {
+      "name": "integration",
+      "displayName": "Integration tests (install + examples)",
+      "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true,
+        "verbosity": "verbose"
+      },
+      "filter": {
+        "include": {
+          "label": "integration"
+        }
+      }
+    },
+    {
       "name": "all",
       "displayName": "All tests",
       "configurePreset": "default",

--- a/cmake/XIOInstallTests.cmake
+++ b/cmake/XIOInstallTests.cmake
@@ -23,6 +23,18 @@ set(XIO_RUN_INSTALL_EXAMPLE
   CACHE FILEPATH
   "Path to the run-install-example.cmake script")
 
+# Derive the ROCm prefix so examples can resolve
+# find_dependency(hip) and find_dependency(hsa-runtime64)
+# inside the installed rocm-xio-config.cmake.
+if(hip_DIR)
+  cmake_path(GET hip_DIR PARENT_PATH _hip_cmake)
+  cmake_path(GET _hip_cmake PARENT_PATH _hip_lib)
+  cmake_path(GET _hip_lib PARENT_PATH
+    XIO_ROCM_PREFIX)
+else()
+  set(XIO_ROCM_PREFIX "/opt/rocm")
+endif()
+
 # xio_install_test_fixture()
 #
 # Register the CTest fixture that installs rocm-xio into
@@ -99,6 +111,7 @@ function(xio_add_install_test)
       -DSOURCE_DIR=${XIO_IT_SOURCE_DIR}
       -DBUILD_DIR=${_build_dir}
       -DPREFIX=${XIO_INSTALL_TEST_PREFIX}
+      -DROCM_PREFIX=${XIO_ROCM_PREFIX}
     )
 
     if(CMAKE_HIP_COMPILER)

--- a/cmake/XIOInstallTests.cmake
+++ b/cmake/XIOInstallTests.cmake
@@ -1,0 +1,131 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# CTest helpers for install-integration tests.
+#
+# These tests install rocm-xio to a temporary prefix and
+# then configure, build, and run standalone example projects
+# against the installed library.
+
+set(XIO_INSTALL_TEST_PREFIX
+  "${CMAKE_BINARY_DIR}/_install_test"
+  CACHE PATH
+  "Prefix for install-integration tests")
+
+set(XIO_INSTALL_TEST_BUILDS
+  "${CMAKE_BINARY_DIR}/_install_test_builds"
+  CACHE PATH
+  "Build tree root for install-integration examples")
+
+set(XIO_RUN_INSTALL_EXAMPLE
+  "${CMAKE_SOURCE_DIR}/cmake/run-install-example.cmake"
+  CACHE FILEPATH
+  "Path to the run-install-example.cmake script")
+
+# xio_install_test_fixture()
+#
+# Register the CTest fixture that installs rocm-xio into
+# XIO_INSTALL_TEST_PREFIX.  All per-example tests declare
+# FIXTURES_REQUIRED on ROCM_XIO_INSTALL so CTest orders
+# them correctly.
+function(xio_install_test_fixture)
+  add_test(
+    NAME install-rocm-xio
+    COMMAND ${CMAKE_COMMAND}
+      --install ${CMAKE_BINARY_DIR}
+      --prefix ${XIO_INSTALL_TEST_PREFIX}
+  )
+  set_tests_properties(install-rocm-xio PROPERTIES
+    FIXTURES_SETUP ROCM_XIO_INSTALL
+    LABELS "integration"
+    TIMEOUT 120
+  )
+endfunction()
+
+# xio_add_install_test()
+#
+# Register a CTest test that builds (and optionally runs) a
+# standalone example project against the installed prefix.
+#
+# Usage:
+#   xio_add_install_test(
+#     NAME list-endpoints
+#     SOURCE_DIR ${CMAKE_SOURCE_DIR}/examples/list-endpoints
+#     [RUN]
+#   )
+#
+# For script-mode (cmake -P) tests:
+#   xio_add_install_test(
+#     NAME find-package
+#     SCRIPT path/to/find-package.cmake
+#   )
+#
+# NAME       - CTest name (prefixed with "example-").
+# SOURCE_DIR - Path to the standalone CMake project.
+# SCRIPT     - Path to a cmake -P script (mutually
+#              exclusive with SOURCE_DIR).
+# RUN        - If set, run the built binary after building
+#              (binary name assumed == NAME).
+function(xio_add_install_test)
+  cmake_parse_arguments(
+    XIO_IT
+    "RUN"
+    "NAME;SOURCE_DIR;SCRIPT"
+    ""
+    ${ARGN}
+  )
+
+  if(NOT XIO_IT_NAME)
+    message(FATAL_ERROR
+      "xio_add_install_test: NAME is required")
+  endif()
+
+  set(_test_name "example-${XIO_IT_NAME}")
+
+  if(XIO_IT_SCRIPT)
+    # Script-mode test: cmake -P <script>
+    add_test(
+      NAME ${_test_name}
+      COMMAND ${CMAKE_COMMAND}
+        -DCMAKE_PREFIX_PATH=${XIO_INSTALL_TEST_PREFIX}
+        -P ${XIO_IT_SCRIPT}
+    )
+  elseif(XIO_IT_SOURCE_DIR)
+    set(_build_dir
+      "${XIO_INSTALL_TEST_BUILDS}/${XIO_IT_NAME}")
+
+    set(_test_args
+      -DSOURCE_DIR=${XIO_IT_SOURCE_DIR}
+      -DBUILD_DIR=${_build_dir}
+      -DPREFIX=${XIO_INSTALL_TEST_PREFIX}
+    )
+
+    if(CMAKE_HIP_COMPILER)
+      list(APPEND _test_args
+        -DHIP_COMPILER=${CMAKE_HIP_COMPILER})
+    endif()
+
+    if(XIO_IT_RUN)
+      list(APPEND _test_args
+        -DRUN_BINARY=${XIO_IT_NAME})
+    endif()
+
+    add_test(
+      NAME ${_test_name}
+      COMMAND ${CMAKE_COMMAND}
+        ${_test_args}
+        -P ${XIO_RUN_INSTALL_EXAMPLE}
+    )
+  else()
+    message(FATAL_ERROR
+      "xio_add_install_test: either SOURCE_DIR "
+      "or SCRIPT is required")
+  endif()
+
+  set_tests_properties(${_test_name} PROPERTIES
+    FIXTURES_REQUIRED ROCM_XIO_INSTALL
+    LABELS "integration"
+    TIMEOUT 120
+  )
+endfunction()

--- a/cmake/rocm-xio-config.cmake.in
+++ b/cmake/rocm-xio-config.cmake.in
@@ -3,20 +3,22 @@
 # Find required dependencies
 find_dependency(hip CONFIG REQUIRED)
 find_dependency(hsa-runtime64 CONFIG REQUIRED)
+find_dependency(hsakmt REQUIRED)
 
 # Include the exported targets
 include("${CMAKE_CURRENT_LIST_DIR}/rocm-xio-targets.cmake")
 
 # Set convenience variables for backward compatibility
 # (though using the target is preferred)
-set(ROCM_XIO_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@/rocm-xio")
+set(ROCM_XIO_INCLUDE_DIRS
+  "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/rocm-xio")
 set(ROCM_XIO_LIBRARIES rocm-xio::rocm-xio)
 
 # Set version variables
-set(ROCM_XIO_VERSION @PACKAGE_VERSION@)
-set(ROCM_XIO_VERSION_MAJOR @PACKAGE_VERSION_MAJOR@)
-set(ROCM_XIO_VERSION_MINOR @PACKAGE_VERSION_MINOR@)
-set(ROCM_XIO_VERSION_PATCH @PACKAGE_VERSION_PATCH@)
+set(ROCM_XIO_VERSION @PROJECT_VERSION@)
+set(ROCM_XIO_VERSION_MAJOR @PROJECT_VERSION_MAJOR@)
+set(ROCM_XIO_VERSION_MINOR @PROJECT_VERSION_MINOR@)
+set(ROCM_XIO_VERSION_PATCH @PROJECT_VERSION_PATCH@)
 
 # Verify required components
 check_required_components(rocm-xio)

--- a/cmake/run-install-example.cmake
+++ b/cmake/run-install-example.cmake
@@ -14,6 +14,9 @@
 #                 prefix (passed as CMAKE_PREFIX_PATH).
 #
 # Optional -D arguments:
+#   ROCM_PREFIX - Path to the ROCm installation (added
+#                 to CMAKE_PREFIX_PATH so find_dependency
+#                 can resolve hip and hsa-runtime64).
 #   RUN_BINARY  - Name of the binary to run after building.
 #                 Skipped if empty or unset.
 #   HIP_COMPILER - Path to the HIP compiler to forward.
@@ -28,10 +31,15 @@ foreach(var SOURCE_DIR BUILD_DIR PREFIX)
 endforeach()
 
 # -- Configure ------------------------------------------
+set(_prefix_path "${PREFIX}")
+if(ROCM_PREFIX)
+  set(_prefix_path "${PREFIX}\;${ROCM_PREFIX}")
+endif()
+
 set(_configure_args
   -S ${SOURCE_DIR}
   -B ${BUILD_DIR}
-  -DCMAKE_PREFIX_PATH=${PREFIX}
+  "-DCMAKE_PREFIX_PATH=${_prefix_path}"
 )
 
 if(HIP_COMPILER)

--- a/cmake/run-install-example.cmake
+++ b/cmake/run-install-example.cmake
@@ -1,0 +1,81 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Wrapper script for CTest install-integration tests.
+#
+# Configures, builds, and optionally runs a standalone
+# example project against an installed rocm-xio prefix.
+#
+# Required -D arguments:
+#   SOURCE_DIR  - Absolute path to the example project.
+#   BUILD_DIR   - Absolute path for the example build tree.
+#   PREFIX      - Absolute path to the rocm-xio install
+#                 prefix (passed as CMAKE_PREFIX_PATH).
+#
+# Optional -D arguments:
+#   RUN_BINARY  - Name of the binary to run after building.
+#                 Skipped if empty or unset.
+#   HIP_COMPILER - Path to the HIP compiler to forward.
+
+cmake_minimum_required(VERSION 3.21)
+
+foreach(var SOURCE_DIR BUILD_DIR PREFIX)
+  if(NOT ${var})
+    message(FATAL_ERROR
+      "${var} must be set (-D${var}=...)")
+  endif()
+endforeach()
+
+# -- Configure ------------------------------------------
+set(_configure_args
+  -S ${SOURCE_DIR}
+  -B ${BUILD_DIR}
+  -DCMAKE_PREFIX_PATH=${PREFIX}
+)
+
+if(HIP_COMPILER)
+  list(APPEND _configure_args
+    -DCMAKE_HIP_COMPILER=${HIP_COMPILER})
+endif()
+
+message(STATUS "Configuring: ${SOURCE_DIR}")
+execute_process(
+  COMMAND ${CMAKE_COMMAND} ${_configure_args}
+  RESULT_VARIABLE _rc
+)
+if(_rc)
+  message(FATAL_ERROR
+    "Configure failed (exit ${_rc})")
+endif()
+
+# -- Build ----------------------------------------------
+message(STATUS "Building: ${BUILD_DIR}")
+execute_process(
+  COMMAND ${CMAKE_COMMAND} --build ${BUILD_DIR}
+  RESULT_VARIABLE _rc
+)
+if(_rc)
+  message(FATAL_ERROR
+    "Build failed (exit ${_rc})")
+endif()
+
+# -- Run (optional) -------------------------------------
+if(RUN_BINARY)
+  set(_bin ${BUILD_DIR}/${RUN_BINARY})
+  if(NOT EXISTS ${_bin})
+    message(FATAL_ERROR
+      "Binary not found: ${_bin}")
+  endif()
+  message(STATUS "Running: ${_bin}")
+  execute_process(
+    COMMAND ${_bin}
+    RESULT_VARIABLE _rc
+  )
+  if(_rc)
+    message(FATAL_ERROR
+      "Run failed (exit ${_rc})")
+  endif()
+endif()
+
+message(STATUS "Install example test passed.")

--- a/examples/endpoint-info/CMakeLists.txt
+++ b/examples/endpoint-info/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Example: iterate the rocm-xio endpoint registry and
+# print each endpoint's name, description, and type.
+#
+# Build against an installed rocm-xio:
+#   cmake -S . -B build \
+#     -DCMAKE_PREFIX_PATH=<install-prefix>
+#   cmake --build build
+
+cmake_minimum_required(VERSION 3.21)
+project(endpoint-info LANGUAGES CXX HIP)
+
+find_package(rocm-xio REQUIRED)
+
+add_executable(endpoint-info endpoint-info.hip)
+target_link_libraries(endpoint-info PRIVATE
+  rocm-xio::rocm-xio)

--- a/examples/endpoint-info/endpoint-info.hip
+++ b/examples/endpoint-info/endpoint-info.hip
@@ -1,0 +1,54 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Example: iterate the rocm-xio endpoint registry and
+ * print each endpoint's name, description, and type.
+ * CPU-only; does not require a GPU to run.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "xio.h"
+
+int main() {
+  const auto& registry = getEndpointRegistry();
+  if (registry.empty()) {
+    printf("ERROR: endpoint registry is empty\n");
+    return 1;
+  }
+
+  printf("rocm-xio endpoint registry "
+         "(%zu entries):\n\n",
+         registry.size());
+
+  for (const auto& ep : registry) {
+    const char* name = getEndpointName(ep.type);
+    if (!name) {
+      printf("ERROR: getEndpointName() returned "
+             "null for type %d\n",
+             static_cast<int>(ep.type));
+      return 1;
+    }
+
+    printf("  %-16s %s\n", ep.name.c_str(), ep.description.c_str());
+
+    if (ep.name != name) {
+      printf("ERROR: registry name '%s' != "
+             "getEndpointName() '%s'\n",
+             ep.name.c_str(), name);
+      return 1;
+    }
+
+    if (!isValidEndpoint(ep.name)) {
+      printf("ERROR: isValidEndpoint('%s') "
+             "returned false\n",
+             ep.name.c_str());
+      return 1;
+    }
+  }
+
+  printf("\nAll endpoint info checks passed.\n");
+  return 0;
+}

--- a/examples/find-package/CMakeLists.txt
+++ b/examples/find-package/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Smoke test: verify that find_package(rocm-xio) locates
+# the installed package and resolves its dependencies.
+#
+# This project has no source files; it validates the
+# install layout at configure time.
+#
+# Usage:
+#   cmake -S . -B build \
+#     -DCMAKE_PREFIX_PATH=<install-prefix>
+
+cmake_minimum_required(VERSION 3.21)
+project(find-package-test LANGUAGES CXX HIP)
+
+find_package(rocm-xio REQUIRED)
+
+message(STATUS
+  "Found rocm-xio ${ROCM_XIO_VERSION}")
+message(STATUS
+  "  Include dirs: ${ROCM_XIO_INCLUDE_DIRS}")
+message(STATUS
+  "  Libraries:    ${ROCM_XIO_LIBRARIES}")
+
+if(NOT ROCM_XIO_VERSION)
+  message(FATAL_ERROR
+    "ROCM_XIO_VERSION is empty after "
+    "find_package(rocm-xio).")
+endif()

--- a/examples/list-endpoints/CMakeLists.txt
+++ b/examples/list-endpoints/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Minimal example: list all registered rocm-xio endpoints.
+#
+# Build against an installed rocm-xio:
+#   cmake -S . -B build \
+#     -DCMAKE_PREFIX_PATH=<install-prefix>
+#   cmake --build build
+
+cmake_minimum_required(VERSION 3.21)
+project(list-endpoints LANGUAGES CXX HIP)
+
+find_package(rocm-xio REQUIRED)
+
+add_executable(list-endpoints list-endpoints.hip)
+target_link_libraries(list-endpoints PRIVATE
+  rocm-xio::rocm-xio)

--- a/examples/list-endpoints/list-endpoints.hip
+++ b/examples/list-endpoints/list-endpoints.hip
@@ -1,0 +1,23 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Minimal example: list all registered rocm-xio endpoints.
+ * CPU-only; does not require a GPU to run.
+ */
+
+#include <cstdio>
+
+#include "xio.h"
+
+int main() {
+  const auto& registry = getEndpointRegistry();
+  if (registry.empty()) {
+    printf("ERROR: endpoint registry is empty\n");
+    return 1;
+  }
+
+  printf("rocm-xio: %zu endpoint(s) registered\n", registry.size());
+  listAvailableEndpoints();
+  return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,11 +5,13 @@
 # Top-level test coordinator for rocm-xio.
 #
 # Label convention (filter with ctest -L):
-#   unit     - CPU-only, no GPU or NIC required
-#   system   - Requires a HIP-capable GPU
-#   hardware - Requires specific NIC/device hardware
-#   stress   - Long-running concurrency tests
-#   rdma     - RDMA-specific tests
+#   unit        - CPU-only, no GPU or NIC required
+#   system      - Requires a HIP-capable GPU
+#   hardware    - Requires specific NIC/device hardware
+#   stress      - Long-running concurrency tests
+#   rdma        - RDMA-specific tests
+#   integration - Install + build examples against prefix
 
 add_subdirectory(unit)
 add_subdirectory(system)
+add_subdirectory(integration)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Install-integration tests for rocm-xio.
+#
+# These tests install the library to a temporary prefix
+# and then configure, build, and run standalone example
+# projects against the installed package.  All tests
+# carry the "integration" CTest label.
+
+include(XIOInstallTests)
+
+xio_install_test_fixture()
+
+# Configure-only: verify find_package(rocm-xio) resolves.
+xio_add_install_test(
+  NAME find-package
+  SOURCE_DIR
+    ${CMAKE_SOURCE_DIR}/examples/find-package
+)
+
+# Compile + run: list available endpoints.
+xio_add_install_test(
+  NAME list-endpoints
+  SOURCE_DIR
+    ${CMAKE_SOURCE_DIR}/examples/list-endpoints
+  RUN
+)
+
+# Compile + run: iterate endpoint registry entries.
+xio_add_install_test(
+  NAME endpoint-info
+  SOURCE_DIR
+    ${CMAKE_SOURCE_DIR}/examples/endpoint-info
+  RUN
+)


### PR DESCRIPTION
## Summary

Verify that the installed rocm-xio package is consumable by
downstream projects via `find_package(rocm-xio)`.  A CTest
fixture installs the library to a temporary prefix; three
standalone example projects are then configured, built, and
(where applicable) run against it.

### Example projects (`examples/`)

- **find-package**: configure-only, validates `find_package`
  resolves targets and variables.
- **list-endpoints**: links the library, calls
  `listAvailableEndpoints()`.
- **endpoint-info**: iterates `getEndpointRegistry()`,
  cross-checks `getEndpointName()` and `isValidEndpoint()`.

### CMake infrastructure

- `cmake/XIOInstallTests.cmake`: `xio_install_test_fixture()`
  and `xio_add_install_test()` helpers; derives the ROCm prefix
  from `hip_DIR` so examples can resolve `find_dependency(hip)`.
- `cmake/run-install-example.cmake`: wrapper script that drives
  configure + build + optional run via `execute_process()`.
- `tests/integration/CMakeLists.txt`: wires the fixture and
  examples into CTest with the `integration` label.
- `CMakePresets.json`: add `integration` test preset.

### Install-rule bug fixes (exposed by the tests)

- Move `include(GNUInstallDirs)` before
  `target_include_directories()` so `CMAKE_INSTALL_INCLUDEDIR`
  is set when the `INSTALL_INTERFACE` generator expression is
  evaluated.
- `rocm-xio-config.cmake.in`: fix `@PACKAGE_...@` variable
  names (`FULL_INCLUDEDIR` -> `INCLUDEDIR`, `VERSION` ->
  `PROJECT_VERSION`).
- `rocm-xio-config.cmake.in`: add missing
  `find_dependency(hsakmt)`.

### CI and SLURM integration

- `build-check.yml`: run integration tests after the install
  step; trigger on `examples/**` changes.
- New `integration.sbatch` + registered in the Alola test list.
- `single-gpu.sbatch`: run `ctest --preset unit` after build.

## Test plan

- [ ] `ctest --preset integration` installs to temp prefix,
      all three examples configure/build/run successfully
- [ ] CI build-check workflow completes green
- [ ] Existing unit and nvme-ep tests unaffected