### PR TITLE
nvme-ep: add doorbell coherence hardening from from-germany review

### DIFF
--- a/.alola/rocm-xio-tests.single-gpu.sbatch
+++ b/.alola/rocm-xio-tests.single-gpu.sbatch
@@ -44,6 +44,9 @@ setup_and_build_workdir "single-gpu"
 test_run "ctest unit tests" \
   "ctest --test-dir build --preset unit"
 
+test_run "doorbell coherence stress" \
+  "./build/tests/system/coherence/test-doorbell-coherence"
+
 test_run "test-ep --emulate" \
   "./build/xio-tester test-ep --emulate -n ${ITERATIONS}"
 

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -576,6 +576,53 @@ ol
 svg
 ul
 
+# ===== Coherence and Doorbell Fencing =====
+coherence
+coalesce
+deadlocked
+deadlocks
+doorbell
+doorbells
+fencing
+libnvm
+DLC
+GLC
+GL0
+GL1
+IoMemory
+SLC
+TLB
+ringDoorbell
+ringDoorbellFenced
+hipHostRegisterIoMemory
+hipHostRegisterMapped
+XIO_DOORBELL_FENCE_AGGRESSIVE
+
+sidesteps
+
+# ===== ISA Fencing Instructions =====
+buffer_gl0_inv
+buffer_gl1_inv
+global_store_dword
+s_dcache_inv
+s_gl1_inv
+s_waitcnt
+s_waitcnt_vscnt
+ISA
+cacheable
+dcache
+dword
+gl
+inv
+vscnt
+waitcnt
+
+# ===== from-germany Coherence Study =====
+AMDGPUUsage
+enfiskutensykkel
+germany
+GL
+
 # ===== Code Constants and Types =====
 ADDR
 CMD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,13 @@ setup_code_generation(
   NVME_EP_GENERATED ${INCLUDE_DIR}/nvme-ep-generated.h
 )
 
+# Doorbell fencing mode for NVMe coherence debugging.
+# When ON, ringDoorbell() uses ISA-level cache
+# invalidations on RDNA GPUs instead of the portable
+# __threadfence_system() path.
+option(XIO_DOORBELL_FENCE_AGGRESSIVE
+  "Use aggressive ISA fencing for doorbell writes" OFF)
+
 # GDA provider options for RDMA endpoint
 option(GDA_BNXT "Build BNXT (Broadcom Thor 2) RDMA provider" ON)
 option(GDA_MLX5 "Build MLX5 (Mellanox ConnectX) RDMA provider" OFF)
@@ -394,6 +401,13 @@ if(GDA_IONIC)
 endif()
 if(GDA_ERNIC)
   target_compile_definitions(rocm-xio PRIVATE GDA_ERNIC)
+endif()
+
+# Aggressive doorbell fencing (ISA-level cache
+# invalidations on RDNA; see xio.h ringDoorbellFenced)
+if(XIO_DOORBELL_FENCE_AGGRESSIVE)
+  target_compile_definitions(rocm-xio PUBLIC
+    XIO_DOORBELL_FENCE_AGGRESSIVE)
 endif()
 
 # Pass the custom rdma-core lib dir so DV backends

