### PR TITLE
ci: add GitHub Pages deployment for Sphinx docs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,67 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Deploy Sphinx documentation to GitHub Pages.
+#
+# Prerequisites (one-time, requires repo-admin access):
+#   Settings > Pages > Source = "GitHub Actions"
+
+name: docs-deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/**/*.h'
+      - 'requirements.txt'
+      - '.github/workflows/docs-deploy.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: sphinx-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v5.0.0
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake doxygen
+        pip install -r requirements.txt
+
+    - name: Configure docs-only build
+      run: |
+        cmake -S . -B build \
+          -DXIO_DOCS_ONLY=ON \
+          -DXIO_BUILD_DOCS=ON
+
+    - name: Build documentation
+      run: cmake --build build --target sphinx-html
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: build/docs/html
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ instructions.
 ## Documentation
 
 Full documentation lives in the [`docs/`](docs/) directory and covers
-building, endpoints, the kernel module, memory modes, and the API reference.
+building, endpoints, the kernel module, memory modes, and the API
+reference. A hosted version is available at the [documentation
+site][docs-site].
+
+<!-- References -->
+
+[docs-site]: https://rocm.github.io/rocm-xio/
 
 ## License
 


### PR DESCRIPTION
Add a docs-deploy workflow that builds the Sphinx + Breathe + Doxygen documentation and deploys it to GitHub Pages via the modern upload-pages-artifact / deploy-pages action pair. The workflow triggers on pushes to main that touch docs, public headers, or requirements.txt, and also supports manual dispatch.

Update README.md to link to the hosted documentation site at https://rocm.github.io/rocm-xio/.

Prerequisite: a repo admin must set Settings > Pages > Source to "GitHub Actions" (one-time toggle).
