### PR TITLE
tests: move sdma-ep tests from single-gpu to two-gpu

### DIFF
--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -79,15 +79,6 @@ done
 test_run "test-ep max-threads" \
   "./build/xio-tester test-ep -n ${ITERATIONS} --threads 32"
 
-# Subcommand must come first; run sdma-ep only when GPU is whitelisted
-if $sdma_ep_allowed; then
-  test_run "sdma-ep p2p --to-host" \
-    "./build/xio-tester sdma-ep p2p --to-host --verify -n 100"
-else
-  echo "INFO: Skipping sdma-ep tests" \
-    "(${ROCM_GPU_ARCH} not in SDMA whitelist)."
-fi
-
 # Negative tests: verify invalid arguments fail gracefully.
 # The ! prefix inverts the exit code so test_run records PASS
 # when the command correctly exits non-zero.

--- a/.alola/rocm-xio-tests.two-gpu.sbatch
+++ b/.alola/rocm-xio-tests.two-gpu.sbatch
@@ -17,6 +17,7 @@
 #SBATCH --container-mount-home
 #SBATCH --constraint=MARKHAM&(GFX942|GFX950)
 #SBATCH --gres=gpu:2
+#SBATCH --exclude=banff-cyxtera-s81-1
 
 set -xe
 
@@ -136,6 +137,9 @@ label="p2p_n${ITERATIONS}_s${TRANSFER_SIZE}"
 
 test_run "sdma-ep P2P (GPU 0 -> GPU 1)" \
   "run_p2p_test ${ITERATIONS} ${TRANSFER_SIZE} ${label}"
+
+test_run "sdma-ep p2p --to-host" \
+  "./build/xio-tester sdma-ep p2p --to-host --verify -n 100"
 
 cd "$HOME"
 rm -rf "${WORKING_DIR}"


### PR DESCRIPTION
Running sdma-ep on a single-GPU allocation causes contention. Move the sdma-ep p2p --to-host test into the two-gpu job, which already requests --gres=gpu:2 and gates on $sdma_ep_allowed.