--- a/docs/coherence-prior-art.rst
+++ b/docs/coherence-prior-art.rst
@@ -1,0 +1,142 @@
+GPU-NVMe Doorbell Coherence: Prior Art
+=======================================
+
+This page documents findings from an independent
+GPU-NVMe coherence study (referred to as the
+"from-germany" reproduction case) and how they
+informed rocm-xio's doorbell write strategy.
+
+Background
+----------
+
+An external research team built a minimal GPU-driven
+NVMe read path on AMD RDNA GPUs using a HIP port of
+the open-source `libnvm`_ library.  Their setup:
+
+- Single GPU thread writes NVMe SQEs to a submission
+  queue (VRAM or host-pinned)
+- GPU rings doorbell registers via direct BAR0 MMIO
+  write
+- GPU polls completion queue for phase-bit flip
+- Commands are sequential: one SQE, one doorbell, poll,
+  then the next
+
+The study focused on **coherence of GPU MMIO writes to
+NVMe BAR0 doorbell registers** and **visibility of
+SQE writes across the PCIe coherence domain**.
+
+Observed Failure Mode
+---------------------
+
+The team observed **deadlocks** where the SSD either:
+
+1. Received an **invalid command** (SQE writes not
+   fully visible when the doorbell fires), or
+2. Received a **spurious doorbell** (doorbell write
+   arrived without a corresponding valid SQE)
+
+The GPU thread would then spin forever waiting for a
+completion entry that the SSD never produced.
+
+The deadlock was **extremely sensitive to timing**:
+inserting a ``printf`` after the MMIO write delayed
+execution enough for 1--2 commands to succeed before
+the hang.
+
+Fencing Approaches Attempted
+-----------------------------
+
+The team iterated through progressively heavier
+memory ordering techniques.  None reliably eliminated
+the deadlock on their RDNA hardware:
+
+1. **Volatile pointer writes** -- deadlocked
+   immediately on every run.
+
+2. **``__threadfence_system()`` before and after** --
+   still deadlocked.
+
+3. **LLVM AMDGPU sequentially-consistent store model**
+   (``s_waitcnt`` drains before/after a
+   ``global_store_dword``) -- still deadlocked.
+
+4. **Full cache invalidation suite** --
+   ``buffer_gl0_inv``, ``buffer_gl1_inv``,
+   ``s_gl1_inv``, ``s_dcache_inv`` plus triple
+   ``s_waitcnt`` barriers and ``__threadfence_system()``
+   -- still deadlocked.
+
+5. **``global_atomic_swap`` for SQE copies** -- used
+   atomics per dword with full fence sandwiches to
+   guarantee write ordering -- still unreliable.
+
+Implications for rocm-xio
+--------------------------
+
+The from-germany findings informed several rocm-xio
+design decisions:
+
+``hipHostRegisterIoMemory`` for BAR mappings
+  ``mapPciBar()`` now uses ``hipHostRegisterIoMemory``
+  instead of ``hipHostRegisterMapped`` when registering
+  NVMe BAR0 space for GPU access.
+  ``hipHostRegisterIoMemory`` is designed for MMIO
+  regions and sets non-cacheable TLB attributes,
+  avoiding GPU write-combine buffering that may
+  reorder or coalesce doorbell writes.
+
+``ringDoorbellFenced()``
+  A new doorbell-write function (``xio.h``) provides
+  RDNA-specific ISA-level fencing: explicit
+  ``s_waitcnt`` / ``s_waitcnt_vscnt`` drains, a
+  ``global_store_dword`` with GLC|SLC|DLC bypass flags,
+  and GL0/GL1 cache invalidation.  On CDNA (MI-series)
+  this falls back to ``__threadfence_system()``.  The
+  ``XIO_DOORBELL_FENCE_AGGRESSIVE`` CMake option makes
+  all ``ringDoorbell()`` calls use this path.
+
+PCI MMIO bridge for emulated NVMe devices
+  When the NVMe device is emulated by QEMU (not a real
+  PCIe endpoint), the PCI MMIO bridge is essential
+  because the emulated BAR0 cannot be reached by a
+  direct GPU store.  For real NVMe SSDs passed through
+  via vfio-pci, direct BAR0 remains the correct and
+  lowest-latency path.
+
+Coherence stress test
+  ``tests/system/coherence/test-doorbell-coherence.hip``
+  reproduces the from-germany access pattern (single
+  GPU thread, sequential produce/consume, poll for
+  completion) against host-pinned memory.
+
+Bugs Found in the from-germany Code
+-------------------------------------
+
+During review, two bugs were identified in the
+from-germany reproduction case:
+
+1. **memset argument order** (``main.cpp:158``):
+   ``memset(ptr, size, value)`` should be
+   ``memset(ptr, value, size)``.
+
+2. **Loop index shadowing** (``main.cpp:93``): the
+   SQE copy loop's inner body uses the outer loop
+   variable ``i`` instead of the inner variable ``j``,
+   causing every inner iteration to write the same
+   dword.
+
+These bugs may have contributed to the observed
+failures, though the underlying coherence ordering
+concern remains valid.
+
+Further Reading
+---------------
+
+- :doc:`memory-modes` -- fine-grained vs coarse-grained
+  memory and ``__threadfence_system()`` guidance
+- :doc:`endpoints` -- NVMe doorbell mode documentation
+- `LLVM AMDGPU Memory Model`_ -- canonical reference
+  for GPU memory ordering on GFX10/11
+
+.. _libnvm: https://github.com/enfiskutensykkel/ssd-gpu-dma
+.. _LLVM AMDGPU Memory Model: https://llvm.org/docs/AMDGPUUsage.html#memory-model-gfx10-gfx11

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -58,6 +58,60 @@ Key features:
      --read-io 1 --batch-size 8 \
      --infinite --less-timing
 
