### PR TITLE
alola: add .alola-exclude for centralized node exclusions

### DIFF
--- a/.alola/.alola-exclude
+++ b/.alola/.alola-exclude
@@ -1,0 +1,35 @@
+# .alola-exclude -- per-node SLURM exclusions
+#
+# Format: node-name [test1,test2,...]
+#
+# If no test list is given the node is excluded from
+# ALL tests.  A comma-separated test list restricts
+# the exclusion to only those tests.
+#
+# Lines starting with # are comments.  Inline # also
+# starts a comment.
+
+# Container launch broken -- enroot prolog runs but
+# container never starts (all tests affected)
+ctr-cx63-mi300x-12
+
+# Stale rocm_xio kernel module stuck loaded; needs
+# node reboot to clear (only affects nvme-ep)
+ctr-cx64-mi300x-4  nvme-ep
+
+# No passwordless sudo -- kernel module install fails
+ctr-cx66-mi300x-13  nvme-ep
+
+# Flaky unsquashfs -- zstd decompression errors on
+# random files during container extraction
+mlse-alola-b39-ws4  nvme-ep
+mlse-alola-b39-ws6  nvme-ep
+
+# RDMA loopback test failures on this node
+banff-cyxtera-s81-5  rdma-ep
+
+# MI308X with intermittent SDMA P2P transfer failures;
+# MLX5 loopback CQE timeout (NIC lacks loopback_mode
+# sysfs, smoke test fails on all seeds);
+# nvme-ep xio-tester hangs after controller probe
+banff-cyxtera-s81-1  two-gpu,rdma-ep,nvme-ep

--- a/.alola/rocm-xio-alola.py
+++ b/.alola/rocm-xio-alola.py
@@ -32,6 +32,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_DIR = SCRIPT_DIR.parent
 JOB_IDS_FILE = SCRIPT_DIR / ".alola-job-ids"
+EXCLUDE_FILE = SCRIPT_DIR / ".alola-exclude"
 
 ALL_TESTS = [
     ("single-gpu",
@@ -244,6 +245,61 @@ def read_sbatch_exclude(script_path):
     except OSError:
         pass
     return []
+
+
+# ── Exclude-file I/O ──────────────────────────────────
+
+
+def load_exclude_file():
+    """Parse ``.alola-exclude`` and return a dict.
+
+    Each non-comment, non-blank line has the form::
+
+        node-name [test1,test2,...]
+
+    If no test list is given the node is excluded from
+    every test (value is ``None``).  Otherwise value is
+    a list of test names.
+
+    Returns ``{node: None | [test, ...], ...}``.
+    """
+    excludes = {}
+    if not EXCLUDE_FILE.is_file():
+        return excludes
+    for raw in EXCLUDE_FILE.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        node = parts[0]
+        if len(parts) > 1:
+            tests = [
+                t.strip()
+                for t in parts[1].split(",")
+                if t.strip()
+            ]
+        else:
+            tests = None
+        if node in excludes:
+            prev = excludes[node]
+            if prev is None or tests is None:
+                excludes[node] = None
+            else:
+                excludes[node] = list(dict.fromkeys(
+                    prev + tests))
+        else:
+            excludes[node] = tests
+    return excludes
+
+
+def excludes_for_test(excludes, test_name):
+    """Return a list of nodes to exclude for
+    *test_name* based on the parsed exclude dict."""
+    nodes = []
+    for node, tests in excludes.items():
+        if tests is None or test_name in tests:
+            nodes.append(node)
+    return nodes
 
 
 # ── Job-IDs file I/O ──────────────────────────────────
@@ -637,6 +693,13 @@ def submit_jobs(
             n for n in extra_exclude
             if n not in exclude_list]
 
+    file_excludes = load_exclude_file()
+    if file_excludes:
+        print(yellow(
+            f"Loaded {len(file_excludes)} node "
+            f"exclusion(s) from {EXCLUDE_FILE}"))
+        print()
+
     job_ids = {}
     out_files = {}
     err_files = {}
@@ -676,6 +739,11 @@ def submit_jobs(
                 "--container-mount-home=no")
 
         merged_exclude = list(exclude_list)
+        for n in excludes_for_test(
+            file_excludes, test_name
+        ):
+            if n not in merged_exclude:
+                merged_exclude.append(n)
         for n in read_sbatch_exclude(script_path):
             if n not in merged_exclude:
                 merged_exclude.append(n)

--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -13,9 +13,7 @@
 #SBATCH --gpus-per-node=1
 #   Ensure job only runs on nodes with spare NVMe devices
 #   To check compatible nodes: sinfo -Na -o "%N %100f" | grep NVME
-#   Also ensure a recent ROCm version since we need to run outside enroot.
 #SBATCH --constraint=MARKHAM&NVME
-#SBATCH --exclude=mlse-alola-b39-ws4,mlse-alola-b39-ws6,ctr-cx66-mi300x-13
 
 set -xe
 

--- a/.alola/rocm-xio-tests.rdma-ep.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep.sbatch
@@ -20,7 +20,6 @@
 #SBATCH --container-image=/cluster/images/rocm-xio/rocm-xio-alola.sqsh
 #SBATCH --container-mount-home
 #SBATCH --constraint=MARKHAM&IB
-#SBATCH --exclude=banff-cyxtera-s81-5
 #SBATCH --gpus-per-node=1
 
 set -xe

--- a/.alola/rocm-xio-tests.two-gpu.sbatch
+++ b/.alola/rocm-xio-tests.two-gpu.sbatch
@@ -20,8 +20,6 @@
 #SBATCH --container-mount-home
 #SBATCH --constraint=MARKHAM&(GFX942|GFX950)
 #SBATCH --gres=gpu:2
-# MI308X nodes with intermittent SDMA P2P transfer failures
-#SBATCH --exclude=banff-cyxtera-s81-1
 
 set -xe
 


### PR DESCRIPTION
Move per-node SLURM exclusions out of individual sbatch scripts and into a shared .alola-exclude file.  Each line names a node and optionally scopes the exclusion to specific tests (e.g. "node nvme-ep,rdma-ep"); omitting the test list excludes from all tests.

The rocm-xio-alola.py submit flow now parses this file and merges its entries with the CLI --exclude-nodes flag and any remaining #SBATCH --exclude directives, per test.

Removed #SBATCH --exclude lines from:
  - nvme-ep  (mlse-alola-b39-ws4, ws6, ctr-cx66-mi300x-13)
  - rdma-ep  (banff-cyxtera-s81-5)
  - two-gpu  (banff-cyxtera-s81-1)

Initial .alola-exclude entries:
  - ctr-cx63-mi300x-12   (all)      container launch broken
  - ctr-cx64-mi300x-4    (nvme-ep)  stale kernel module
  - ctr-cx66-mi300x-13   (nvme-ep)  no passwordless sudo
  - mlse-alola-b39-ws4/6 (nvme-ep)  flaky unsquashfs
  - banff-cyxtera-s81-5  (rdma-ep)  loopback CQE timeout
  - banff-cyxtera-s81-1  (two-gpu,rdma-ep)  SDMA P2P + CQE
