### PR TITLE
docs: fix Breathe parse failures for __forceinline__ device functions

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -44,6 +44,7 @@ PREDEFINED             = __host__= \
                          __device__= \
                          __global__= \
                          __shared__= \
+                         __forceinline__= \
                          __attribute__(x)= \
                          __HIP_DEVICE_COMPILE__=0
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ html_theme_options = {
         "https://github.com/ROCm/rocm-xio"
     ),
     "use_repository_button": True,
-    "show_toc_level": 2,
+    "show_toc_level": 3,
 }
 html_title = f"rocm-xio {version}"
 html_static_path = []


### PR DESCRIPTION
Doxygen's PREDEFINED macros stripped __host__, __device__, __global__, and __shared__ but not __forceinline__. Breathe's C++ parser cannot handle the non-standard keyword, causing all 11 sdma_ep device-side function references in api.rst to render as warnings instead of documentation.

Add __forceinline__= to the PREDEFINED list so Doxygen expands it to nothing during preprocessing, matching the treatment of other HIP qualifiers.

Also increase show_toc_level from 2 to 3 in conf.py so that Breathe- generated struct and function names under SDMA subsection headings (Configuration, Host-Side Setup, Device-Side Operations, Validation) appear in the right-hand "On this page" TOC, consistent with how NVMe endpoint entries are displayed.