+Doorbell Modes
+^^^^^^^^^^^^^^
+
+The NVMe endpoint supports two doorbell delivery modes.
+Choosing the right one depends on whether the NVMe
+device is a real PCIe endpoint or an emulated device
+inside a virtual machine.
+
+**Direct BAR0 (default -- use with real hardware)**
+  The GPU writes directly to the NVMe controller's BAR0
+  doorbell registers.  This is the correct mode when the
+  NVMe SSD is passed through to the VM (or bare-metal
+  host) via **vfio-pci** or is otherwise a real PCIe
+  endpoint.  Direct BAR0 avoids the extra latency of the
+  MMIO bridge and is the lowest-overhead path.
+
+  The direct path uses ``__threadfence_system()`` for
+  cross-device ordering, which is sufficient on CDNA
+  (MI-series) GPUs.  On RDNA (consumer Radeon) GPUs,
+  direct BAR0 doorbell writes have been observed to
+  cause coherence issues in independent testing.  If
+  you experience hangs on RDNA hardware, try rebuilding
+  with aggressive ISA-level fencing:
+
+  .. code-block:: bash
+
+     cmake -DXIO_DOORBELL_FENCE_AGGRESSIVE=ON ..
+
+  See :doc:`coherence-prior-art` for background on the
+  coherence investigation.
+
+**PCI MMIO bridge (emulated devices in VMs only)**
+  Routes doorbell writes through a QEMU virtual PCI
+  device that forwards them to the emulated NVMe
+  controller's BAR0.  This mode is **essential** when
+  the NVMe device is emulated by QEMU (e.g. the
+  built-in ``nvme`` device model) because the emulated
+  BAR0 lives in QEMU's address space and cannot be
+  reached by a direct GPU store.  Enable with
+  ``--pci-mmio-bridge``:
+
+  .. code-block:: bash
+
+     sudo ./build/xio-tester nvme-ep \
+       --controller /dev/nvme0 \
+       --read-io 8 --pci-mmio-bridge
+
+  **Do not** use the PCI MMIO bridge with real NVMe
+  endpoints passed through via vfio-pci.  The bridge
+  adds an unnecessary PCIe hop and QEMU processing
+  overhead that hurts latency and throughput with no
+  benefit -- real hardware already exposes its BAR0
+  directly to the GPU.
+
 rdma-ep -- RDMA Endpoint
 -------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ Quick Start
    examples
    kernel-module
    memory-modes
