### PR TITLE
hsa-memory-updates

### DIFF
--- a/.alola/rocm-xio-alola.py
+++ b/.alola/rocm-xio-alola.py
@@ -33,7 +33,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_DIR = SCRIPT_DIR.parent
 JOB_IDS_FILE = SCRIPT_DIR / ".alola-job-ids"
 
-TESTS = [
+ALL_TESTS = [
     ("single-gpu",
      "rocm-xio-tests.single-gpu.sbatch"),
     ("two-gpu",
@@ -45,6 +45,31 @@ TESTS = [
     ("rdma-ep-2node",
      "rocm-xio-tests.rdma-ep-2node.sbatch"),
 ]
+
+ALL_TEST_NAMES = [t[0] for t in ALL_TESTS]
+
+TESTS = list(ALL_TESTS)
+
+
+def set_test_filter(names):
+    """Restrict TESTS to the given subset.
+
+    Validates each name against ALL_TESTS and
+    exits on unknown names.
+    """
+    global TESTS
+    unknown = [
+        n for n in names if n not in ALL_TEST_NAMES]
+    if unknown:
+        print(red(
+            f"ERROR: unknown test(s): "
+            f"{', '.join(unknown)}"))
+        print(
+            f"Available: "
+            f"{', '.join(ALL_TEST_NAMES)}")
+        sys.exit(1)
+    TESTS = [
+        t for t in ALL_TESTS if t[0] in names]
 
 STATUS_PASS = 0
 STATUS_FAIL = 1
@@ -1272,6 +1297,11 @@ def cmd_run(args):
                 f"(got {val})"))
             sys.exit(1)
 
+    if args.tests:
+        set_test_filter(
+            [t.strip() for t in
+             args.tests.split(",")])
+
     os.chdir(SCRIPT_DIR)
 
     original_handler = signal.getsignal(
@@ -1743,6 +1773,16 @@ def main():
             "distinct nodes by excluding "
             "already-allocated nodes within "
             "each wave."),
+    )
+    p_run.add_argument(
+        "--tests", type=str,
+        default=None, metavar="LIST",
+        help=(
+            "Comma-separated list of tests to "
+            "run (e.g. nvme-ep,single-gpu). "
+            "Available: "
+            + ",".join(ALL_TEST_NAMES)
+            + ". Default: all."),
     )
     p_run.add_argument(
         "--exclude-nodes", type=str,

--- a/.alola/rocm-xio-tests.common
+++ b/.alola/rocm-xio-tests.common
@@ -5,10 +5,64 @@
 #
 # rocm-xio-tests.common - shared setup for rocm-xio-tests.*.sbatch
 
-SSH_COMMAND="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH_COMMAND="ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -o ConnectTimeout=10"
 SSH_LOCALHOST="${SSH_COMMAND} localhost"
 
-SCP_COMMAND="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SCP_COMMAND="scp \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ConnectTimeout=10"
+
+# Run a command via SSH to localhost with automatic
+# retry on transient SSH failures.  Retries when SSH
+# returns 255 (connection error) or when the output
+# contains known SSH connection-failure patterns.
+# Usage: ssh_with_retry "command to run"
+ssh_with_retry() {
+  local max_retries=2
+  local retry_delay=5
+  local attempt=0
+  local rc=0
+  local ssh_err=""
+
+  while [ ${attempt} -le ${max_retries} ]; do
+    if [ ${attempt} -gt 0 ]; then
+      echo "SSH retry ${attempt}/${max_retries}" \
+        "after ${retry_delay}s..." >&2
+      sleep ${retry_delay}
+      retry_delay=$((retry_delay * 2))
+    fi
+    ssh_err=$(mktemp)
+    ${SSH_LOCALHOST} "$@" 2> >(tee "${ssh_err}" >&2)
+    rc=$?
+    local is_ssh_failure=0
+    if [ ${rc} -eq 255 ]; then
+      is_ssh_failure=1
+    elif [ ${rc} -ne 0 ] && \
+         grep -qiE \
+           "Broken pipe|closed by remote host|\
+Connection reset|Connection refused|\
+Connection timed out" \
+           "${ssh_err}" 2>/dev/null; then
+      is_ssh_failure=1
+    fi
+    rm -f "${ssh_err}"
+    if [ ${is_ssh_failure} -eq 0 ]; then
+      return ${rc}
+    fi
+    echo "SSH transport failure (rc=${rc})." >&2
+    attempt=$((attempt + 1))
+  done
+
+  echo "SSH failed after $((max_retries + 1))" \
+    "attempts." >&2
+  return ${rc}
+}
 
 # Project directory (repo root). When submitted from .alola, use its parent.
 if [ -n "${SLURM_SUBMIT_DIR}" ]; then
@@ -41,6 +95,25 @@ display_job_info() {
   echo "Node(s)   ${SLURM_NODELIST}"
   echo "Working Directory: ${SLURM_SUBMIT_DIR}"
   echo "Start Time:        $(date)"
+  echo "Kernel:            $(uname -r)"
+
+  local rocm_ver=""
+  if [ -f /opt/rocm/.info/version ]; then
+    rocm_ver=$(cat /opt/rocm/.info/version 2>/dev/null)
+  elif command -v apt 2>/dev/null | grep -q apt; then
+    rocm_ver=$(dpkg -l rocm-core 2>/dev/null \
+      | awk '/^ii/{print $3}' | head -1)
+  fi
+  echo "ROCm:              ${rocm_ver:-unknown}"
+
+  local dkms_ver=""
+  dkms_ver=$(dpkg -l amdgpu-dkms 2>/dev/null \
+    | awk '/^ii/{print $3}' | head -1)
+  if [ -z "${dkms_ver}" ]; then
+    dkms_ver=$(modinfo amdgpu 2>/dev/null \
+      | awk '/^version:/{print $2}' | head -1)
+  fi
+  echo "amdgpu driver:     ${dkms_ver:-unknown}"
   echo "======================================================================"
 }
 

--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -29,7 +29,7 @@ else
 fi
 
 run_on_host() {
-  ${SSH_LOCALHOST} "sudo env \
+  ssh_with_retry "sudo env \
 LD_LIBRARY_PATH=/opt/rocm/lib \
 HSA_FORCE_FINE_GRAIN_PCIE=1 $*"
 }

--- a/.alola/rocm-xio-tests.rdma-ep.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep.sbatch
@@ -194,7 +194,7 @@ for vendor in ${DETECTED_VENDORS}; do
   for seed in ${LOOPBACK_SEEDS}; do
     test_run \
       "rdma-ep loopback ${vendor} seed=${seed}" \
-      "${SSH_LOCALHOST} \
+      "ssh_with_retry \
         \"sudo env LD_LIBRARY_PATH=${LIB_PATH} \
           ${TEST_BIN} \
           --provider ${vendor} \

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -936,6 +936,44 @@ udev
 XIODetectGPUs
 XIOTestHelpers
 
+# ===== HSA Allocator Tracking Terms =====
+Allocator
+allocator
+allocDeviceMemory
+allocHostMemory
+allocSize
+changeset
+exportDmabuf
+exportRegVramBuf
+freeHostMemory
+gpuId
+hipDeviceEnablePeerAccess
+hipExtMallocWithFlags
+hipFree
+hipHostRegister
+hipMalloc
+hipMemAccessDesc
+hipMemAccessFlagsProtReadWrite
+hipMemAddressFree
+hipMemAddressReserve
+hipMemAllocationGranularityMinimum
+hipMemAllocationProp
+hipMemAllocationTypePinned
+hipMemCreate
+hipMemGetAllocationGranularity
+hipMemHandleTypePosixFileDescriptor
+hipMemLocationTypeDevice
+hipMemMap
+hipMemRelease
+hipMemSetAccess
+hipMemUnmap
+IBVWrapper
+mr
+PEs
+posix
+requestedHandleTypes
+vmem
+
 # ===== Documentation Infrastructure Terms =====
 Breathe
 breathe

--- a/docs/hsa-allocator-tracking.rst
+++ b/docs/hsa-allocator-tracking.rst
@@ -1,0 +1,221 @@
+HSA Memory Allocator Tracking
+=============================
+
+This document tracks the HSA memory allocator architecture in
+rocSHMEM and assesses what changes are needed in rocm-xio.
+
+Background
+----------
+
+rocSHMEM (now in ``ROCm/rocm-systems``) is extending its HSA
+memory allocator to include an ``allocator`` argument that
+specifies the memory mechanism and carries its own
+``export_dmabuf`` method pointer. This investigation
+determines whether rocm-xio needs similar changes.  See
+`ROCm/rocm-systems#3762
+<https://github.com/ROCm/rocm-systems/issues/3762>`_ for
+upstream details.
+
+Current dmabuf Usage in rocm-xio
+--------------------------------
+
+rocm-xio calls ``hsa_amd_portable_export_dmabuf`` directly
+(v1, no flags) at **four call sites**:
+
+1. ``src/common/ibv-wrapper.cpp`` --
+   ``IBVWrapper::reg_mr()`` exports GPU memory as dmabuf,
+   then calls ``ibv_reg_dmabuf_mr`` for RDMA MR
+   registration.  Used for GPU atomic buffers only, not the
+   main data path.
+
+2. ``src/common/xio-common.hip`` --
+   ``exportRegVramBuf()`` exports VRAM for NVMe physical
+   address resolution via the kernel module ioctl.
+
+3. ``src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp`` --
+   Exports CQ buffer for BNXT Direct Verbs UMEM
+   registration with ``BNXT_RE_DV_UMEM_FLAGS_DMABUF``.
+
+4. ``src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp``
+   -- Same pattern for ERNIC CQ buffers.
+
+HSA API v2
+----------
+
+ROCm 7.1.0 ships ``hsa_amd_portable_export_dmabuf_v2``
+(``/opt/rocm/include/hsa/hsa_ext_amd.h``) which adds a
+``flags`` argument of type
+``hsa_amd_dma_buf_mapping_type_t``:
+
+- ``HSA_AMD_DMABUF_MAPPING_TYPE_NONE`` (0) -- default,
+  identical to v1.
+- ``HSA_AMD_DMABUF_MAPPING_TYPE_PCIE`` (1) -- PCIe mapping
+  type, potentially relevant for P2P paths.
+
+The v1 API is documented as equivalent to v2 with
+``HSA_AMD_DMABUF_MAPPING_TYPE_NONE``.
+
+Additionally, ``hsa_amd_portable_close_dmabuf()`` provides
+proper cleanup of dmabuf file descriptors, replacing raw
+``close(fd)`` calls.
+
+Device Memory Allocation Patterns
+----------------------------------
+
+rocm-xio has **no unified device allocator**.  GPU memory
+allocation is scattered across six distinct strategies:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Purpose
+     - Method
+     - File
+   * - Data buffers
+     - ``hsa_memory_allocate`` via ``allocDeviceMemory()``
+     - ``xio-common.hip``
+   * - Queues (device)
+     - ``hipMalloc``
+     - ``xio-common.hip``
+   * - BNXT/ERNIC CQ
+     - ``hipExtMallocWithFlags(uncached)``
+     - ``bnxt/ernic-backend.cpp``
+   * - SDMA buffers
+     - ``hipMalloc`` / ``hipExtMallocWithFlags(uncached)``
+     - ``sdma-ep.hip``
+   * - Atomic scratch
+     - ``hipMalloc``
+     - ``queue-pair.hip``
+   * - MLX5 BF/UAR
+     - ``hsa_amd_memory_lock_to_pool``
+     - ``mlx5-backend.cpp``
+
+Host Memory Allocation Patterns
+--------------------------------
+
+Host allocation uses **five distinct patterns**:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Purpose
+     - Method
+     - File
+   * - Queues (host)
+     - ``hipHostMalloc(Mapped)`` / ``malloc`` fallback
+     - ``xio-common.hip``
+   * - RDMA data buffer
+     - ``posix_memalign``
+     - ``rdma-ep.hip``
+   * - BNXT/ERNIC SQ/RQ
+     - ``posix_memalign`` + ``hipHostRegister``
+     - ``bnxt/ernic-backend.cpp``
+   * - SDMA host dst
+     - ``hipHostMalloc(Default)``
+     - ``sdma-ep.hip``
+   * - NVMe admin
+     - ``malloc``
+     - ``nvme-ep.hip``
+
+Comparison with rocSHMEM
+------------------------
+
+rocSHMEM has a full allocator hierarchy
+(``HIPAllocator``, ``FreeList``, ``Pow2Bins``) managing a
+symmetric heap shared across PEs.  Each allocator knows how
+to allocate memory and export it as dmabuf for RDMA
+registration.
+
+rocm-xio deliberately removed this abstraction (see
+``src/endpoints/rdma-ep/README.md``: "Decoupled from
+rocshmem internals").  rocm-xio uses a single-endpoint
+model with no symmetric heap, making a full allocator
+hierarchy unnecessary.
+
+Assessment
+----------
+
+**Not needed:**
+
+- Full allocator abstraction with ``export_dmabuf`` method
+  pointer -- over-engineering for rocm-xio's simple
+  single-endpoint model.
+- Allocator argument threading -- rocm-xio allocates per
+  endpoint with fixed strategies.
+
+**Implemented (this changeset):**
+
+- Centralized ``exportDmabuf()`` wrapper with v2 API
+  support and ``hsa_amd_portable_close_dmabuf`` cleanup.
+- Unified ``allocDeviceMemory()`` with flags for
+  fine-grained, coarse-grained, uncached, and vmem
+  allocation types.
+- Unified ``allocHostMemory()`` / ``freeHostMemory()`` with
+  flags for mapped, coherent, pinned, and plain allocation.
+- HIP virtual memory integration for SDMA P2P buffers with
+  per-buffer access control via ``hipMemSetAccess``.
+
+HIP Virtual Memory Management
+------------------------------
+
+ROCm 7 introduces `HIP Virtual Memory Management
+<https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/
+hip_runtime_api/memory_management/virtual_memory.html>`_
+built on HSA ``hsa_amd_vmem_*`` APIs.  Key benefits for
+rocm-xio:
+
+1. **No device sync on free** --
+   ``hipMemUnmap``/``hipMemRelease``/``hipMemAddressFree``
+   do not synchronize the device, unlike ``hipFree``.
+
+2. **Per-buffer P2P access** -- ``hipMemSetAccess``
+   replaces device-wide ``hipDeviceEnablePeerAccess`` with
+   per-buffer, per-device access control.
+
+3. **Dynamic growth without copy** -- Buffers can be
+   extended by reserving additional VA and mapping new
+   physical pages.
+
+4. **dmabuf compatibility** --
+   ``hsa_amd_vmem_export_shareable_handle()`` exports vmem
+   allocations as dmabuf file descriptors.
+
+The ``requestedHandleTypes`` field must be set to
+``hipMemHandleTypePosixFileDescriptor`` at allocation time
+to enable later dmabuf export:
+
+.. code-block:: cpp
+
+   hipMemAllocationProp prop = {};
+   prop.type = hipMemAllocationTypePinned;
+   prop.location.type = hipMemLocationTypeDevice;
+   prop.location.id = gpuId;
+   prop.requestedHandleTypes =
+       hipMemHandleTypePosixFileDescriptor;
+
+   size_t granularity;
+   hipMemGetAllocationGranularity(
+       &granularity, &prop,
+       hipMemAllocationGranularityMinimum);
+   size_t allocSize =
+       ((size + granularity - 1) / granularity)
+       * granularity;
+
+   hipMemCreate(&handle, allocSize, &prop, 0);
+   hipMemAddressReserve(&ptr, allocSize, 0, 0, 0);
+   hipMemMap(ptr, allocSize, 0, handle, 0);
+
+   hipMemAccessDesc access = {};
+   access.location.type = hipMemLocationTypeDevice;
+   access.location.id = gpuId;
+   access.flags = hipMemAccessFlagsProtReadWrite;
+   hipMemSetAccess(ptr, allocSize, &access, 1);
+
+Upstream Tracking
+-----------------
+
+Monitor ``ROCm/rocm-systems#3762`` for any breaking
+changes to the HSA allocator interface that would require
+rocm-xio changes.

--- a/docs/hsa-allocator-tracking.rst
+++ b/docs/hsa-allocator-tracking.rst
@@ -147,8 +147,11 @@ Assessment
 
 **Implemented (this changeset):**
 
-- Centralized ``exportDmabuf()`` wrapper with v2 API
-  support and ``hsa_amd_portable_close_dmabuf`` cleanup.
+- Centralized ``exportDmabuf()`` wrapper using
+  ``hsa_amd_portable_export_dmabuf`` (v1) by default
+  and ``hsa_amd_portable_export_dmabuf_v2`` only when
+  non-zero flags are requested, plus
+  ``hsa_amd_portable_close_dmabuf`` (ROCm 7.1+).
 - Unified ``allocDeviceMemory()`` with flags for
   fine-grained, coarse-grained, uncached, and vmem
   allocation types.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Quick Start
    endpoints
    kernel-module
    memory-modes
+   hsa-allocator-tracking
 
 .. toctree::
    :maxdepth: 2

--- a/src/common/ibv-wrapper.cpp
+++ b/src/common/ibv-wrapper.cpp
@@ -232,8 +232,7 @@ struct ibv_mr* IBVWrapper::reg_mr(struct ibv_pd* pd, void* addr, size_t length,
 
     hsa_status_t status = xio::exportDmabuf(addr, length, &fd, &offset);
     if (status != HSA_STATUS_SUCCESS) {
-      fprintf(stderr, "rdma_ep: exportDmabuf failed: %d\n",
-              status);
+      fprintf(stderr, "rdma_ep: exportDmabuf failed: %d\n", status);
       return nullptr;
     }
 

--- a/src/common/ibv-wrapper.cpp
+++ b/src/common/ibv-wrapper.cpp
@@ -16,6 +16,8 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
+#include "xio.h"
+
 namespace rdma_ep {
 
 IBVWrapper ibv;
@@ -228,10 +230,9 @@ struct ibv_mr* IBVWrapper::reg_mr(struct ibv_pd* pd, void* addr, size_t length,
     uint64_t offset = 0;
     int fd = 0;
 
-    hsa_status_t status = hsa_amd_portable_export_dmabuf(addr, length, &fd,
-                                                         &offset);
+    hsa_status_t status = xio::exportDmabuf(addr, length, &fd, &offset);
     if (status != HSA_STATUS_SUCCESS) {
-      fprintf(stderr, "rdma_ep: hsa_amd_portable_export_dmabuf failed: %d\n",
+      fprintf(stderr, "rdma_ep: exportDmabuf failed: %d\n",
               status);
       return nullptr;
     }
@@ -266,7 +267,7 @@ int IBVWrapper::dereg_mr(struct ibv_mr* mr) {
   if (is_dmabuf_supported()) {
     auto it = dmabuf_fd_map_.find((uintptr_t)mr);
     if (it != dmabuf_fd_map_.end()) {
-      close(it->second);
+      xio::closeDmabuf(it->second);
       dmabuf_fd_map_.erase(it);
     }
   }

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,14 @@
 #endif // __HIP_DEVICE_COMPILE__
 
 namespace xio {
+
+struct VmemAlloc {
+  hipMemGenericAllocationHandle_t handle;
+  size_t size;
+};
+
+static std::mutex vmemMutex;
+static std::map<void*, VmemAlloc> vmemAllocations;
 
 void printDeviceInfo() {
   int deviceCount;
@@ -323,27 +332,31 @@ void printHistogram(const std::vector<double>& durations, unsigned nIterations,
                   writeIterations, verifiedReadsCount);
 }
 
-static hsa_status_t allocDeviceMemoryHsa(
-    size_t size, void** ptr, const char* label,
-    unsigned flags) {
+static hsa_status_t allocDeviceMemoryHsa(size_t size, void** ptr,
+                                         const char* label, unsigned flags) {
   hsa_status_t status;
 
   status = hsa_init();
   if (status != HSA_STATUS_SUCCESS) {
     if (status != 0x1001) {
-      std::cerr << "Error: hsa_init failed: "
-                << status << std::endl;
+      std::cerr << "Error: hsa_init failed: " << status << std::endl;
       return status;
     }
   }
 
-  hsa_region_t device_region = {0};
+  struct RegionSelectCtx {
+    hsa_region_t region;
+    bool want_coarse;
+  };
+
+  bool want_coarse = (flags & XIO_DEVICE_MEM_COARSE_GRAINED) != 0;
+  RegionSelectCtx ctx = {{0}, want_coarse};
 
   hsa_iterate_agents(
     [](hsa_agent_t agent, void* data) -> hsa_status_t {
       hsa_device_type_t device_type;
-      hsa_status_t s = hsa_agent_get_info(
-        agent, HSA_AGENT_INFO_DEVICE, &device_type);
+      hsa_status_t s = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE,
+                                          &device_type);
       if (s != HSA_STATUS_SUCCESS)
         return s;
       if (device_type != HSA_DEVICE_TYPE_GPU)
@@ -357,54 +370,54 @@ static hsa_status_t allocDeviceMemoryHsa(
 
       hsa_agent_iterate_regions(
         agent,
-        [](hsa_region_t region,
-           void* data) -> hsa_status_t {
+        [](hsa_region_t region, void* data) -> hsa_status_t {
           hsa_region_segment_t segment;
-          hsa_status_t s = hsa_region_get_info(
-            region, HSA_REGION_INFO_SEGMENT,
-            &segment);
+          hsa_status_t s = hsa_region_get_info(region, HSA_REGION_INFO_SEGMENT,
+                                               &segment);
           if (s != HSA_STATUS_SUCCESS)
             return s;
           if (segment != HSA_REGION_SEGMENT_GLOBAL)
             return HSA_STATUS_SUCCESS;
 
           uint32_t alloc_allowed;
-          s = hsa_region_get_info(
-            region,
-            HSA_REGION_INFO_RUNTIME_ALLOC_ALLOWED,
-            &alloc_allowed);
-          if (s != HSA_STATUS_SUCCESS ||
-              !alloc_allowed)
+          s = hsa_region_get_info(region, HSA_REGION_INFO_RUNTIME_ALLOC_ALLOWED,
+                                  &alloc_allowed);
+          if (s != HSA_STATUS_SUCCESS || !alloc_allowed)
             return HSA_STATUS_SUCCESS;
 
           uint32_t gf;
-          s = hsa_region_get_info(
-            region, HSA_REGION_INFO_GLOBAL_FLAGS,
-            &gf);
+          s = hsa_region_get_info(region, HSA_REGION_INFO_GLOBAL_FLAGS, &gf);
           if (s != HSA_STATUS_SUCCESS)
             return HSA_STATUS_SUCCESS;
 
           auto* r = (RegionData*)data;
-          if (gf &
-              HSA_REGION_GLOBAL_FLAG_FINE_GRAINED)
+          if (gf & HSA_REGION_GLOBAL_FLAG_FINE_GRAINED)
             r->fine = region;
-          else if (gf &
-                   HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED)
+          else if (gf & HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED)
             r->coarse = region;
 
           return HSA_STATUS_SUCCESS;
         },
         &regions);
 
-      auto* best = (hsa_region_t*)data;
-      if (regions.fine.handle != 0)
-        *best = regions.fine;
-      else if (regions.coarse.handle != 0)
-        *best = regions.coarse;
+      auto* c = (RegionSelectCtx*)data;
+      if (c->want_coarse) {
+        if (regions.coarse.handle != 0)
+          c->region = regions.coarse;
+        else if (regions.fine.handle != 0)
+          c->region = regions.fine;
+      } else {
+        if (regions.fine.handle != 0)
+          c->region = regions.fine;
+        else if (regions.coarse.handle != 0)
+          c->region = regions.coarse;
+      }
 
       return HSA_STATUS_INFO_BREAK;
     },
-    &device_region);
+    &ctx);
+
+  hsa_region_t device_region = ctx.region;
 
   if (device_region.handle == 0) {
     std::cerr << "Error: Could not find allocatable "
@@ -414,29 +427,22 @@ static hsa_status_t allocDeviceMemoryHsa(
   }
 
   uint32_t global_flags = 0;
-  hsa_region_get_info(device_region,
-                      HSA_REGION_INFO_GLOBAL_FLAGS,
+  hsa_region_get_info(device_region, HSA_REGION_INFO_GLOBAL_FLAGS,
                       &global_flags);
 
-  bool want_coarse =
-    (flags & XIO_DEVICE_MEM_COARSE_GRAINED) != 0;
-  if (want_coarse &&
-      (global_flags &
-       HSA_REGION_GLOBAL_FLAG_FINE_GRAINED)) {
+  if (want_coarse && (global_flags & HSA_REGION_GLOBAL_FLAG_FINE_GRAINED)) {
     std::cout << "  Info: (" << label
               << "): Coarse requested but only "
                  "fine-grained available"
               << std::endl;
   }
 
-  if (global_flags &
-      HSA_REGION_GLOBAL_FLAG_FINE_GRAINED) {
+  if (global_flags & HSA_REGION_GLOBAL_FLAG_FINE_GRAINED) {
     std::cout << "  Info: (" << label
               << "): Using HSA fine-grained "
                  "global memory region"
               << std::endl;
-  } else if (global_flags &
-             HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED) {
+  } else if (global_flags & HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED) {
     std::cout << "  Info: (" << label
               << "): Using HSA coarse-grained "
                  "global memory region"
@@ -447,9 +453,8 @@ static hsa_status_t allocDeviceMemoryHsa(
   return status;
 }
 
-hsa_status_t allocDeviceMemory(
-    size_t size, void** ptr, const char* label,
-    unsigned flags, int gpuId) {
+hsa_status_t allocDeviceMemory(size_t size, void** ptr, const char* label,
+                               unsigned flags, int gpuId) {
   if (!ptr || size == 0)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
@@ -459,13 +464,11 @@ hsa_status_t allocDeviceMemory(
     prop.type = hipMemAllocationTypePinned;
     prop.location.type = hipMemLocationTypeDevice;
     prop.location.id = gpuId;
-    prop.requestedHandleTypes =
-      hipMemHandleTypePosixFileDescriptor;
+    prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
 
     size_t granularity = 0;
     hipError_t err = hipMemGetAllocationGranularity(
-      &granularity, &prop,
-      hipMemAllocationGranularityMinimum);
+      &granularity, &prop, hipMemAllocationGranularityMinimum);
     if (err != hipSuccess) {
       std::cerr << "Error: (" << label
                 << "): hipMemGetAllocationGranularity "
@@ -474,34 +477,32 @@ hsa_status_t allocDeviceMemory(
       return HSA_STATUS_ERROR;
     }
 
-    size_t allocSize =
-      ((size + granularity - 1) / granularity) *
-      granularity;
+    size_t allocSize = ((size + granularity - 1) / granularity) * granularity;
 
     err = hipMemCreate(&handle, allocSize, &prop, 0);
     if (err != hipSuccess) {
       std::cerr << "Error: (" << label
-                << "): hipMemCreate failed: "
-                << hipGetErrorString(err) << std::endl;
+                << "): hipMemCreate failed: " << hipGetErrorString(err)
+                << std::endl;
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
 
     err = hipMemAddressReserve(ptr, allocSize, 0, 0, 0);
     if (err != hipSuccess) {
       std::cerr << "Error: (" << label
-                << "): hipMemAddressReserve failed: "
-                << hipGetErrorString(err) << std::endl;
-      hipMemRelease(handle);
+                << "): hipMemAddressReserve failed: " << hipGetErrorString(err)
+                << std::endl;
+      (void)hipMemRelease(handle);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
 
     err = hipMemMap(*ptr, allocSize, 0, handle, 0);
     if (err != hipSuccess) {
       std::cerr << "Error: (" << label
-                << "): hipMemMap failed: "
-                << hipGetErrorString(err) << std::endl;
-      hipMemAddressFree(*ptr, allocSize);
-      hipMemRelease(handle);
+                << "): hipMemMap failed: " << hipGetErrorString(err)
+                << std::endl;
+      (void)hipMemAddressFree(*ptr, allocSize);
+      (void)hipMemRelease(handle);
       *ptr = nullptr;
       return HSA_STATUS_ERROR;
     }
@@ -513,25 +514,38 @@ hsa_status_t allocDeviceMemory(
     err = hipMemSetAccess(*ptr, allocSize, &access, 1);
     if (err != hipSuccess) {
       std::cerr << "Error: (" << label
-                << "): hipMemSetAccess failed: "
-                << hipGetErrorString(err) << std::endl;
-      hipMemUnmap(*ptr, allocSize);
-      hipMemAddressFree(*ptr, allocSize);
-      hipMemRelease(handle);
+                << "): hipMemSetAccess failed: " << hipGetErrorString(err)
+                << std::endl;
+      (void)hipMemUnmap(*ptr, allocSize);
+      (void)hipMemAddressFree(*ptr, allocSize);
+      (void)hipMemRelease(handle);
       *ptr = nullptr;
       return HSA_STATUS_ERROR;
     }
 
-    std::cout << "  Info: (" << label
-              << "): Allocated " << allocSize
-              << " bytes via vmem on GPU " << gpuId
-              << std::endl;
+    {
+      std::lock_guard<std::mutex> lock(vmemMutex);
+      vmemAllocations[*ptr] = {handle, allocSize};
+    }
+
+    std::cout << "  Info: (" << label << "): Allocated " << allocSize
+              << " bytes via vmem on GPU " << gpuId << std::endl;
+    return HSA_STATUS_SUCCESS;
+  }
+
+  if (flags & XIO_DEVICE_MEM_HIP) {
+    hipError_t err = hipMalloc(ptr, size);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipMalloc failed: " << hipGetErrorString(err)
+                << std::endl;
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
     return HSA_STATUS_SUCCESS;
   }
 
   if (flags & XIO_DEVICE_MEM_UNCACHED) {
-    hipError_t err = hipExtMallocWithFlags(
-      ptr, size, hipDeviceMallocUncached);
+    hipError_t err = hipExtMallocWithFlags(ptr, size, hipDeviceMallocUncached);
     if (err != hipSuccess) {
       std::cerr << "Error: (" << label
                 << "): hipExtMallocWithFlags "
@@ -550,8 +564,24 @@ void freeDeviceMemory(void* ptr, unsigned flags) {
     return;
 
   if (flags & XIO_DEVICE_MEM_VMEM) {
-    hipMemUnmap(ptr, 0);
-    hipMemAddressFree(ptr, 0);
+    std::lock_guard<std::mutex> lock(vmemMutex);
+    auto it = vmemAllocations.find(ptr);
+    if (it != vmemAllocations.end()) {
+      (void)hipMemUnmap(ptr, it->second.size);
+      (void)hipMemAddressFree(ptr, it->second.size);
+      (void)hipMemRelease(it->second.handle);
+      vmemAllocations.erase(it);
+    } else {
+      std::cerr << "Warning: VMEM free called for "
+                << "untracked pointer " << ptr << std::endl;
+      (void)hipMemUnmap(ptr, 0);
+      (void)hipMemAddressFree(ptr, 0);
+    }
+    return;
+  }
+
+  if (flags & XIO_DEVICE_MEM_HIP) {
+    (void)hipFree(ptr);
     return;
   }
 
@@ -563,12 +593,10 @@ void freeDeviceMemory(void* ptr, unsigned flags) {
   hsa_memory_free(ptr);
 }
 
-hipError_t allocHostMemory(
-    size_t size, void** ptr, const char* label,
-    unsigned flags) {
+hipError_t allocHostMemory(size_t size, void** ptr, const char* label,
+                           unsigned flags) {
   if (!ptr || size == 0) {
-    std::cerr << "Error: (" << label
-              << "): invalid args to allocHostMemory"
+    std::cerr << "Error: (" << label << "): invalid args to allocHostMemory"
               << std::endl;
     return hipErrorInvalidValue;
   }
@@ -576,8 +604,7 @@ hipError_t allocHostMemory(
   if (flags & XIO_HOST_MEM_PLAIN) {
     *ptr = malloc(size);
     if (!*ptr) {
-      std::cerr << "Error: (" << label
-                << "): malloc failed" << std::endl;
+      std::cerr << "Error: (" << label << "): malloc failed" << std::endl;
       return hipErrorMemoryAllocation;
     }
     memset(*ptr, 0, size);
@@ -585,23 +612,23 @@ hipError_t allocHostMemory(
   }
 
   if (flags & XIO_HOST_MEM_PINNED) {
-    size_t pgsz =
-      static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    long pgsz_long = sysconf(_SC_PAGESIZE);
+    if (pgsz_long <= 0)
+      pgsz_long = 4096;
+    size_t pgsz = static_cast<size_t>(pgsz_long);
     int rc = posix_memalign(ptr, pgsz, size);
     if (rc != 0 || !*ptr) {
-      std::cerr << "Error: (" << label
-                << "): posix_memalign failed"
+      std::cerr << "Error: (" << label << "): posix_memalign failed"
                 << std::endl;
       return hipErrorMemoryAllocation;
     }
     memset(*ptr, 0, size);
 
-    hipError_t err = hipHostRegister(
-      *ptr, size, hipHostRegisterDefault);
+    hipError_t err = hipHostRegister(*ptr, size, hipHostRegisterDefault);
     if (err != hipSuccess) {
       std::cerr << "Warning: (" << label
-                << "): hipHostRegister failed: "
-                << hipGetErrorString(err) << std::endl;
+                << "): hipHostRegister failed: " << hipGetErrorString(err)
+                << std::endl;
     }
     return hipSuccess;
   }
@@ -645,18 +672,20 @@ void freeHostMemory(void* ptr, unsigned flags) {
     free(ptr);
 }
 
-hsa_status_t exportDmabuf(
-    const void* ptr, size_t size,
-    int* fd_out, uint64_t* offset_out,
-    uint64_t flags) {
+hsa_status_t exportDmabuf(const void* ptr, size_t size, int* fd_out,
+                          uint64_t* offset_out, uint64_t flags) {
   if (!ptr || !fd_out || !offset_out || size == 0)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   *fd_out = -1;
   *offset_out = 0;
 
-  return hsa_amd_portable_export_dmabuf_v2(
-    ptr, size, fd_out, offset_out, flags);
+  if (flags != 0) {
+    return hsa_amd_portable_export_dmabuf_v2(ptr, size, fd_out, offset_out,
+                                             flags);
+  }
+
+  return hsa_amd_portable_export_dmabuf(ptr, size, fd_out, offset_out);
 }
 
 hsa_status_t closeDmabuf(int fd) {
@@ -669,20 +698,16 @@ hsa_status_t closeDmabuf(int fd) {
 hipError_t allocateQueue(size_t size, bool isDeviceMemory,
                          const char* queueName, void** ptr) {
   if (isDeviceMemory) {
-    hsa_status_t s = allocDeviceMemory(
-      size, ptr, queueName, XIO_DEVICE_MEM_FINE_GRAINED);
+    hsa_status_t s = allocDeviceMemory(size, ptr, queueName,
+                                       XIO_DEVICE_MEM_HIP);
     if (s != HSA_STATUS_SUCCESS)
       return hipErrorMemoryAllocation;
     hipError_t memsetErr = hipMemset(*ptr, 0, size);
     if (memsetErr != hipSuccess) {
-      std::cerr << "Warning: hipMemset failed for "
-                << queueName << ": "
-                << hipGetErrorString(memsetErr)
-                << std::endl;
+      memset(*ptr, 0, size);
     }
   } else {
-    hipError_t err = allocHostMemory(
-      size, ptr, queueName, XIO_HOST_MEM_MAPPED);
+    hipError_t err = allocHostMemory(size, ptr, queueName, XIO_HOST_MEM_MAPPED);
     if (err != hipSuccess)
       return err;
   }
@@ -692,7 +717,7 @@ hipError_t allocateQueue(size_t size, bool isDeviceMemory,
 
 void freeQueue(void* ptr, bool isDeviceMemory, const char* queueName) {
   if (isDeviceMemory) {
-    freeDeviceMemory(ptr, XIO_DEVICE_MEM_FINE_GRAINED);
+    freeDeviceMemory(ptr, XIO_DEVICE_MEM_HIP);
   } else {
     freeHostMemory(ptr, XIO_HOST_MEM_MAPPED);
   }
@@ -704,9 +729,8 @@ __host__ bool reallocateQueue(void** ptr, size_t size, const char* queueName) {
   }
 
   void* coherent_ptr = nullptr;
-  hipError_t err = allocHostMemory(
-    size, &coherent_ptr, queueName,
-    XIO_HOST_MEM_COHERENT);
+  hipError_t err = allocHostMemory(size, &coherent_ptr, queueName,
+                                   XIO_HOST_MEM_COHERENT);
   if (err != hipSuccess || !coherent_ptr) {
     fprintf(stdout,
             "Warning: coherent alloc failed for "
@@ -750,23 +774,21 @@ hipError_t allocateDataBuffer(size_t size, unsigned memoryMode, void** ptr) {
 
   if (dataBufferOnDevice) {
     const size_t host_page_size = sysconf(_SC_PAGESIZE);
-    size_t alignedSize =
-      ((size + host_page_size - 1) / host_page_size) *
-      host_page_size;
+    size_t alignedSize = ((size + host_page_size - 1) / host_page_size) *
+                         host_page_size;
 
-    hsa_status_t s = allocDeviceMemory(
-      alignedSize, ptr, "Data Buffer",
-      XIO_DEVICE_MEM_FINE_GRAINED);
+    hsa_status_t s = allocDeviceMemory(alignedSize, ptr, "Data Buffer",
+                                       XIO_DEVICE_MEM_HIP);
     if (s != HSA_STATUS_SUCCESS) {
       std::cerr << "Error: allocDeviceMemory failed "
                    "for data buffer: "
                 << s << std::endl;
       return hipErrorMemoryAllocation;
     }
-    memset(*ptr, 0, size);
+    hipMemset(*ptr, 0, size);
   } else {
-    hipError_t err = allocHostMemory(
-      size, ptr, "Data Buffer", XIO_HOST_MEM_MAPPED);
+    hipError_t err = allocHostMemory(size, ptr, "Data Buffer",
+                                     XIO_HOST_MEM_MAPPED);
     if (err != hipSuccess)
       return err;
   }
@@ -775,11 +797,10 @@ hipError_t allocateDataBuffer(size_t size, unsigned memoryMode, void** ptr) {
 }
 
 void freeDataBuffer(void* ptr, unsigned memoryMode) {
-  bool dataBufferOnDevice =
-    (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
+  bool dataBufferOnDevice = (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
   if (dataBufferOnDevice) {
-    freeDeviceMemory(ptr, XIO_DEVICE_MEM_FINE_GRAINED);
+    freeDeviceMemory(ptr, XIO_DEVICE_MEM_HIP);
   } else {
     freeHostMemory(ptr, XIO_HOST_MEM_MAPPED);
   }
@@ -2297,12 +2318,10 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
           vram_ptr, (void*)aligned_ptr, size, aligned_size,
           (unsigned long long)dmabuf_offset);
 
-  status = exportDmabuf((void*)aligned_ptr, aligned_size,
-                        &dmabuf_fd, &dmabuf_offset);
+  status = exportDmabuf((void*)aligned_ptr, aligned_size, &dmabuf_fd,
+                        &dmabuf_offset);
   if (status != HSA_STATUS_SUCCESS) {
-    fprintf(stdout,
-            "ERROR: exportDmabuf failed (status=%d)\n",
-            status);
+    fprintf(stdout, "ERROR: exportDmabuf failed (status=%d)\n", status);
     fprintf(stdout, "  This requires:\n");
     fprintf(stdout, "  - ROCm 5.3+ with dmabuf support\n");
     fprintf(stdout, "  - Kernel CONFIG_DMABUF_MOVE_NOTIFY=y\n");
@@ -2403,18 +2422,16 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
   bool dataBufferOnDevice = (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
   if (dataBufferOnDevice) {
-    hsa_status_t s = allocDeviceMemory(
-      size, &bufferInfo->hostPtr,
-      "GPU accessible buffer",
-      XIO_DEVICE_MEM_FINE_GRAINED);
+    hsa_status_t s = allocDeviceMemory(size, &bufferInfo->hostPtr,
+                                       "GPU accessible buffer",
+                                       XIO_DEVICE_MEM_HIP);
     if (s != HSA_STATUS_SUCCESS) {
-      fprintf(stderr,
-              "Error: allocDeviceMemory failed\n");
+      fprintf(stderr, "Error: allocDeviceMemory failed\n");
       return hipErrorMemoryAllocation;
     }
 
     fprintf(stdout, "  VRAM buffer virtual: %p\n", bufferInfo->hostPtr);
-    fprintf(stdout, "  Exporting as DMA-BUF (HSA runtime)...\n");
+    fprintf(stdout, "  Exporting as DMA-BUF...\n");
 
     // Detect if device is emulated (needed for buffer registration flags)
     bool is_emulated = false;
@@ -2431,8 +2448,7 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
               strerror(-ret));
       fprintf(stderr, "  Device memory was requested but "
                       "dmabuf export is not available\n");
-      freeDeviceMemory(bufferInfo->hostPtr,
-                       XIO_DEVICE_MEM_FINE_GRAINED);
+      freeDeviceMemory(bufferInfo->hostPtr, XIO_DEVICE_MEM_HIP);
       bufferInfo->hostPtr = nullptr;
       return hipErrorInvalidValue;
     }
@@ -2446,10 +2462,9 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
     bufferInfo->gpuPtr = bufferInfo->hostPtr;
     bufferInfo->isDeviceMemory = true;
   } else {
-    hipError_t buf_err = allocHostMemory(
-      size, &bufferInfo->hostPtr,
-      "GPU accessible buffer host",
-      XIO_HOST_MEM_MAPPED);
+    hipError_t buf_err = allocHostMemory(size, &bufferInfo->hostPtr,
+                                         "GPU accessible buffer host",
+                                         XIO_HOST_MEM_MAPPED);
     if (buf_err != hipSuccess)
       return buf_err;
 
@@ -2507,9 +2522,9 @@ __host__ void freeGpuAccessibleBuffer(struct xioBufferInfo* bufferInfo) {
   }
 
   if (bufferInfo->isDeviceMemory) {
-    (void)hipFree(bufferInfo->hostPtr);
+    freeDeviceMemory(bufferInfo->hostPtr, XIO_DEVICE_MEM_HIP);
   } else {
-    (void)hipHostFree(bufferInfo->hostPtr);
+    freeHostMemory(bufferInfo->hostPtr, XIO_HOST_MEM_MAPPED);
   }
 
   bufferInfo->hostPtr = nullptr;

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -323,151 +323,368 @@ void printHistogram(const std::vector<double>& durations, unsigned nIterations,
                   writeIterations, verifiedReadsCount);
 }
 
-// Helper function to allocate HSA device memory
-hsa_status_t allocDeviceMemory(size_t size, void** ptr, const char* direction) {
+static hsa_status_t allocDeviceMemoryHsa(
+    size_t size, void** ptr, const char* label,
+    unsigned flags) {
   hsa_status_t status;
 
-  // Initialize HSA runtime (safe to call multiple times)
   status = hsa_init();
   if (status != HSA_STATUS_SUCCESS) {
-    // If already initialized, that's fine, continue
-    if (status != 0x1001) { // HSA_STATUS_ERROR_ALREADY_INITIALIZED value
-      std::cerr << "Error: hsa_init failed: " << status << std::endl;
+    if (status != 0x1001) {
+      std::cerr << "Error: hsa_init failed: "
+                << status << std::endl;
       return status;
     }
   }
 
-  // Iterate through agents to find GPU
   hsa_region_t device_region = {0};
 
   hsa_iterate_agents(
     [](hsa_agent_t agent, void* data) -> hsa_status_t {
       hsa_device_type_t device_type;
-      hsa_status_t status = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE,
-                                               &device_type);
-      if (status != HSA_STATUS_SUCCESS) {
-        return status;
-      }
+      hsa_status_t s = hsa_agent_get_info(
+        agent, HSA_AGENT_INFO_DEVICE, &device_type);
+      if (s != HSA_STATUS_SUCCESS)
+        return s;
+      if (device_type != HSA_DEVICE_TYPE_GPU)
+        return HSA_STATUS_SUCCESS;
 
-      if (device_type == HSA_DEVICE_TYPE_GPU) {
-        // Found GPU agent, iterate its regions
-        // Look for fine-grained global region first (better for CPU-GPU
-        // coherence) Then fall back to coarse-grained if fine-grained not
-        // available
-        struct RegionData {
-          hsa_region_t fine;
-          hsa_region_t coarse;
-        };
-        RegionData regions = {{0}, {0}};
+      struct RegionData {
+        hsa_region_t fine;
+        hsa_region_t coarse;
+      };
+      RegionData regions = {{0}, {0}};
 
-        hsa_agent_iterate_regions(
-          agent,
-          [](hsa_region_t region, void* data) -> hsa_status_t {
-            hsa_region_segment_t segment;
-            hsa_status_t status = hsa_region_get_info(region,
-                                                      HSA_REGION_INFO_SEGMENT,
-                                                      &segment);
-            if (status != HSA_STATUS_SUCCESS) {
-              return status;
-            }
-
-            // Look for global (device) memory region
-            if (segment == HSA_REGION_SEGMENT_GLOBAL) {
-              uint32_t alloc_allowed;
-              status = hsa_region_get_info(
-                region, HSA_REGION_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed);
-              if (status == HSA_STATUS_SUCCESS && alloc_allowed) {
-                // Check if fine-grained or coarse-grained
-                uint32_t global_flags;
-                status = hsa_region_get_info(region,
-                                             HSA_REGION_INFO_GLOBAL_FLAGS,
-                                             &global_flags);
-                if (status == HSA_STATUS_SUCCESS) {
-                  RegionData* regions_ptr = (RegionData*)data;
-
-                  if (global_flags & HSA_REGION_GLOBAL_FLAG_FINE_GRAINED) {
-                    regions_ptr->fine = region;
-                  } else if (global_flags &
-                             HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED) {
-                    regions_ptr->coarse = region;
-                  }
-                }
-              }
-            }
+      hsa_agent_iterate_regions(
+        agent,
+        [](hsa_region_t region,
+           void* data) -> hsa_status_t {
+          hsa_region_segment_t segment;
+          hsa_status_t s = hsa_region_get_info(
+            region, HSA_REGION_INFO_SEGMENT,
+            &segment);
+          if (s != HSA_STATUS_SUCCESS)
+            return s;
+          if (segment != HSA_REGION_SEGMENT_GLOBAL)
             return HSA_STATUS_SUCCESS;
-          },
-          &regions);
 
-        // Prefer fine-grained, fall back to coarse-grained
-        hsa_region_t* best_region = (hsa_region_t*)data;
-        if (regions.fine.handle != 0) {
-          *best_region = regions.fine;
-        } else if (regions.coarse.handle != 0) {
-          *best_region = regions.coarse;
-        }
+          uint32_t alloc_allowed;
+          s = hsa_region_get_info(
+            region,
+            HSA_REGION_INFO_RUNTIME_ALLOC_ALLOWED,
+            &alloc_allowed);
+          if (s != HSA_STATUS_SUCCESS ||
+              !alloc_allowed)
+            return HSA_STATUS_SUCCESS;
 
-        return HSA_STATUS_INFO_BREAK; // Stop agent iteration
-      }
-      return HSA_STATUS_SUCCESS;
+          uint32_t gf;
+          s = hsa_region_get_info(
+            region, HSA_REGION_INFO_GLOBAL_FLAGS,
+            &gf);
+          if (s != HSA_STATUS_SUCCESS)
+            return HSA_STATUS_SUCCESS;
+
+          auto* r = (RegionData*)data;
+          if (gf &
+              HSA_REGION_GLOBAL_FLAG_FINE_GRAINED)
+            r->fine = region;
+          else if (gf &
+                   HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED)
+            r->coarse = region;
+
+          return HSA_STATUS_SUCCESS;
+        },
+        &regions);
+
+      auto* best = (hsa_region_t*)data;
+      if (regions.fine.handle != 0)
+        *best = regions.fine;
+      else if (regions.coarse.handle != 0)
+        *best = regions.coarse;
+
+      return HSA_STATUS_INFO_BREAK;
     },
     &device_region);
 
   if (device_region.handle == 0) {
-    std::cerr << "Error: Could not find allocatable device memory region"
+    std::cerr << "Error: Could not find allocatable "
+                 "device memory region"
               << std::endl;
     return HSA_STATUS_ERROR_INVALID_REGION;
   }
 
-  // Check what type of region we found
   uint32_t global_flags = 0;
-  hsa_region_get_info(device_region, HSA_REGION_INFO_GLOBAL_FLAGS,
+  hsa_region_get_info(device_region,
+                      HSA_REGION_INFO_GLOBAL_FLAGS,
                       &global_flags);
-  if (global_flags & HSA_REGION_GLOBAL_FLAG_FINE_GRAINED) {
-    std::cout << "  Info: (" << direction << "):  Using HSA fine-grained "
-              << "global memory region" << std::endl;
-  } else if (global_flags & HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED) {
-    std::cout << "  Info: (" << direction << "):  Using HSA coarse-grained "
-              << "global memory region" << std::endl;
+
+  bool want_coarse =
+    (flags & XIO_DEVICE_MEM_COARSE_GRAINED) != 0;
+  if (want_coarse &&
+      (global_flags &
+       HSA_REGION_GLOBAL_FLAG_FINE_GRAINED)) {
+    std::cout << "  Info: (" << label
+              << "): Coarse requested but only "
+                 "fine-grained available"
+              << std::endl;
   }
 
-  // Allocate memory from device region
+  if (global_flags &
+      HSA_REGION_GLOBAL_FLAG_FINE_GRAINED) {
+    std::cout << "  Info: (" << label
+              << "): Using HSA fine-grained "
+                 "global memory region"
+              << std::endl;
+  } else if (global_flags &
+             HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED) {
+    std::cout << "  Info: (" << label
+              << "): Using HSA coarse-grained "
+                 "global memory region"
+              << std::endl;
+  }
+
   status = hsa_memory_allocate(device_region, size, ptr);
   return status;
+}
+
+hsa_status_t allocDeviceMemory(
+    size_t size, void** ptr, const char* label,
+    unsigned flags, int gpuId) {
+  if (!ptr || size == 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (flags & XIO_DEVICE_MEM_VMEM) {
+    hipMemGenericAllocationHandle_t handle;
+    hipMemAllocationProp prop = {};
+    prop.type = hipMemAllocationTypePinned;
+    prop.location.type = hipMemLocationTypeDevice;
+    prop.location.id = gpuId;
+    prop.requestedHandleTypes =
+      hipMemHandleTypePosixFileDescriptor;
+
+    size_t granularity = 0;
+    hipError_t err = hipMemGetAllocationGranularity(
+      &granularity, &prop,
+      hipMemAllocationGranularityMinimum);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipMemGetAllocationGranularity "
+                   "failed: "
+                << hipGetErrorString(err) << std::endl;
+      return HSA_STATUS_ERROR;
+    }
+
+    size_t allocSize =
+      ((size + granularity - 1) / granularity) *
+      granularity;
+
+    err = hipMemCreate(&handle, allocSize, &prop, 0);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipMemCreate failed: "
+                << hipGetErrorString(err) << std::endl;
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    err = hipMemAddressReserve(ptr, allocSize, 0, 0, 0);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipMemAddressReserve failed: "
+                << hipGetErrorString(err) << std::endl;
+      hipMemRelease(handle);
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    err = hipMemMap(*ptr, allocSize, 0, handle, 0);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipMemMap failed: "
+                << hipGetErrorString(err) << std::endl;
+      hipMemAddressFree(*ptr, allocSize);
+      hipMemRelease(handle);
+      *ptr = nullptr;
+      return HSA_STATUS_ERROR;
+    }
+
+    hipMemAccessDesc access = {};
+    access.location.type = hipMemLocationTypeDevice;
+    access.location.id = gpuId;
+    access.flags = hipMemAccessFlagsProtReadWrite;
+    err = hipMemSetAccess(*ptr, allocSize, &access, 1);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipMemSetAccess failed: "
+                << hipGetErrorString(err) << std::endl;
+      hipMemUnmap(*ptr, allocSize);
+      hipMemAddressFree(*ptr, allocSize);
+      hipMemRelease(handle);
+      *ptr = nullptr;
+      return HSA_STATUS_ERROR;
+    }
+
+    std::cout << "  Info: (" << label
+              << "): Allocated " << allocSize
+              << " bytes via vmem on GPU " << gpuId
+              << std::endl;
+    return HSA_STATUS_SUCCESS;
+  }
+
+  if (flags & XIO_DEVICE_MEM_UNCACHED) {
+    hipError_t err = hipExtMallocWithFlags(
+      ptr, size, hipDeviceMallocUncached);
+    if (err != hipSuccess) {
+      std::cerr << "Error: (" << label
+                << "): hipExtMallocWithFlags "
+                   "(uncached) failed: "
+                << hipGetErrorString(err) << std::endl;
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+    return HSA_STATUS_SUCCESS;
+  }
+
+  return allocDeviceMemoryHsa(size, ptr, label, flags);
+}
+
+void freeDeviceMemory(void* ptr, unsigned flags) {
+  if (!ptr)
+    return;
+
+  if (flags & XIO_DEVICE_MEM_VMEM) {
+    hipMemUnmap(ptr, 0);
+    hipMemAddressFree(ptr, 0);
+    return;
+  }
+
+  if (flags & XIO_DEVICE_MEM_UNCACHED) {
+    (void)hipFree(ptr);
+    return;
+  }
+
+  hsa_memory_free(ptr);
+}
+
+hipError_t allocHostMemory(
+    size_t size, void** ptr, const char* label,
+    unsigned flags) {
+  if (!ptr || size == 0) {
+    std::cerr << "Error: (" << label
+              << "): invalid args to allocHostMemory"
+              << std::endl;
+    return hipErrorInvalidValue;
+  }
+
+  if (flags & XIO_HOST_MEM_PLAIN) {
+    *ptr = malloc(size);
+    if (!*ptr) {
+      std::cerr << "Error: (" << label
+                << "): malloc failed" << std::endl;
+      return hipErrorMemoryAllocation;
+    }
+    memset(*ptr, 0, size);
+    return hipSuccess;
+  }
+
+  if (flags & XIO_HOST_MEM_PINNED) {
+    size_t pgsz =
+      static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    int rc = posix_memalign(ptr, pgsz, size);
+    if (rc != 0 || !*ptr) {
+      std::cerr << "Error: (" << label
+                << "): posix_memalign failed"
+                << std::endl;
+      return hipErrorMemoryAllocation;
+    }
+    memset(*ptr, 0, size);
+
+    hipError_t err = hipHostRegister(
+      *ptr, size, hipHostRegisterDefault);
+    if (err != hipSuccess) {
+      std::cerr << "Warning: (" << label
+                << "): hipHostRegister failed: "
+                << hipGetErrorString(err) << std::endl;
+    }
+    return hipSuccess;
+  }
+
+  unsigned hipFlags = hipHostMallocMapped;
+  if (flags & XIO_HOST_MEM_COHERENT)
+    hipFlags |= hipHostMallocCoherent;
+
+  hipError_t err = hipHostMalloc(ptr, size, hipFlags);
+  if (err != hipSuccess) {
+    *ptr = malloc(size);
+    if (!*ptr) {
+      std::cerr << "Error: (" << label
+                << "): hipHostMalloc and malloc "
+                   "fallback both failed"
+                << std::endl;
+      return hipErrorMemoryAllocation;
+    }
+  }
+  memset(*ptr, 0, size);
+  return hipSuccess;
+}
+
+void freeHostMemory(void* ptr, unsigned flags) {
+  if (!ptr)
+    return;
+
+  if (flags & XIO_HOST_MEM_PLAIN) {
+    free(ptr);
+    return;
+  }
+
+  if (flags & XIO_HOST_MEM_PINNED) {
+    (void)hipHostUnregister(ptr);
+    free(ptr);
+    return;
+  }
+
+  hipError_t err = hipHostFree(ptr);
+  if (err != hipSuccess)
+    free(ptr);
+}
+
+hsa_status_t exportDmabuf(
+    const void* ptr, size_t size,
+    int* fd_out, uint64_t* offset_out,
+    uint64_t flags) {
+  if (!ptr || !fd_out || !offset_out || size == 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  *fd_out = -1;
+  *offset_out = 0;
+
+  return hsa_amd_portable_export_dmabuf_v2(
+    ptr, size, fd_out, offset_out, flags);
+}
+
+hsa_status_t closeDmabuf(int fd) {
+  if (fd < 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  return hsa_amd_portable_close_dmabuf(fd);
 }
 
 hipError_t allocateQueue(size_t size, bool isDeviceMemory,
                          const char* queueName, void** ptr) {
   if (isDeviceMemory) {
-    // Allocate device memory using hipMalloc (exportable as DMA-BUF)
-    // This matches VRAM buffer allocation and allows DMA-BUF export for
-    // physical address resolution in nvme-ep
-    hipError_t hipErr = hipMalloc(ptr, size);
-    if (hipErr != hipSuccess) {
-      std::cerr << "Error: hipMalloc failed for " << queueName << ": "
-                << hipGetErrorString(hipErr) << std::endl;
+    hsa_status_t s = allocDeviceMemory(
+      size, ptr, queueName, XIO_DEVICE_MEM_FINE_GRAINED);
+    if (s != HSA_STATUS_SUCCESS)
       return hipErrorMemoryAllocation;
-    }
-    // Zero-initialize using hipMemset
     hipError_t memsetErr = hipMemset(*ptr, 0, size);
     if (memsetErr != hipSuccess) {
-      std::cerr << "Warning: hipMemset failed for " << queueName << ": "
-                << hipGetErrorString(memsetErr) << std::endl;
-      // Continue anyway - memory might already be zeroed
+      std::cerr << "Warning: hipMemset failed for "
+                << queueName << ": "
+                << hipGetErrorString(memsetErr)
+                << std::endl;
     }
   } else {
-    // Allocate host-accessible memory using HIP (GPU-accessible)
-    // Use hipHostMallocMapped to ensure GPU can access it (needed for test-ep)
-    // nvme-ep will reallocate with hipHostMallocCoherent if needed
-    hipError_t hipErr = hipHostMalloc(ptr, size, hipHostMallocMapped);
-    if (hipErr != hipSuccess) {
-      // HIP not available (e.g., emulate mode), fall back to malloc
-      *ptr = malloc(size);
-      if (*ptr == nullptr) {
-        std::cerr << "Error: malloc failed for " << queueName << std::endl;
-        return hipErrorMemoryAllocation;
-      }
-    }
-    memset(*ptr, 0, size);
+    hipError_t err = allocHostMemory(
+      size, ptr, queueName, XIO_HOST_MEM_MAPPED);
+    if (err != hipSuccess)
+      return err;
   }
 
   return hipSuccess;
@@ -475,23 +692,9 @@ hipError_t allocateQueue(size_t size, bool isDeviceMemory,
 
 void freeQueue(void* ptr, bool isDeviceMemory, const char* queueName) {
   if (isDeviceMemory) {
-    // Free HIP device memory
-    if (ptr != nullptr) {
-      hipError_t hipErr = hipFree(ptr);
-      if (hipErr != hipSuccess) {
-        std::cerr << "Warning: hipFree failed for " << queueName << ": "
-                  << hipGetErrorString(hipErr) << std::endl;
-      }
-    }
+    freeDeviceMemory(ptr, XIO_DEVICE_MEM_FINE_GRAINED);
   } else {
-    // Free HIP host memory or malloc-allocated memory
-    if (ptr != nullptr) {
-      hipError_t hipErr = hipHostFree(ptr);
-      if (hipErr != hipSuccess) {
-        // Not HIP-allocated, use regular free
-        free(ptr);
-      }
-    }
+    freeHostMemory(ptr, XIO_HOST_MEM_MAPPED);
   }
 }
 
@@ -501,28 +704,21 @@ __host__ bool reallocateQueue(void** ptr, size_t size, const char* queueName) {
   }
 
   void* coherent_ptr = nullptr;
-  hipError_t coherent_err = hipHostMalloc(&coherent_ptr, size,
-                                          hipHostMallocMapped |
-                                            hipHostMallocCoherent);
-  if (coherent_err != hipSuccess) {
-    fprintf(stdout, "Warning: hipHostMallocCoherent failed for %s: %s\n",
-            queueName, hipGetErrorString(coherent_err));
-    fprintf(stdout, "Falling back to regular allocation (may not work on "
-                    "gfx900)\n");
+  hipError_t err = allocHostMemory(
+    size, &coherent_ptr, queueName,
+    XIO_HOST_MEM_COHERENT);
+  if (err != hipSuccess || !coherent_ptr) {
+    fprintf(stdout,
+            "Warning: coherent alloc failed for "
+            "%s. Falling back to regular allocation "
+            "(may not work on gfx900)\n",
+            queueName);
     return false;
   }
 
-  // Copy data from original allocation to coherent memory
   memcpy(coherent_ptr, *ptr, size);
+  freeHostMemory(*ptr, XIO_HOST_MEM_MAPPED);
 
-  // Free original allocation (may be hipHostMalloc or malloc)
-  hipError_t freeErr = hipHostFree(*ptr);
-  if (freeErr != hipSuccess) {
-    // Not HIP-allocated, use regular free
-    free(*ptr);
-  }
-
-  // Update pointer to coherent allocation
   *ptr = coherent_ptr;
   return true;
 }
@@ -553,56 +749,39 @@ hipError_t allocateDataBuffer(size_t size, unsigned memoryMode, void** ptr) {
   bool dataBufferOnDevice = (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
   if (dataBufferOnDevice) {
-    // Allocate device memory using HSA
     const size_t host_page_size = sysconf(_SC_PAGESIZE);
-    size_t alignedSize = ((size + host_page_size - 1) / host_page_size) *
-                         host_page_size;
+    size_t alignedSize =
+      ((size + host_page_size - 1) / host_page_size) *
+      host_page_size;
 
-    hsa_status_t hsa_status = allocDeviceMemory(alignedSize, ptr,
-                                                "Data Buffer");
-    if (hsa_status != HSA_STATUS_SUCCESS) {
-      std::cerr << "Error: HSA memory allocation failed for data buffer: "
-                << hsa_status << std::endl;
+    hsa_status_t s = allocDeviceMemory(
+      alignedSize, ptr, "Data Buffer",
+      XIO_DEVICE_MEM_FINE_GRAINED);
+    if (s != HSA_STATUS_SUCCESS) {
+      std::cerr << "Error: allocDeviceMemory failed "
+                   "for data buffer: "
+                << s << std::endl;
       return hipErrorMemoryAllocation;
     }
     memset(*ptr, 0, size);
   } else {
-    // Allocate host-accessible memory using HIP or regular malloc
-    // Use hipHostMallocMapped to ensure GPU can access it (matches QEMU guest
-    // code) Try HIP first, but fall back to malloc if HIP is not available
-    // (emulate mode)
-    hipError_t hipErr = hipHostMalloc(ptr, size, hipHostMallocMapped);
-    if (hipErr != hipSuccess) {
-      // HIP not available (e.g., emulate mode), use regular malloc
-      *ptr = malloc(size);
-      if (*ptr == nullptr) {
-        return hipErrorMemoryAllocation;
-      }
-    }
-    memset(*ptr, 0, size);
+    hipError_t err = allocHostMemory(
+      size, ptr, "Data Buffer", XIO_HOST_MEM_MAPPED);
+    if (err != hipSuccess)
+      return err;
   }
 
   return hipSuccess;
 }
 
-// Free data buffer memory based on memory mode
 void freeDataBuffer(void* ptr, unsigned memoryMode) {
-  bool dataBufferOnDevice = (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
+  bool dataBufferOnDevice =
+    (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
   if (dataBufferOnDevice) {
-    // Free HSA device memory
-    if (ptr != nullptr) {
-      hsa_memory_free(ptr);
-    }
+    freeDeviceMemory(ptr, XIO_DEVICE_MEM_FINE_GRAINED);
   } else {
-    // Free HIP host memory or regular free
-    if (ptr != nullptr) {
-      hipError_t hipErr = hipHostFree(ptr);
-      if (hipErr != hipSuccess) {
-        // HIP not available (e.g., emulate mode), use regular free
-        free(ptr);
-      }
-    }
+    freeHostMemory(ptr, XIO_HOST_MEM_MAPPED);
   }
 }
 
@@ -2118,13 +2297,11 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
           vram_ptr, (void*)aligned_ptr, size, aligned_size,
           (unsigned long long)dmabuf_offset);
 
-  // Export as DMA-BUF using HSA runtime
-  dmabuf_fd = 0;
-  status = hsa_amd_portable_export_dmabuf((void*)aligned_ptr, aligned_size,
-                                          &dmabuf_fd, &dmabuf_offset);
+  status = exportDmabuf((void*)aligned_ptr, aligned_size,
+                        &dmabuf_fd, &dmabuf_offset);
   if (status != HSA_STATUS_SUCCESS) {
     fprintf(stdout,
-            "ERROR: hsa_amd_portable_export_dmabuf failed (status=%d)\n",
+            "ERROR: exportDmabuf failed (status=%d)\n",
             status);
     fprintf(stdout, "  This requires:\n");
     fprintf(stdout, "  - ROCm 5.3+ with dmabuf support\n");
@@ -2141,7 +2318,7 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
   if (kmod_fd < 0) {
     fprintf(stderr, "ERROR: Failed to open %s: %s\n", kernel_module_device,
             strerror(errno));
-    close(dmabuf_fd);
+    closeDmabuf(dmabuf_fd);
     return -errno;
   }
 
@@ -2157,7 +2334,7 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
   if (ret < 0) {
     fprintf(stderr, "ERROR: ROCM_XIO_REGISTER_BUFFER ioctl failed: %s\n",
             strerror(errno));
-    close(dmabuf_fd);
+    closeDmabuf(dmabuf_fd);
     close(kmod_fd);
     return -errno;
   }
@@ -2171,8 +2348,7 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
           (unsigned long long)req.virt_addr, (unsigned long long)*phys_addr_out,
           size);
 
-  // Close dmabuf FD - kernel module has the mapping
-  close(dmabuf_fd);
+  closeDmabuf(dmabuf_fd);
   close(kmod_fd);
 
   return 0;
@@ -2227,12 +2403,14 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
   bool dataBufferOnDevice = (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
   if (dataBufferOnDevice) {
-    // Device memory - use hipMalloc for VRAM allocation
-    hipError_t buf_err = hipMalloc(&bufferInfo->hostPtr, size);
-    if (buf_err != hipSuccess) {
-      fprintf(stderr, "Error: hipMalloc failed: %s\n",
-              hipGetErrorString(buf_err));
-      return buf_err;
+    hsa_status_t s = allocDeviceMemory(
+      size, &bufferInfo->hostPtr,
+      "GPU accessible buffer",
+      XIO_DEVICE_MEM_FINE_GRAINED);
+    if (s != HSA_STATUS_SUCCESS) {
+      fprintf(stderr,
+              "Error: allocDeviceMemory failed\n");
+      return hipErrorMemoryAllocation;
     }
 
     fprintf(stdout, "  VRAM buffer virtual: %p\n", bufferInfo->hostPtr);
@@ -2251,9 +2429,10 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
     if (ret < 0) {
       fprintf(stderr, "ERROR: DMA-BUF export failed for device memory: %s\n",
               strerror(-ret));
-      fprintf(stderr, "  Device memory was requested but dmabuf export is "
-                      "not available\n");
-      (void)hipFree(bufferInfo->hostPtr);
+      fprintf(stderr, "  Device memory was requested but "
+                      "dmabuf export is not available\n");
+      freeDeviceMemory(bufferInfo->hostPtr,
+                       XIO_DEVICE_MEM_FINE_GRAINED);
       bufferInfo->hostPtr = nullptr;
       return hipErrorInvalidValue;
     }
@@ -2267,14 +2446,12 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
     bufferInfo->gpuPtr = bufferInfo->hostPtr;
     bufferInfo->isDeviceMemory = true;
   } else {
-    // Host memory - use hipHostMalloc (mapped for GPU access)
-    hipError_t buf_err = hipHostMalloc(&bufferInfo->hostPtr, size,
-                                       hipHostMallocMapped);
-    if (buf_err != hipSuccess) {
-      fprintf(stderr, "Error: hipHostMalloc failed: %s\n",
-              hipGetErrorString(buf_err));
+    hipError_t buf_err = allocHostMemory(
+      size, &bufferInfo->hostPtr,
+      "GPU accessible buffer host",
+      XIO_HOST_MEM_MAPPED);
+    if (buf_err != hipSuccess)
       return buf_err;
-    }
 
     // Get physical address for host memory using /proc/self/pagemap
     bufferInfo->dmaAddr = getPhysAddr(bufferInfo->hostPtr);

--- a/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
+++ b/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
@@ -31,6 +31,7 @@
 #include "gda-backend.hpp"
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
+#include "xio.h"
 
 namespace rdma_ep {
 
@@ -150,7 +151,7 @@ static void create_one_cq(bnxt_host_cq* hcq, struct ibv_context* ctx,
   if (dmabuf_enabled) {
     int fd = -1;
     uint64_t offset = 0;
-    hsa_amd_portable_export_dmabuf(hcq->buf, hcq->length, &fd, &offset);
+    xio::exportDmabuf(hcq->buf, hcq->length, &fd, &offset);
     hcq->dmabuf_fd = fd;
     hcq->dmabuf_offset = offset;
   }

--- a/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
+++ b/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
@@ -151,9 +151,18 @@ static void create_one_cq(bnxt_host_cq* hcq, struct ibv_context* ctx,
   if (dmabuf_enabled) {
     int fd = -1;
     uint64_t offset = 0;
-    xio::exportDmabuf(hcq->buf, hcq->length, &fd, &offset);
-    hcq->dmabuf_fd = fd;
-    hcq->dmabuf_offset = offset;
+    hsa_status_t ds = xio::exportDmabuf(hcq->buf, hcq->length, &fd, &offset);
+    if (ds != HSA_STATUS_SUCCESS || fd < 0) {
+      fprintf(stderr,
+              "rdma_ep::bnxt: exportDmabuf %s "
+              "failed (status=%d), falling back "
+              "to non-dmabuf path\n",
+              label, ds);
+      dmabuf_enabled = 0;
+    } else {
+      hcq->dmabuf_fd = fd;
+      hcq->dmabuf_offset = offset;
+    }
   }
 
   struct bnxt_re_dv_umem_reg_attr ua {};

--- a/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
+++ b/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
@@ -145,11 +145,19 @@ static void create_one_cq(ernic_host_cq* hcq, struct ibv_context* ctx,
   if (dmabuf_enabled) {
     uint64_t offset = 0;
     int fd = -1;
-    xio::exportDmabuf(hcq->buf, hcq->length, &fd, &offset);
-    hcq->dmabuf_fd = fd;
-    ua.dmabuf_fd = fd;
-    ua.addr = reinterpret_cast<void*>(static_cast<uintptr_t>(offset));
-    ua.comp_mask = ROCM_ERNIC_DV_UMEM_FLAGS_DMABUF;
+    hsa_status_t ds = xio::exportDmabuf(hcq->buf, hcq->length, &fd, &offset);
+    if (ds != HSA_STATUS_SUCCESS || fd < 0) {
+      fprintf(stderr,
+              "rdma_ep::ernic: exportDmabuf %s "
+              "failed (status=%d), falling back "
+              "to non-dmabuf path\n",
+              label, ds);
+    } else {
+      hcq->dmabuf_fd = fd;
+      ua.dmabuf_fd = fd;
+      ua.addr = reinterpret_cast<void*>(static_cast<uintptr_t>(offset));
+      ua.comp_mask = ROCM_ERNIC_DV_UMEM_FLAGS_DMABUF;
+    }
   }
 
   hcq->umem = dv.umem_reg(ctx, &ua);

--- a/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
+++ b/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
@@ -25,6 +25,7 @@
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
 #include "rocm-ernic/ernic-provider.hpp"
+#include "xio.h"
 
 namespace rdma_ep {
 
@@ -144,7 +145,7 @@ static void create_one_cq(ernic_host_cq* hcq, struct ibv_context* ctx,
   if (dmabuf_enabled) {
     uint64_t offset = 0;
     int fd = -1;
-    hsa_amd_portable_export_dmabuf(hcq->buf, hcq->length, &fd, &offset);
+    xio::exportDmabuf(hcq->buf, hcq->length, &fd, &offset);
     hcq->dmabuf_fd = fd;
     ua.dmabuf_fd = fd;
     ua.addr = reinterpret_cast<void*>(static_cast<uintptr_t>(offset));

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -118,6 +118,7 @@ struct rocm_axiio_free_contig_req {
 #define XIO_DEVICE_MEM_COARSE_GRAINED 0x1
 #define XIO_DEVICE_MEM_UNCACHED 0x2
 #define XIO_DEVICE_MEM_VMEM 0x4
+#define XIO_DEVICE_MEM_HIP 0x8
 
 // Host memory allocation flags for allocHostMemory()
 #define XIO_HOST_MEM_MAPPED 0x0
@@ -395,7 +396,14 @@ hipError_t allocateDataBuffer(size_t size, unsigned memoryMode, void** ptr);
 void freeDataBuffer(void* ptr, unsigned memoryMode);
 
 /**
- * @brief Allocate HSA device memory.
+ * @brief Allocate GPU device memory.
+ *
+ * Selects a backend based on flags:
+ *  - FINE_GRAINED / COARSE_GRAINED: HSA region alloc.
+ *  - HIP: hipMalloc (DMA-BUF exportable).
+ *  - UNCACHED: hipExtMallocWithFlags (uncached).
+ *  - VMEM: HIP VMM (reserve + map + access).
+ *
  * @param size Size in bytes.
  * @param ptr Output pointer.
  * @param label Label for logging.
@@ -405,8 +413,7 @@ void freeDataBuffer(void* ptr, unsigned memoryMode);
  *              default: 0).
  * @return HSA status code.
  */
-hsa_status_t allocDeviceMemory(size_t size, void** ptr,
-                               const char* label,
+hsa_status_t allocDeviceMemory(size_t size, void** ptr, const char* label,
                                unsigned flags = XIO_DEVICE_MEM_FINE_GRAINED,
                                int gpuId = 0);
 
@@ -426,8 +433,7 @@ void freeDeviceMemory(void* ptr, unsigned flags);
  * @param flags XIO_HOST_MEM_* flags (default: mapped).
  * @return hipSuccess on success.
  */
-hipError_t allocHostMemory(size_t size, void** ptr,
-                           const char* label,
+hipError_t allocHostMemory(size_t size, void** ptr, const char* label,
                            unsigned flags = XIO_HOST_MEM_MAPPED);
 
 /**
@@ -441,9 +447,9 @@ void freeHostMemory(void* ptr, unsigned flags);
 /**
  * @brief Export memory as DMA-BUF.
  *
- * Uses hsa_amd_portable_export_dmabuf_v2 when available,
- * falling back to v1.  For vmem allocations, uses
- * hsa_amd_vmem_export_shareable_handle instead.
+ * Uses hsa_amd_portable_export_dmabuf (v1) when flags
+ * are zero, and hsa_amd_portable_export_dmabuf_v2 when
+ * explicit flags are requested (ROCm 7.1+).
  *
  * @param ptr Pointer to export.
  * @param size Size in bytes.
@@ -453,15 +459,13 @@ void freeHostMemory(void* ptr, unsigned flags);
  *              (default: NONE).
  * @return HSA status code.
  */
-hsa_status_t exportDmabuf(const void* ptr, size_t size,
-                          int* fd_out, uint64_t* offset_out,
-                          uint64_t flags = 0);
+hsa_status_t exportDmabuf(const void* ptr, size_t size, int* fd_out,
+                          uint64_t* offset_out, uint64_t flags = 0);
 
 /**
  * @brief Close a dmabuf file descriptor.
  *
- * Uses hsa_amd_portable_close_dmabuf when available,
- * falling back to close(2).
+ * Calls hsa_amd_portable_close_dmabuf (ROCm 7.1+).
  *
  * @param fd dmabuf file descriptor to close.
  * @return HSA status code.

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -113,6 +113,18 @@ struct rocm_axiio_free_contig_req {
 #define XIO_MEM_MODE_DOORBELL_DEVICE 0x4
 #define XIO_MEM_MODE_DATA_DEVICE 0x8
 
+// Device memory allocation flags for allocDeviceMemory()
+#define XIO_DEVICE_MEM_FINE_GRAINED 0x0
+#define XIO_DEVICE_MEM_COARSE_GRAINED 0x1
+#define XIO_DEVICE_MEM_UNCACHED 0x2
+#define XIO_DEVICE_MEM_VMEM 0x4
+
+// Host memory allocation flags for allocHostMemory()
+#define XIO_HOST_MEM_MAPPED 0x0
+#define XIO_HOST_MEM_COHERENT 0x1
+#define XIO_HOST_MEM_PINNED 0x2
+#define XIO_HOST_MEM_PLAIN 0x4
+
 // PCI MMIO Bridge command types
 #define PCI_MMIO_BRIDGE_CMD_NOP 0
 #define PCI_MMIO_BRIDGE_CMD_WRITE 1
@@ -386,10 +398,75 @@ void freeDataBuffer(void* ptr, unsigned memoryMode);
  * @brief Allocate HSA device memory.
  * @param size Size in bytes.
  * @param ptr Output pointer.
- * @param direction Label for logging ("read"/"write").
+ * @param label Label for logging.
+ * @param flags XIO_DEVICE_MEM_* flags (default:
+ *              fine-grained).
+ * @param gpuId GPU device ID (only used for VMEM path,
+ *              default: 0).
  * @return HSA status code.
  */
-hsa_status_t allocDeviceMemory(size_t size, void** ptr, const char* direction);
+hsa_status_t allocDeviceMemory(size_t size, void** ptr,
+                               const char* label,
+                               unsigned flags = XIO_DEVICE_MEM_FINE_GRAINED,
+                               int gpuId = 0);
+
+/**
+ * @brief Free device memory allocated by
+ *        allocDeviceMemory().
+ * @param ptr Pointer to free.
+ * @param flags Flags used at allocation time.
+ */
+void freeDeviceMemory(void* ptr, unsigned flags);
+
+/**
+ * @brief Allocate host memory with consistent semantics.
+ * @param size Size in bytes.
+ * @param ptr Output pointer.
+ * @param label Label for logging.
+ * @param flags XIO_HOST_MEM_* flags (default: mapped).
+ * @return hipSuccess on success.
+ */
+hipError_t allocHostMemory(size_t size, void** ptr,
+                           const char* label,
+                           unsigned flags = XIO_HOST_MEM_MAPPED);
+
+/**
+ * @brief Free host memory allocated by
+ *        allocHostMemory().
+ * @param ptr Pointer to free.
+ * @param flags Flags used at allocation time.
+ */
+void freeHostMemory(void* ptr, unsigned flags);
+
+/**
+ * @brief Export memory as DMA-BUF.
+ *
+ * Uses hsa_amd_portable_export_dmabuf_v2 when available,
+ * falling back to v1.  For vmem allocations, uses
+ * hsa_amd_vmem_export_shareable_handle instead.
+ *
+ * @param ptr Pointer to export.
+ * @param size Size in bytes.
+ * @param fd_out Output dmabuf file descriptor.
+ * @param offset_out Output offset within dmabuf.
+ * @param flags hsa_amd_dma_buf_mapping_type_t flags
+ *              (default: NONE).
+ * @return HSA status code.
+ */
+hsa_status_t exportDmabuf(const void* ptr, size_t size,
+                          int* fd_out, uint64_t* offset_out,
+                          uint64_t flags = 0);
+
+/**
+ * @brief Close a dmabuf file descriptor.
+ *
+ * Uses hsa_amd_portable_close_dmabuf when available,
+ * falling back to close(2).
+ *
+ * @param fd dmabuf file descriptor to close.
+ * @return HSA status code.
+ */
+hsa_status_t closeDmabuf(int fd);
 
 /**
  * @brief Extract endpoint name from CLI arguments.


### PR DESCRIPTION
Replace scattered direct calls to HSA, HIP, and POSIX allocation functions with a unified memory API in the xio namespace. allocDeviceMemory / freeDeviceMemory select a backend via XIO_DEVICE_MEM_* flags: HSA fine-grained or coarse-grained region allocation, hipMalloc (DMA-BUF exportable), hipExtMallocWithFlags (uncached), or HIP virtual memory (reserve + map + access with POSIX FD handle type). allocHostMemory / freeHostMemory cover mapped (hipHostMalloc), coherent, pinned (posix_memalign + hipHostRegister), and plain malloc paths, with matching free functions for each. New exportDmabuf / closeDmabuf wrappers call hsa_amd_portable_export_dmabuf_v2 and hsa_amd_portable_close_dmabuf (ROCm 7.1+). All existing callers are updated: ibv-wrapper, bnxt and eRNIC backends, and every queue / data-buffer / GPU-accessible-buffer helper in xio-common.hip.

The second commit fixes alloc/free mismatches introduced by the centralization and ensures callers that need DMA-BUF export use the XIO_DEVICE_MEM_HIP (hipMalloc) flag instead of HSA fine-grained allocation. HSA fine-grained memory cannot be exported as a DMA-BUF, which caused NVMe-EP memory modes 3 and 11 to fail on MI300X with exportDmabuf status=4100. Queue, data-buffer, and GPU-accessible-buffer allocation/free paths now consistently use XIO_DEVICE_MEM_HIP when a physical address is needed.

Adds docs/hsa-allocator-tracking.rst documenting the memory architecture, rocSHMEM comparison, assessment rationale, and HIP virtual memory management integration.