+   coherence-prior-art
    hsa-allocator-tracking
 
 .. toctree::

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -1835,13 +1835,19 @@ __host__ int mapPciBar(uint16_t pci_bdf, uint8_t bar, void** bar_cpu,
 
   fprintf(stdout, "PCI BAR%u mapped at %p (size=%zu)\n", bar, mapped, bar_size);
 
-  // Register with HIP for GPU access
+  // Register with HIP for GPU access.
+  // hipHostRegisterIoMemory ensures the mapping uses non-cacheable
+  // attributes appropriate for MMIO regions (e.g. NVMe BAR0
+  // doorbells).  hipHostRegisterMapped alone may allow GPU caching
+  // that defeats doorbell write ordering -- an issue observed in
+  // independent GPU-NVMe coherence testing (from-germany repro).
   void* gpu_ptr = nullptr;
-  hipError_t hip_err = hipHostRegister(mapped, bar_size, hipHostRegisterMapped);
+  hipError_t hip_err = hipHostRegister(mapped, bar_size,
+                                       hipHostRegisterIoMemory);
   if (hip_err == hipSuccess) {
     fprintf(stdout,
-            "PCI BAR%u registered with HIP for GPU "
-            "access\n",
+            "PCI BAR%u registered with HIP "
+            "(IoMemory) for GPU access\n",
             bar);
 
     hipError_t gpu_ptr_err = hipHostGetDevicePointer(&gpu_ptr, mapped, 0);

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -777,17 +777,73 @@ __host__ int registerMemoryForGpu(void* host_ptr, size_t size, const char* name,
 
 /**
  * @brief Ring a doorbell register via direct MMIO write.
+ *
+ * Uses __threadfence_system() for portable cross-device
+ * ordering.  For MMIO coherence debugging on RDNA GPUs,
+ * see ringDoorbellFenced() which adds ISA-level cache
+ * invalidations inspired by from-germany coherence testing.
+ *
+ * When XIO_DOORBELL_FENCE_AGGRESSIVE is defined at compile
+ * time, this function delegates to ringDoorbellFenced().
+ *
  * @param doorbell_addr GPU-accessible doorbell pointer.
  * @param value Value to write (typically queue tail).
  */
 __host__ __device__ static inline void ringDoorbell(
+  volatile uint32_t* doorbell_addr, uint32_t value);
+
+/**
+ * @brief Ring a doorbell with aggressive ISA-level fencing.
+ *
+ * On RDNA GPUs (gfx10xx / gfx11xx), emits explicit
+ * s_waitcnt + s_waitcnt_vscnt drains, a global_store_dword
+ * with GLC|SLC|DLC flags to bypass caches, and full GL0/GL1
+ * cache invalidation.  On CDNA GPUs this falls back to the
+ * same __threadfence_system() path as ringDoorbell().
+ *
+ * Use this variant when debugging doorbell ordering issues
+ * on consumer RDNA hardware.
+ *
+ * @param doorbell_addr GPU-accessible doorbell pointer.
+ * @param value Value to write (typically queue tail).
+ */
+__host__ __device__ static inline void ringDoorbellFenced(
   volatile uint32_t* doorbell_addr, uint32_t value) {
+#ifdef __HIP_DEVICE_COMPILE__
+#if __gfx1010__ || __gfx1030__ || __gfx1031__ || __gfx1032__ || __gfx1100__ || \
+  __gfx1101__ || __gfx1102__ || __gfx1200__ || __gfx1201__
+  asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0) \n"
+               "s_waitcnt_vscnt null, 0x0 \n"
+               "global_store_dword %0, %1, off glc slc dlc \n"
+               "s_waitcnt lgkmcnt(0) vmcnt(0) \n"
+               "s_waitcnt_vscnt null, 0x0 \n"
+               "buffer_gl1_inv \n"
+               "buffer_gl0_inv \n" ::"v"(doorbell_addr),
+               "v"(value)
+               : "memory");
+  __threadfence_system();
+#else
+  __threadfence_system();
+  *doorbell_addr = value;
+  __threadfence_system();
+#endif
+#else
+  *doorbell_addr = value;
+#endif
+}
+
+__host__ __device__ static inline void ringDoorbell(
+  volatile uint32_t* doorbell_addr, uint32_t value) {
+#ifdef XIO_DOORBELL_FENCE_AGGRESSIVE
+  ringDoorbellFenced(doorbell_addr, value);
+#else
 #ifdef __HIP_DEVICE_COMPILE__
   __threadfence_system();
 #endif
   *doorbell_addr = value;
 #ifdef __HIP_DEVICE_COMPILE__
   __threadfence_system();
+#endif
 #endif
 }
 
@@ -804,6 +860,23 @@ __host__ __device__ static inline void ringDoorbell(void* base_addr,
     volatile uint32_t* doorbell_reg = reinterpret_cast<volatile uint32_t*>(
       static_cast<volatile char*>(base_addr) + offset);
     ringDoorbell(doorbell_reg, value);
+  }
+}
+
+/**
+ * @brief Ring a doorbell at base+offset with aggressive
+ *        ISA-level fencing.
+ * @param base_addr Base address (e.g., BAR0).
+ * @param offset Byte offset to the doorbell register.
+ * @param value Value to write.
+ */
+__host__ __device__ static inline void ringDoorbellFenced(void* base_addr,
+                                                          uint32_t offset,
+                                                          uint32_t value) {
+  if (base_addr != nullptr) {
+    volatile uint32_t* doorbell_reg = reinterpret_cast<volatile uint32_t*>(
+      static_cast<volatile char*>(base_addr) + offset);
+    ringDoorbellFenced(doorbell_reg, value);
   }
 }
 

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -6,3 +6,4 @@
 # HIP-capable GPU and are labelled "system".
 
 add_subdirectory(test-ep)
+add_subdirectory(coherence)

--- a/tests/system/coherence/CMakeLists.txt
+++ b/tests/system/coherence/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Coherence stress tests -- exercises GPU-to-host memory
+# ordering patterns used by doorbell-driven endpoints
+# (NVMe, RDMA).  Requires a HIP-capable GPU.
+
+xio_add_test(
+  NAME test-doorbell-coherence
+  SOURCE test-doorbell-coherence.hip
+  LABELS system stress coherence
+  TIMEOUT 120
+  GPU
+)

--- a/tests/system/coherence/test-doorbell-coherence.hip
+++ b/tests/system/coherence/test-doorbell-coherence.hip
@@ -1,0 +1,244 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Coherence stress test for GPU-to-host doorbell ordering.
+ *
+ * Reproduces the access pattern from an external GPU-NVMe
+ * coherence study (from-germany): a single GPU thread writes
+ * sequential "commands" to a shared queue, rings a doorbell
+ * (host-pinned memory standing in for BAR0 MMIO), and polls
+ * for completions.  A host thread monitors the doorbell,
+ * validates commands, and writes completions.
+ *
+ * The test passes if all iterations complete before the
+ * timeout.  Deadlocks indicate that either the doorbell
+ * write or the completion write is not visible across the
+ * GPU/CPU coherence boundary.
+ */
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#include <hip/hip_runtime.h>
+
+#include "xio.h"
+
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    hipError_t err = (call);                                                   \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "HIP error %d (%s) at %s:%d\n", err,                     \
+              hipGetErrorString(err), __FILE__, __LINE__);                     \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+struct CoherenceCmd {
+  volatile uint32_t cmd_id;
+  volatile uint32_t payload;
+};
+
+struct CoherenceCpl {
+  volatile uint32_t cpl_id;
+  volatile uint32_t status;
+};
+
+static constexpr uint32_t CMD_EMPTY = 0;
+static constexpr uint32_t CPL_PENDING = 0;
+static constexpr uint32_t CPL_DONE = 1;
+
+__global__ void coherence_kernel(volatile CoherenceCmd* sq,
+                                 volatile CoherenceCpl* cq,
+                                 volatile uint32_t* doorbell,
+                                 unsigned iterations) {
+  for (unsigned i = 1; i <= iterations; i++) {
+    sq->payload = i * 7;
+    __threadfence_system();
+
+    sq->cmd_id = i;
+    __threadfence_system();
+
+    xio::ringDoorbell(const_cast<volatile uint32_t*>(doorbell), i);
+
+    while (cq->cpl_id != i) {
+      ;
+    }
+    __threadfence_system();
+  }
+}
+
+__global__ void coherence_kernel_fenced(volatile CoherenceCmd* sq,
+                                        volatile CoherenceCpl* cq,
+                                        volatile uint32_t* doorbell,
+                                        unsigned iterations) {
+  for (unsigned i = 1; i <= iterations; i++) {
+    sq->payload = i * 7;
+    __threadfence_system();
+
+    sq->cmd_id = i;
+    __threadfence_system();
+
+    xio::ringDoorbellFenced(const_cast<volatile uint32_t*>(doorbell), i);
+
+    while (cq->cpl_id != i) {
+      ;
+    }
+    __threadfence_system();
+  }
+}
+
+struct SharedState {
+  CoherenceCmd* sq;
+  CoherenceCpl* cq;
+  uint32_t* doorbell;
+  unsigned iterations;
+  std::atomic<bool> host_done{false};
+  std::atomic<bool> error{false};
+};
+
+static void host_responder(SharedState* state) {
+  volatile CoherenceCmd* sq = state->sq;
+  volatile CoherenceCpl* cq = state->cq;
+  volatile uint32_t* db = state->doorbell;
+
+  for (unsigned expected = 1; expected <= state->iterations; expected++) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+    while (*db < expected) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        fprintf(stderr,
+                "Host responder timed out waiting for "
+                "doorbell %u (current=%u)\n",
+                expected, *db);
+        state->error.store(true);
+        state->host_done.store(true);
+        return;
+      }
+      std::this_thread::yield();
+    }
+
+    uint32_t observed_id = sq->cmd_id;
+    uint32_t observed_payload = sq->payload;
+
+    if (observed_id != expected) {
+      fprintf(stderr,
+              "Command mismatch: expected cmd_id=%u, "
+              "got %u\n",
+              expected, observed_id);
+      state->error.store(true);
+    }
+    if (observed_payload != expected * 7) {
+      fprintf(stderr,
+              "Payload mismatch at cmd %u: expected %u, "
+              "got %u\n",
+              expected, expected * 7, observed_payload);
+      state->error.store(true);
+    }
+
+    cq->cpl_id = expected;
+    __sync_synchronize();
+  }
+
+  state->host_done.store(true);
+}
+
+static int run_test(const char* label, bool use_fenced) {
+  static constexpr unsigned kIterations = 4096;
+
+  CoherenceCmd* sq = nullptr;
+  CoherenceCpl* cq = nullptr;
+  uint32_t* doorbell = nullptr;
+
+  HIP_CHECK(hipHostMalloc(&sq, sizeof(CoherenceCmd), hipHostMallocDefault));
+  HIP_CHECK(hipHostMalloc(&cq, sizeof(CoherenceCpl), hipHostMallocDefault));
+  HIP_CHECK(hipHostMalloc(&doorbell, sizeof(uint32_t), hipHostMallocDefault));
+
+  memset((void*)sq, 0, sizeof(CoherenceCmd));
+  memset((void*)cq, 0, sizeof(CoherenceCpl));
+  *doorbell = 0;
+
+  SharedState state;
+  state.sq = sq;
+  state.cq = cq;
+  state.doorbell = doorbell;
+  state.iterations = kIterations;
+
+  std::thread responder(host_responder, &state);
+
+  if (use_fenced) {
+    hipLaunchKernelGGL(coherence_kernel_fenced, dim3(1), dim3(1), 0, 0, sq, cq,
+                       doorbell, kIterations);
+  } else {
+    hipLaunchKernelGGL(coherence_kernel, dim3(1), dim3(1), 0, 0, sq, cq,
+                       doorbell, kIterations);
+  }
+
+  HIP_CHECK(hipPeekAtLastError());
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+
+  hipError_t sync_err = hipErrorNotReady;
+  while (sync_err == hipErrorNotReady) {
+    sync_err = hipStreamQuery(0);
+    if (sync_err == hipSuccess)
+      break;
+    if (sync_err != hipErrorNotReady) {
+      fprintf(stderr, "%s: kernel error: %s\n", label,
+              hipGetErrorString(sync_err));
+      break;
+    }
+    if (std::chrono::steady_clock::now() > deadline) {
+      fprintf(stderr,
+              "%s: DEADLOCK detected -- kernel did not "
+              "complete within 30 seconds\n",
+              label);
+      sync_err = hipErrorLaunchTimeOut;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  responder.join();
+
+  int result = 0;
+  if (sync_err != hipSuccess) {
+    fprintf(stderr, "%s: FAILED (kernel error)\n", label);
+    result = 1;
+  } else if (state.error.load()) {
+    fprintf(stderr, "%s: FAILED (data mismatch)\n", label);
+    result = 1;
+  } else {
+    printf("%s: PASSED (%u iterations)\n", label, kIterations);
+  }
+
+  HIP_CHECK(hipHostFree(sq));
+  HIP_CHECK(hipHostFree(cq));
+  HIP_CHECK(hipHostFree(doorbell));
+
+  return result;
+}
+
+int main() {
+  int failures = 0;
+
+  printf("=== Doorbell coherence stress test ===\n");
+  printf("Tests GPU->host doorbell visibility with "
+         "sequential producer/consumer pattern\n\n");
+
+  failures += run_test("threadfence_system doorbell", false);
+  failures += run_test("ISA-fenced doorbell", true);
+
+  if (failures == 0) {
+    printf("\nAll doorbell coherence tests passed.\n");
+    return 0;
+  }
+  printf("\n%d doorbell coherence test(s) failed.\n", failures);
+  return 1;
+}


### PR DESCRIPTION
Review of an external GPU-NVMe coherence study (from-germany) revealed that GPU MMIO doorbell writes can silently reorder or coalesce on RDNA hardware, causing NVMe deadlocks even under aggressive software fencing.  This commit incorporates the lessons learned:

- mapPciBar(): switch from hipHostRegisterMapped to hipHostRegisterIoMemory for BAR regions so the GPU TLB uses non-cacheable attributes appropriate for MMIO
- xio.h: add ringDoorbellFenced() with RDNA-specific ISA fencing (s_waitcnt drains, global_store_dword with GLC|SLC|DLC bypass, GL0/GL1 cache invalidation); falls back to __threadfence_system() on CDNA
- CMakeLists.txt: add XIO_DOORBELL_FENCE_AGGRESSIVE option that makes all ringDoorbell() calls use the fenced path
- docs/endpoints.rst: document doorbell modes -- direct BAR0 for real hardware/vfio-pci, PCI MMIO bridge for QEMU emulated devices only
- docs/coherence-prior-art.rst: archive the from-germany findings (fencing approaches attempted, failure modes, bugs found in their code, implications for rocm-xio)
- tests/system/coherence/: add GPU-to-host doorbell coherence stress test exercising both standard and fenced paths
