### PR TITLE
refactor: deduplicate shared patterns across codebase

### DIFF
--- a/.alola/rocm-xio-alola.py
+++ b/.alola/rocm-xio-alola.py
@@ -988,6 +988,7 @@ def display_results(
     total_unknown = 0
     total_running = 0
     subtest_counts = []
+    failed_details = []
 
     for test_name, script in TESTS:
         print("-" * 40)
@@ -1058,6 +1059,8 @@ def display_results(
             else:
                 print(f"Status: {label}")
             total_failed += 1
+            failed_details.append(
+                (test_name, suffix.strip("() ")))
 
         elif sc == STATUS_RUNNING:
             print(
@@ -1144,6 +1147,11 @@ def display_results(
     print(f"Passed: {green(total_passed)}")
     if total_failed > 0:
         print(f"Failed: {red(total_failed)}")
+        for fname, fdetail in failed_details:
+            if fdetail:
+                print(f"  {fname}: {fdetail}")
+            else:
+                print(f"  {fname}")
     else:
         print(f"Failed: {green(total_failed)}")
     if total_running > 0:

--- a/.alola/rocm-xio-tests.common
+++ b/.alola/rocm-xio-tests.common
@@ -453,19 +453,20 @@ detect_rdma_nic() {
   local ssh_cmd="$1"
   local host="$2"
   local vendor="$3"
+  local ib="/sys/class/infiniband"
 
   local pattern
   case "${vendor}" in
-    bnxt)  pattern="rocm-rdma-bnxt* bnxt_*" ;;
-    mlx5)  pattern="rocm-rdma-mlx5* mlx5_*" ;;
-    ionic) pattern="rocm-rdma-ionic* ionic_*" ;;
+    bnxt)  pattern="${ib}/rocm-rdma-bnxt* ${ib}/bnxt_*" ;;
+    mlx5)  pattern="${ib}/rocm-rdma-mlx5* ${ib}/mlx5_*" ;;
+    ionic) pattern="${ib}/rocm-rdma-ionic* ${ib}/ionic_*" ;;
     *)     return 1 ;;
   esac
 
   local sysfs_hit
   sysfs_hit=$(${ssh_cmd} "${host}" \
-    "ls -d /sys/class/infiniband/${pattern} \
-    2>/dev/null | head -1" 2>/dev/null || true)
+    "ls -d ${pattern} 2>/dev/null | head -1" \
+    2>/dev/null || true)
   if [ -n "${sysfs_hit}" ]; then
     ${ssh_cmd} "${host}" "basename ${sysfs_hit}"
   fi

--- a/.alola/rocm-xio-tests.common
+++ b/.alola/rocm-xio-tests.common
@@ -414,3 +414,78 @@ test_report() {
     return 1
   fi
 }
+
+# ---------------------------------------------------------
+# rdma_alola_build WORKDIR TARGET
+#
+# rsync + cmake + build for RDMA tests.  Sets
+# RDMA_CORE_LIB and TEST_BIN for the caller.
+# ---------------------------------------------------------
+rdma_alola_build() {
+  local workdir="$1"
+  local target="$2"
+
+  mkdir -p "${workdir}"
+  rsync -a --exclude='.git' . "${workdir}"
+  cd "${workdir}"
+  rm -rf build
+  cmake -S . -B build \
+    -DGDA_BNXT=ON -DGDA_MLX5=ON -DGDA_IONIC=ON
+  cmake --build build \
+    --target "${target}" \
+    --target install-rdma-core \
+    --parallel
+
+  RDMA_CORE_LIB="${workdir}/build/_deps"
+  RDMA_CORE_LIB="${RDMA_CORE_LIB}/rdma-core/install/lib"
+  TEST_BIN="${workdir}/build/tests/unit"
+  TEST_BIN="${TEST_BIN}/rdma-ep/${target}"
+}
+
+# ---------------------------------------------------------
+# detect_rdma_nic SSH_CMD HOST VENDOR
+#
+# Check a single vendor on HOST via SSH_CMD.  Prints
+# "DEVICE" on stdout if found, empty otherwise.
+# VENDOR is one of: bnxt, mlx5, ionic
+# ---------------------------------------------------------
+detect_rdma_nic() {
+  local ssh_cmd="$1"
+  local host="$2"
+  local vendor="$3"
+
+  local pattern
+  case "${vendor}" in
+    bnxt)  pattern="rocm-rdma-bnxt* bnxt_*" ;;
+    mlx5)  pattern="rocm-rdma-mlx5* mlx5_*" ;;
+    ionic) pattern="rocm-rdma-ionic* ionic_*" ;;
+    *)     return 1 ;;
+  esac
+
+  local sysfs_hit
+  sysfs_hit=$(${ssh_cmd} "${host}" \
+    "ls -d /sys/class/infiniband/${pattern} \
+    2>/dev/null | head -1" 2>/dev/null || true)
+  if [ -n "${sysfs_hit}" ]; then
+    ${ssh_cmd} "${host}" "basename ${sysfs_hit}"
+  fi
+}
+
+# ---------------------------------------------------------
+# nvme_ep_test LABEL EXTRA_ARGS...
+#
+# Shorthand for the repeated xio-tester nvme-ep invocation
+# pattern in nvme-ep.sbatch.  Runs test_run with the
+# standard controller, seed, and access-pattern options,
+# then sleeps 3s between tests.
+#
+# Required env: WORKING_DIR, NON_ROOTFS_CTRL
+# ---------------------------------------------------------
+nvme_ep_test() {
+  local label="$1"; shift
+  test_run "${label}" \
+    "run_on_host '${WORKING_DIR}/build/xio-tester \
+nvme-ep --controller ${NON_ROOTFS_CTRL} \
+--access-pattern random $*'"
+  sleep 3
+}

--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -168,115 +168,60 @@ test_run "nvme-ep reject --batch-size > max block size (expect fail)" \
 nvme-ep --controller ${NON_ROOTFS_CTRL} \
 --batch-size 1024 -n 1'"
 
-test_run "NVMe-EP memory-mode 0" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
---queue-length 128'"
+nvme_ep_test "NVMe-EP memory-mode 0" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 23 --queue-length 128
 
-sleep 3
+nvme_ep_test "NVMe-EP batch-size 4 memory-mode 0" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 23 --queue-length 128 --batch-size 4
 
-test_run "NVMe-EP batch-size 4 memory-mode 0" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
---queue-length 128 --batch-size 4'"
+nvme_ep_test "NVMe-EP batch-size 16 memory-mode 0" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 23 --queue-length 128 --batch-size 16
 
-sleep 3
+nvme_ep_test "NVMe-EP batch-size 0 (all-at-once)" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 23 --queue-length 128 --batch-size 0
 
-test_run "NVMe-EP batch-size 16 memory-mode 0" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
---queue-length 128 --batch-size 16'"
+nvme_ep_test "NVMe-EP multi-wavefront batch-size 128" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 256 --queue-length 256 --batch-size 128
 
-sleep 3
+nvme_ep_test "NVMe-EP num-queues 2" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 23 --queue-length 128 --num-queues 2
 
-test_run "NVMe-EP batch-size 0 (all-at-once)" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
---queue-length 128 --batch-size 0'"
+nvme_ep_test "NVMe-EP num-queues 4" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 23 --queue-length 128 --num-queues 4
 
-sleep 3
-
-test_run "NVMe-EP multi-wavefront batch-size 128" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 256 \
---queue-length 256 --batch-size 128'"
-
-sleep 3
-
-test_run "NVMe-EP num-queues 2" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
---queue-length 128 --num-queues 2'"
-
-sleep 3
-
-test_run "NVMe-EP num-queues 4" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 23 \
---queue-length 128 --num-queues 4'"
-
-sleep 3
-
-test_run "NVMe-EP num-queues 2 + batch-size 16" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 0 \
---lbas-per-io 1 --lfsr-seed 32 --read-io 64 \
---queue-length 128 --num-queues 2 --batch-size 16'"
-
-sleep 3
+nvme_ep_test "NVMe-EP num-queues 2 + batch-size 16" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 32 \
+  --read-io 64 --queue-length 128 --num-queues 2 \
+  --batch-size 16
 
 # VRAM-backed queues require CDNA GPUs; RDNA (gfx1100)
 # cannot DMA NVMe I/O to device memory reliably.
 if [ "${ROCM_GPU_ARCH}" != "gfx1100" ]; then
 
-test_run "NVMe-EP memory-mode 3" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 3 --less-timing \
---lbas-per-io 1 --lfsr-seed 32 --read-io 573 \
---queue-length 128'"
+nvme_ep_test "NVMe-EP memory-mode 3" \
+  --memory-mode 3 --less-timing --lbas-per-io 1 \
+  --lfsr-seed 32 --read-io 573 --queue-length 128
 
-sleep 3
+nvme_ep_test "NVMe-EP batch-size 4 memory-mode 3" \
+  --memory-mode 3 --less-timing --lbas-per-io 1 \
+  --lfsr-seed 32 --read-io 573 --queue-length 128 \
+  --batch-size 4
 
-test_run "NVMe-EP batch-size 4 memory-mode 3" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 3 --less-timing \
---lbas-per-io 1 --lfsr-seed 32 --read-io 573 \
---queue-length 128 --batch-size 4'"
+nvme_ep_test "NVMe-EP memory-mode 11" \
+  --memory-mode 11 --less-timing --lbas-per-io 1 \
+  --lfsr-seed 32 --read-io 573 --queue-length 128
 
-sleep 3
-
-test_run "NVMe-EP memory-mode 11" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 11 --less-timing \
---lbas-per-io 1 --lfsr-seed 32 --read-io 573 \
---queue-length 128'"
-
-sleep 3
-
-test_run "NVMe-EP batch-size 16 memory-mode 11" \
-  "run_on_host '${WORKING_DIR}/build/xio-tester \
-nvme-ep --controller ${NON_ROOTFS_CTRL} \
---access-pattern random --memory-mode 11 --less-timing \
---lbas-per-io 1 --lfsr-seed 32 --read-io 573 \
---queue-length 128 --batch-size 16'"
+nvme_ep_test "NVMe-EP batch-size 16 memory-mode 11" \
+  --memory-mode 11 --less-timing --lbas-per-io 1 \
+  --lfsr-seed 32 --read-io 573 --queue-length 128 \
+  --batch-size 16
 
 else
   echo "INFO: Skipping VRAM memory-modes 3/11" \

--- a/.alola/rocm-xio-tests.rdma-ep-2node.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep-2node.sbatch
@@ -71,21 +71,7 @@ detect_gpu_arch
 
 # --- Build phase (inside container) ---
 WORKING_DIR="/tmp/rocm-xio-tests.rdma-2n.$RANDOM"
-mkdir -p "${WORKING_DIR}"
-rsync -a --exclude='.git' . "${WORKING_DIR}"
-cd "${WORKING_DIR}"
-rm -rf build
-cmake -S . -B build \
-  -DGDA_BNXT=ON -DGDA_MLX5=ON -DGDA_IONIC=ON
-cmake --build build \
-  --target test-rdma-2node \
-  --target install-rdma-core \
-  --parallel
-
-RDMA_CORE_LIB="${WORKING_DIR}/build/_deps"
-RDMA_CORE_LIB="${RDMA_CORE_LIB}/rdma-core/install/lib"
-TEST_BIN="${WORKING_DIR}/build/tests/unit"
-TEST_BIN="${TEST_BIN}/rdma-ep/test-rdma-2node"
+rdma_alola_build "${WORKING_DIR}" "test-rdma-2node"
 
 # --- Copy artifacts to both nodes ---
 echo ""
@@ -108,47 +94,15 @@ echo "Detecting RDMA NICs on ${NODE_SERVER}..."
 
 detect_vendor_on_node() {
   local node="$1"
-  local vendor=""
-  local dev=""
-
-  local has_mlx5
-  has_mlx5=$(${SSH_COMMAND} "${node}" \
-    "ls -d /sys/class/infiniband/rocm-rdma-mlx5* \
-    /sys/class/infiniband/mlx5_* 2>/dev/null \
-    | head -1" || true)
-  if [ -n "${has_mlx5}" ]; then
-    vendor="mlx5"
-    dev=$(${SSH_COMMAND} "${node}" \
-      "basename ${has_mlx5}")
-    echo "${vendor} ${dev}"
-    return
-  fi
-
-  local has_bnxt
-  has_bnxt=$(${SSH_COMMAND} "${node}" \
-    "ls -d /sys/class/infiniband/rocm-rdma-bnxt* \
-    /sys/class/infiniband/bnxt_* 2>/dev/null \
-    | head -1" || true)
-  if [ -n "${has_bnxt}" ]; then
-    vendor="bnxt"
-    dev=$(${SSH_COMMAND} "${node}" \
-      "basename ${has_bnxt}")
-    echo "${vendor} ${dev}"
-    return
-  fi
-
-  local has_ionic
-  has_ionic=$(${SSH_COMMAND} "${node}" \
-    "ls -d /sys/class/infiniband/rocm-rdma-ionic* \
-    /sys/class/infiniband/ionic_* 2>/dev/null \
-    | head -1" || true)
-  if [ -n "${has_ionic}" ]; then
-    vendor="ionic"
-    dev=$(${SSH_COMMAND} "${node}" \
-      "basename ${has_ionic}")
-    echo "${vendor} ${dev}"
-    return
-  fi
+  for _v in mlx5 bnxt ionic; do
+    local _dev
+    _dev=$(detect_rdma_nic "${SSH_COMMAND}" \
+      "${node}" "${_v}")
+    if [ -n "${_dev}" ]; then
+      echo "${_v} ${_dev}"
+      return
+    fi
+  done
 }
 
 read -r SRV_VENDOR SRV_DEV \

--- a/.alola/rocm-xio-tests.rdma-ep.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep.sbatch
@@ -61,24 +61,8 @@ cd "${PROJECT_DIR}"
 detect_gpu_arch
 
 # --- Build phase (inside container) ---
-# Cannot use setup_and_build_workdir because we
-# need extra cmake flags and specific build targets.
 WORKING_DIR="/tmp/rocm-xio-tests.rdma-ep.$RANDOM"
-mkdir -p "${WORKING_DIR}"
-rsync -a --exclude='.git' . "${WORKING_DIR}"
-cd "${WORKING_DIR}"
-rm -rf build
-cmake -S . -B build \
-  -DGDA_BNXT=ON -DGDA_MLX5=ON -DGDA_IONIC=ON
-cmake --build build \
-  --target test-rdma-loopback \
-  --target install-rdma-core \
-  --parallel
-
-RDMA_CORE_LIB="${WORKING_DIR}/build/_deps"
-RDMA_CORE_LIB="${RDMA_CORE_LIB}/rdma-core/install/lib"
-TEST_BIN="${WORKING_DIR}/build/tests/unit"
-TEST_BIN="${TEST_BIN}/rdma-ep/test-rdma-loopback"
+rdma_alola_build "${WORKING_DIR}" "test-rdma-loopback"
 SETUP_SCRIPT="${WORKING_DIR}/scripts/test"
 SETUP_SCRIPT="${SETUP_SCRIPT}/setup-rdma-loopback.sh"
 
@@ -112,41 +96,18 @@ resolve_ib_bdf() {
     | xargs basename" 2>/dev/null || echo "unknown"
 }
 
-HAS_BNXT=$(${SSH_LOCALHOST} \
-  "ls -d /sys/class/infiniband/rocm-rdma-bnxt* \
-  /sys/class/infiniband/bnxt_* 2>/dev/null \
-  | head -1" || true)
-if [ -n "${HAS_BNXT}" ]; then
-  BNXT_DEV=$(${SSH_LOCALHOST} \
-    "basename ${HAS_BNXT}")
-  BNXT_BDF=$(resolve_ib_bdf "${BNXT_DEV}")
-  DETECTED_VENDORS="${DETECTED_VENDORS} bnxt"
-  echo "  Found BNXT: ${BNXT_DEV} (PCI ${BNXT_BDF})"
-fi
-
-HAS_MLX5=$(${SSH_LOCALHOST} \
-  "ls -d /sys/class/infiniband/rocm-rdma-mlx5* \
-  /sys/class/infiniband/mlx5_* 2>/dev/null \
-  | head -1" || true)
-if [ -n "${HAS_MLX5}" ]; then
-  MLX5_DEV=$(${SSH_LOCALHOST} \
-    "basename ${HAS_MLX5}")
-  MLX5_BDF=$(resolve_ib_bdf "${MLX5_DEV}")
-  DETECTED_VENDORS="${DETECTED_VENDORS} mlx5"
-  echo "  Found MLX5: ${MLX5_DEV} (PCI ${MLX5_BDF})"
-fi
-
-HAS_IONIC=$(${SSH_LOCALHOST} \
-  "ls -d /sys/class/infiniband/rocm-rdma-ionic* \
-  /sys/class/infiniband/ionic_* 2>/dev/null \
-  | head -1" || true)
-if [ -n "${HAS_IONIC}" ]; then
-  IONIC_DEV=$(${SSH_LOCALHOST} \
-    "basename ${HAS_IONIC}")
-  IONIC_BDF=$(resolve_ib_bdf "${IONIC_DEV}")
-  DETECTED_VENDORS="${DETECTED_VENDORS} ionic"
-  echo "  Found IONIC: ${IONIC_DEV} (PCI ${IONIC_BDF})"
-fi
+for _v in bnxt mlx5 ionic; do
+  _dev=$(detect_rdma_nic "${SSH_LOCALHOST}" \
+    "localhost" "${_v}")
+  if [ -n "${_dev}" ]; then
+    _bdf=$(resolve_ib_bdf "${_dev}")
+    eval "${_v^^}_DEV=\${_dev}"
+    eval "${_v^^}_BDF=\${_bdf}"
+    DETECTED_VENDORS="${DETECTED_VENDORS} ${_v}"
+    echo "  Found ${_v^^}: ${_dev} (PCI ${_bdf})"
+  fi
+done
+unset _v _dev _bdf
 
 if [ -z "${DETECTED_VENDORS}" ]; then
   echo "ERROR: No RDMA NICs detected on host."

--- a/.alola/rocm-xio-tests.rdma-ep.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep.sbatch
@@ -97,7 +97,7 @@ resolve_ib_bdf() {
 }
 
 for _v in bnxt mlx5 ionic; do
-  _dev=$(detect_rdma_nic "${SSH_LOCALHOST}" \
+  _dev=$(detect_rdma_nic "${SSH_COMMAND}" \
     "localhost" "${_v}")
   if [ -n "${_dev}" ]; then
     _bdf=$(resolve_ib_bdf "${_dev}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,83 +37,48 @@
   ],
   "testPresets": [
     {
-      "name": "unit",
-      "displayName": "Unit tests (CPU-only)",
+      "name": "base",
+      "hidden": true,
       "configurePreset": "default",
       "output": {
         "outputOnFailure": true,
         "verbosity": "verbose"
-      },
-      "filter": {
-        "include": {
-          "label": "unit"
-        }
       }
+    },
+    {
+      "name": "unit",
+      "displayName": "Unit tests (CPU-only)",
+      "inherits": "base",
+      "filter": { "include": { "label": "unit" } }
     },
     {
       "name": "system",
       "displayName": "System tests (GPU required)",
-      "configurePreset": "default",
-      "output": {
-        "outputOnFailure": true,
-        "verbosity": "verbose"
-      },
-      "filter": {
-        "include": {
-          "label": "system"
-        }
-      }
+      "inherits": "base",
+      "filter": { "include": { "label": "system" } }
     },
     {
       "name": "hardware",
       "displayName": "Hardware tests (NIC/device)",
-      "configurePreset": "default",
-      "output": {
-        "outputOnFailure": true,
-        "verbosity": "verbose"
-      },
-      "filter": {
-        "include": {
-          "label": "hardware"
-        }
-      }
+      "inherits": "base",
+      "filter": { "include": { "label": "hardware" } }
     },
     {
       "name": "sweep",
       "displayName": "Loopback sweep (multi-seed)",
-      "configurePreset": "default",
-      "output": {
-        "outputOnFailure": true,
-        "verbosity": "verbose"
-      },
-      "filter": {
-        "include": {
-          "label": "sweep"
-        }
-      }
+      "inherits": "base",
+      "filter": { "include": { "label": "sweep" } }
     },
     {
       "name": "integration",
       "displayName": "Integration tests (install + examples)",
-      "configurePreset": "default",
-      "output": {
-        "outputOnFailure": true,
-        "verbosity": "verbose"
-      },
-      "filter": {
-        "include": {
-          "label": "integration"
-        }
-      }
+      "inherits": "base",
+      "filter": { "include": { "label": "integration" } }
     },
     {
       "name": "all",
       "displayName": "All tests",
-      "configurePreset": "default",
-      "output": {
-        "outputOnFailure": true,
-        "verbosity": "verbose"
-      }
+      "inherits": "base"
     }
   ]
 }

--- a/cmake/XIOTestHelpers.cmake
+++ b/cmake/XIOTestHelpers.cmake
@@ -9,6 +9,7 @@
 set(XIO_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/include)
 set(XIO_ENDPOINTS_DIR ${CMAKE_SOURCE_DIR}/src/endpoints)
 set(XIO_COMMON_DIR ${CMAKE_SOURCE_DIR}/src/common)
+set(XIO_TEST_COMMON_DIR ${CMAKE_SOURCE_DIR}/tests/unit/common)
 
 # xio_add_test()
 #
@@ -66,6 +67,7 @@ function(xio_add_test)
   target_include_directories(${XIO_TEST_NAME} PRIVATE
     ${XIO_INCLUDE_DIR}
     ${XIO_COMMON_DIR}
+    ${XIO_TEST_COMMON_DIR}
   )
 
   if(XIO_TEST_INCLUDE_DIRS)

--- a/kernel/bnxt/setup-bnxt-re-dkms.sh
+++ b/kernel/bnxt/setup-bnxt-re-dkms.sh
@@ -86,72 +86,13 @@ done
 
 DKMS_SRC="/usr/src/${PKG_NAME}-${PKG_VERSION}"
 
-# -----------------------------------------------------------
-# Uninstall
-# -----------------------------------------------------------
+# shellcheck source=../dkms-common.sh
+. "$(dirname "${SCRIPT_DIR}")/dkms-common.sh"
 
-if $UNINSTALL; then
-  echo "Removing DKMS module" \
-    "${PKG_NAME}/${PKG_VERSION}..."
-  sudo dkms remove "${PKG_NAME}/${PKG_VERSION}" \
-    --all 2>/dev/null || true
-  sudo rm -rf "${DKMS_SRC}"
-  echo "Done."
-  exit 0
-fi
-
-# -----------------------------------------------------------
-# Prerequisites
-# -----------------------------------------------------------
-
-check_prereqs() {
-  local missing=()
-  command -v curl &>/dev/null || missing+=("curl")
-  command -v dkms &>/dev/null || missing+=("dkms")
-  command -v make &>/dev/null || missing+=("make")
-
-  if [ ${#missing[@]} -gt 0 ]; then
-    echo "ERROR: Missing required tools:" \
-      "${missing[*]}"
-    echo "Install with:"
-    echo "  sudo apt install ${missing[*]}"
-    exit 1
-  fi
-
-  local kver
-  kver="$(uname -r)"
-  if [ ! -f "/lib/modules/${kver}/build/Makefile" ]
-  then
-    echo "ERROR: Kernel headers not found for" \
-      "${kver}."
-    echo "Install with:"
-    echo "  sudo apt install" \
-      "linux-headers-${kver}"
-    exit 1
-  fi
-}
-
-check_prereqs
-
-# -----------------------------------------------------------
-# Detect kernel tag
-# -----------------------------------------------------------
-
-detect_kernel_tag() {
-  if [ -n "${KERNEL_TAG}" ]; then
-    return
-  fi
-  local kver
-  kver="$(uname -r)"
-  local major_minor
-  major_minor="$(echo "${kver}" | \
-    sed 's/\([0-9]*\.[0-9]*\).*/\1/')"
-  KERNEL_TAG="v${major_minor}"
-  echo "Auto-detected kernel tag: ${KERNEL_TAG}" \
-    "(from ${kver})"
-}
-
-detect_kernel_tag
+dkms_uninstall_guard
+dkms_check_tools curl dkms make
+dkms_check_kernel_headers
+dkms_detect_kernel_tag
 
 echo ""
 echo "=== setup-bnxt-re-dkms ==="
@@ -161,17 +102,7 @@ echo "  DKMS src    : ${DKMS_SRC}"
 echo "  package     : ${PKG_NAME}/${PKG_VERSION}"
 echo ""
 
-# -----------------------------------------------------------
-# Skip if already installed
-# -----------------------------------------------------------
-
-if ! $BUILD_ONLY && \
-    dkms status "${PKG_NAME}/${PKG_VERSION}" \
-    2>/dev/null | grep -q "installed"; then
-  echo "${PKG_NAME}/${PKG_VERSION} already installed."
-  echo "Use --uninstall to remove first."
-  exit 0
-fi
+dkms_skip_if_installed
 
 # -----------------------------------------------------------
 # Download kernel source (cached in download/)
@@ -469,49 +400,9 @@ populate_dkms
 # Register and build with DKMS
 # -----------------------------------------------------------
 
-build_dkms() {
-  echo ""
-
-  if dkms status "${PKG_NAME}/${PKG_VERSION}" \
-      2>/dev/null | grep -q .; then
-    echo "Removing stale DKMS registration..."
-    sudo dkms remove "${PKG_NAME}/${PKG_VERSION}" \
-      --all 2>/dev/null || true
-  fi
-
-  echo "Registering with DKMS..."
-  sudo dkms add "${PKG_NAME}/${PKG_VERSION}"
-
-  local kver
-  kver="$(uname -r)"
-
-  echo "Building bnxt_re.ko for ${kver}..."
-  if ! sudo dkms build \
-      "${PKG_NAME}/${PKG_VERSION}" -k "${kver}"
-  then
-    echo ""
-    echo "ERROR: DKMS build failed."
-    echo "Check: /var/lib/dkms/${PKG_NAME}/" \
-      "${PKG_VERSION}/build/make.log"
-    exit 1
-  fi
-
-  echo ""
-  echo "=== bnxt_re (DV) built via DKMS ==="
-  echo "  Module: /var/lib/dkms/${PKG_NAME}/" \
-    "${PKG_VERSION}/${kver}/x86_64/module/"
-  echo ""
-  echo "To install:"
-  echo "  $0 # (re-run without --build-only)"
-}
-
-install_dkms() {
-  local kver
-  kver="$(uname -r)"
-
-  echo "Installing bnxt_re.ko..."
-  sudo dkms install \
-    "${PKG_NAME}/${PKG_VERSION}" -k "${kver}"
+dkms_build "bnxt_re (DV)"
+if ! $BUILD_ONLY; then
+  dkms_install "bnxt_re (DV)"
 
   echo ""
   echo "=== bnxt_re (DV) installed via DKMS ==="
@@ -527,9 +418,4 @@ install_dkms() {
   echo "  $0 --uninstall"
   echo "  sudo depmod -a"
   echo "  sudo modprobe bnxt_re"
-}
-
-build_dkms
-if ! $BUILD_ONLY; then
-  install_dkms
 fi

--- a/kernel/dkms-common.sh
+++ b/kernel/dkms-common.sh
@@ -1,0 +1,190 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Shared DKMS lifecycle helpers sourced by the
+# per-driver setup-*-dkms.sh scripts.
+#
+# The caller must set these variables before sourcing:
+#   PKG_NAME       - e.g. "rocm-xio-bnxt-re"
+#   PKG_VERSION    - e.g. "0.1.0-gabcdef0"
+#   DKMS_SRC       - /usr/src/${PKG_NAME}-${PKG_VERSION}
+#   BUILD_ONLY     - true / false
+#   UNINSTALL      - true / false
+#
+# Optional:
+#   KERNEL_TAG     - set before calling dkms_detect_kernel_tag
+
+# ---------------------------------------------------------
+# dkms_uninstall_guard
+#   Exit early if --uninstall was requested.
+# ---------------------------------------------------------
+dkms_uninstall_guard() {
+  if $UNINSTALL; then
+    echo "Removing DKMS module" \
+      "${PKG_NAME}/${PKG_VERSION}..."
+    sudo dkms remove \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      --all 2>/dev/null || true
+    sudo rm -rf "${DKMS_SRC}"
+    echo "Done."
+    exit 0
+  fi
+}
+
+# ---------------------------------------------------------
+# dkms_check_kernel_headers
+#   Verify kernel headers are installed.
+# ---------------------------------------------------------
+dkms_check_kernel_headers() {
+  local kver
+  kver="$(uname -r)"
+  if [ ! -f "/lib/modules/${kver}/build/Makefile" ]
+  then
+    echo "ERROR: Kernel headers not found for" \
+      "${kver}."
+    echo "Install with:"
+    echo "  sudo apt install" \
+      "linux-headers-${kver}"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------
+# dkms_check_tools TOOL [TOOL ...]
+#   Verify that each listed command exists on PATH.
+# ---------------------------------------------------------
+dkms_check_tools() {
+  local missing=()
+  for tool in "$@"; do
+    command -v "${tool}" &>/dev/null \
+      || missing+=("${tool}")
+  done
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: Missing required tools:" \
+      "${missing[*]}"
+    echo "Install with:"
+    echo "  sudo apt install ${missing[*]}"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------
+# dkms_detect_kernel_tag
+#   Auto-detect KERNEL_TAG from uname if not set.
+# ---------------------------------------------------------
+dkms_detect_kernel_tag() {
+  if [ -n "${KERNEL_TAG:-}" ]; then
+    return
+  fi
+  local kver
+  kver="$(uname -r)"
+  local major_minor
+  major_minor="$(echo "${kver}" | \
+    sed 's/\([0-9]*\.[0-9]*\).*/\1/')"
+  KERNEL_TAG="v${major_minor}"
+  echo "Auto-detected kernel tag:" \
+    "${KERNEL_TAG} (from ${kver})"
+}
+
+# ---------------------------------------------------------
+# dkms_skip_if_installed
+#   Exit 0 if the module is already installed and
+#   we're not in build-only mode.
+# ---------------------------------------------------------
+dkms_skip_if_installed() {
+  if ! $BUILD_ONLY && \
+      dkms status \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      2>/dev/null | grep -q "installed"; then
+    echo "${PKG_NAME}/${PKG_VERSION}" \
+      "already installed."
+    echo "Use --uninstall to remove first."
+    exit 0
+  fi
+}
+
+# ---------------------------------------------------------
+# dkms_build MODULE_LABEL
+#   Remove stale registration, add, and build.
+#   MODULE_LABEL is a human-readable string like
+#   "bnxt_re.ko" or "ionic + ionic_rdma".
+# ---------------------------------------------------------
+dkms_build() {
+  local label="${1:?MODULE_LABEL required}"
+  echo ""
+
+  if dkms status \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      2>/dev/null | grep -q .; then
+    echo "Removing stale DKMS registration..."
+    sudo dkms remove \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      --all 2>/dev/null || true
+  fi
+
+  echo "Registering with DKMS..."
+  sudo dkms add "${PKG_NAME}/${PKG_VERSION}"
+
+  local kver
+  kver="$(uname -r)"
+
+  echo "Building ${label} for ${kver}..."
+  if ! sudo dkms build \
+      "${PKG_NAME}/${PKG_VERSION}" \
+      -k "${kver}"; then
+    echo ""
+    echo "ERROR: DKMS build failed."
+    echo "Check: /var/lib/dkms/${PKG_NAME}/" \
+      "${PKG_VERSION}/build/make.log"
+    exit 1
+  fi
+
+  echo ""
+  echo "=== ${label} built via DKMS ==="
+  echo "  Module: /var/lib/dkms/${PKG_NAME}/" \
+    "${PKG_VERSION}/${kver}/$(uname -m)/module/"
+  echo ""
+  echo "To install:"
+  echo "  $0  (re-run without --build-only)"
+}
+
+# ---------------------------------------------------------
+# dkms_install MODULE_LABEL
+#   Install the already-built module.
+# ---------------------------------------------------------
+dkms_install() {
+  local label="${1:?MODULE_LABEL required}"
+  local kver
+  kver="$(uname -r)"
+
+  echo "Installing ${label}..."
+  sudo dkms install \
+    "${PKG_NAME}/${PKG_VERSION}" -k "${kver}"
+}
+
+# ---------------------------------------------------------
+# dkms_build_and_install MODULE_LABEL
+#   Convenience: build, then install unless
+#   BUILD_ONLY is true.
+# ---------------------------------------------------------
+dkms_build_and_install() {
+  local label="${1:?MODULE_LABEL required}"
+  dkms_build "${label}"
+  if ! $BUILD_ONLY; then
+    dkms_install "${label}"
+  fi
+}
+
+# ---------------------------------------------------------
+# dkms_patch_version DKMS_CONF
+#   Sed PACKAGE_VERSION into dkms.conf.
+# ---------------------------------------------------------
+dkms_patch_version() {
+  local conf="${1:?DKMS_CONF path required}"
+  sudo sed -i \
+    "s/@PACKAGE_VERSION@/${PKG_VERSION}/g" \
+    "${conf}"
+}

--- a/kernel/ionic/setup-ionic-eth-rdma-dkms.sh
+++ b/kernel/ionic/setup-ionic-eth-rdma-dkms.sh
@@ -84,87 +84,22 @@ done
 
 DKMS_SRC="/usr/src/${PKG_NAME}-${PKG_VERSION}"
 
-# -------------------------------------------------------
-# Uninstall
-# -------------------------------------------------------
+# shellcheck source=../dkms-common.sh
+. "$(dirname "${SCRIPT_DIR}")/dkms-common.sh"
 
-if $UNINSTALL; then
-  echo "Removing DKMS module" \
-    "${PKG_NAME}/${PKG_VERSION}..."
-  sudo dkms remove \
-    "${PKG_NAME}/${PKG_VERSION}" \
-    --all 2>/dev/null || true
-  sudo rm -rf "${DKMS_SRC}"
-  echo "Done."
-  exit 0
+dkms_uninstall_guard
+dkms_check_tools curl dkms make patch
+dkms_check_kernel_headers
+
+if [ ! -d "${PATCHES_DIR}" ] || \
+   [ -z "$(ls -A "${PATCHES_DIR}"/*.patch \
+     2>/dev/null)" ]; then
+  echo "ERROR: No patches found in" \
+    "${PATCHES_DIR}/"
+  exit 1
 fi
 
-# -------------------------------------------------------
-# Prerequisites
-# -------------------------------------------------------
-
-check_prereqs() {
-  local missing=()
-  command -v curl &>/dev/null \
-    || missing+=("curl")
-  command -v dkms &>/dev/null \
-    || missing+=("dkms")
-  command -v make &>/dev/null \
-    || missing+=("make")
-  command -v patch &>/dev/null \
-    || missing+=("patch")
-
-  if [ ${#missing[@]} -gt 0 ]; then
-    echo "ERROR: Missing required tools:" \
-      "${missing[*]}"
-    echo "Install with:"
-    echo "  sudo apt install ${missing[*]}"
-    exit 1
-  fi
-
-  local kver
-  kver="$(uname -r)"
-  if [ ! -f \
-    "/lib/modules/${kver}/build/Makefile" ]
-  then
-    echo "ERROR: Kernel headers not found" \
-      "for ${kver}."
-    echo "Install with:"
-    echo "  sudo apt install" \
-      "linux-headers-${kver}"
-    exit 1
-  fi
-
-  if [ ! -d "${PATCHES_DIR}" ] || \
-     [ -z "$(ls -A "${PATCHES_DIR}"/*.patch \
-       2>/dev/null)" ]; then
-    echo "ERROR: No patches found in" \
-      "${PATCHES_DIR}/"
-    exit 1
-  fi
-}
-
-check_prereqs
-
-# -------------------------------------------------------
-# Detect kernel tag
-# -------------------------------------------------------
-
-detect_kernel_tag() {
-  if [ -n "${KERNEL_TAG}" ]; then
-    return
-  fi
-  local kver
-  kver="$(uname -r)"
-  local major_minor
-  major_minor="$(echo "${kver}" \
-    | sed 's/\([0-9]*\.[0-9]*\).*/\1/')"
-  KERNEL_TAG="v${major_minor}"
-  echo "Auto-detected kernel tag:" \
-    "${KERNEL_TAG} (from ${kver})"
-}
-
-detect_kernel_tag
+dkms_detect_kernel_tag
 
 echo ""
 echo "=== setup-ionic-eth-rdma-dkms ==="
@@ -175,19 +110,7 @@ echo "  package     :" \
   "${PKG_NAME}/${PKG_VERSION}"
 echo ""
 
-# -------------------------------------------------------
-# Skip if already installed
-# -------------------------------------------------------
-
-if ! $BUILD_ONLY && \
-    dkms status \
-    "${PKG_NAME}/${PKG_VERSION}" \
-    2>/dev/null | grep -q "installed"; then
-  echo "${PKG_NAME}/${PKG_VERSION}" \
-    "already installed."
-  echo "Use --uninstall to remove first."
-  exit 0
-fi
+dkms_skip_if_installed
 
 # -------------------------------------------------------
 # Download kernel source (cached)
@@ -439,53 +362,9 @@ populate_dkms
 # Register and build with DKMS
 # -------------------------------------------------------
 
-build_dkms() {
-  echo ""
-
-  if dkms status \
-      "${PKG_NAME}/${PKG_VERSION}" \
-      2>/dev/null | grep -q .; then
-    echo "Removing stale DKMS registration..."
-    sudo dkms remove \
-      "${PKG_NAME}/${PKG_VERSION}" \
-      --all 2>/dev/null || true
-  fi
-
-  echo "Registering with DKMS..."
-  sudo dkms add \
-    "${PKG_NAME}/${PKG_VERSION}"
-
-  local kver
-  kver="$(uname -r)"
-
-  echo "Building ionic + ionic_rdma" \
-    "for ${kver}..."
-  if ! sudo dkms build \
-      "${PKG_NAME}/${PKG_VERSION}" \
-      -k "${kver}"; then
-    echo ""
-    echo "ERROR: DKMS build failed."
-    echo "Check: /var/lib/dkms/${PKG_NAME}/" \
-      "${PKG_VERSION}/build/make.log"
-    exit 1
-  fi
-
-  echo ""
-  echo "=== ionic RDMA built via DKMS ==="
-  echo "  Module: /var/lib/dkms/${PKG_NAME}/" \
-    "${PKG_VERSION}/${kver}/x86_64/module/"
-  echo ""
-  echo "To install:"
-  echo "  $0  (re-run without --build-only)"
-}
-
-install_dkms() {
-  local kver
-  kver="$(uname -r)"
-
-  echo "Installing ionic + ionic_rdma..."
-  sudo dkms install \
-    "${PKG_NAME}/${PKG_VERSION}" -k "${kver}"
+dkms_build "ionic + ionic_rdma"
+if ! $BUILD_ONLY; then
+  dkms_install "ionic + ionic_rdma"
 
   echo ""
   echo "=== ionic RDMA installed via DKMS ==="
@@ -503,9 +382,4 @@ install_dkms() {
   echo "  $0 --uninstall"
   echo "  sudo depmod -a"
   echo "  sudo modprobe ionic"
-}
-
-build_dkms
-if ! $BUILD_ONLY; then
-  install_dkms
 fi

--- a/kernel/rocm-ernic/setup-rocm-ernic-eth-rdma-dkms.sh
+++ b/kernel/rocm-ernic/setup-rocm-ernic-eth-rdma-dkms.sh
@@ -82,69 +82,27 @@ fi
 
 DKMS_SRC="/usr/src/${PKG_NAME}-${PKG_VERSION}"
 
-# -------------------------------------------------------
-# Uninstall
-# -------------------------------------------------------
+# shellcheck source=../dkms-common.sh
+. "$(dirname "${SCRIPT_DIR}")/dkms-common.sh"
 
-if $UNINSTALL; then
-  echo "Removing DKMS module" \
-    "${PKG_NAME}/${PKG_VERSION}..."
-  sudo dkms remove \
-    "${PKG_NAME}/${PKG_VERSION}" \
-    --all 2>/dev/null || true
-  sudo rm -rf "${DKMS_SRC}"
-  echo "Done."
-  exit 0
+dkms_uninstall_guard
+dkms_check_tools dkms make
+dkms_check_kernel_headers
+
+if [ ! -d "${ERNIC_DRV_DIR}" ]; then
+  echo "ERROR: rocm-ernic driver source not" \
+    "found at ${ERNIC_DRV_DIR}"
+  echo "Set --ernic-dir to the rocm-ernic" \
+    "project root."
+  exit 1
 fi
 
-# -------------------------------------------------------
-# Prerequisites
-# -------------------------------------------------------
-
-check_prereqs() {
-  local missing=()
-  command -v dkms &>/dev/null \
-    || missing+=("dkms")
-  command -v make &>/dev/null \
-    || missing+=("make")
-
-  if [ ${#missing[@]} -gt 0 ]; then
-    echo "ERROR: Missing required tools:" \
-      "${missing[*]}"
-    echo "Install with:"
-    echo "  sudo apt install ${missing[*]}"
-    exit 1
-  fi
-
-  if [ ! -d "${ERNIC_DRV_DIR}" ]; then
-    echo "ERROR: rocm-ernic driver source not" \
-      "found at ${ERNIC_DRV_DIR}"
-    echo "Set --ernic-dir to the rocm-ernic" \
-      "project root."
-    exit 1
-  fi
-
-  if [ ! -f "${ERNIC_DRV_DIR}/rocm_ernic_main.c" ]
-  then
-    echo "ERROR: rocm_ernic_main.c not found in" \
-      "${ERNIC_DRV_DIR}"
-    exit 1
-  fi
-
-  local kver
-  kver="$(uname -r)"
-  if [ ! -f \
-    "/lib/modules/${kver}/build/Makefile" ]; then
-    echo "ERROR: Kernel headers not found" \
-      "for ${kver}."
-    echo "Install with:"
-    echo "  sudo apt install" \
-      "linux-headers-${kver}"
-    exit 1
-  fi
-}
-
-check_prereqs
+if [ ! -f "${ERNIC_DRV_DIR}/rocm_ernic_main.c" ]
+then
+  echo "ERROR: rocm_ernic_main.c not found in" \
+    "${ERNIC_DRV_DIR}"
+  exit 1
+fi
 
 # -------------------------------------------------------
 # Print status
@@ -159,19 +117,7 @@ echo "  package     :" \
   "${PKG_NAME}/${PKG_VERSION}"
 echo ""
 
-# -------------------------------------------------------
-# Skip if already installed
-# -------------------------------------------------------
-
-if ! $BUILD_ONLY && \
-    dkms status \
-    "${PKG_NAME}/${PKG_VERSION}" \
-    2>/dev/null | grep -q "installed"; then
-  echo "${PKG_NAME}/${PKG_VERSION}" \
-    "already installed."
-  echo "Use --uninstall to remove first."
-  exit 0
-fi
+dkms_skip_if_installed
 
 # -------------------------------------------------------
 # Populate DKMS source tree
@@ -235,52 +181,9 @@ populate_dkms
 # Register and build with DKMS
 # -------------------------------------------------------
 
-build_dkms() {
-  echo ""
-
-  if dkms status \
-      "${PKG_NAME}/${PKG_VERSION}" \
-      2>/dev/null | grep -q .; then
-    echo "Removing stale DKMS registration..."
-    sudo dkms remove \
-      "${PKG_NAME}/${PKG_VERSION}" \
-      --all 2>/dev/null || true
-  fi
-
-  echo "Registering with DKMS..."
-  sudo dkms add "${PKG_NAME}/${PKG_VERSION}"
-
-  local kver
-  kver="$(uname -r)"
-
-  echo "Building rocm_ernic_eth + rocm_ernic_rdma" \
-    "for ${kver}..."
-  if ! sudo dkms build \
-      "${PKG_NAME}/${PKG_VERSION}" \
-      -k "${kver}"; then
-    echo ""
-    echo "ERROR: DKMS build failed."
-    echo "Check: /var/lib/dkms/${PKG_NAME}/" \
-      "${PKG_VERSION}/build/make.log"
-    exit 1
-  fi
-
-  echo ""
-  echo "=== rocm_ernic eth+RDMA built via DKMS ==="
-  echo "  Module: /var/lib/dkms/${PKG_NAME}/" \
-    "${PKG_VERSION}/${kver}/$(uname -m)/module/"
-  echo ""
-  echo "To install:"
-  echo "  $0  (re-run without --build-only)"
-}
-
-install_dkms() {
-  local kver
-  kver="$(uname -r)"
-
-  echo "Installing rocm_ernic_eth + rocm_ernic_rdma..."
-  sudo dkms install \
-    "${PKG_NAME}/${PKG_VERSION}" -k "${kver}"
+dkms_build "rocm_ernic eth+RDMA"
+if ! $BUILD_ONLY; then
+  dkms_install "rocm_ernic eth+RDMA"
 
   echo ""
   echo "=== rocm_ernic eth+RDMA installed via DKMS ==="
@@ -298,9 +201,4 @@ install_dkms() {
   echo "To revert:"
   echo "  $0 --uninstall"
   echo "  sudo depmod -a"
-}
-
-build_dkms
-if ! $BUILD_ONLY; then
-  install_dkms
 fi

--- a/src/common/ibv-wrapper.cpp
+++ b/src/common/ibv-wrapper.cpp
@@ -16,6 +16,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
+#include "xio-rdma-check.h"
 #include "xio.h"
 
 namespace rdma_ep {
@@ -24,26 +25,8 @@ IBVWrapper ibv;
 
 namespace {
 
-template <typename FuncPtr>
-int dlsym_load(FuncPtr& out, void* handle, const char* prefix,
-               const char* name) {
-  char full_name[256];
-  snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
-  if (!out) {
-    fprintf(stderr, "rdma_ep: dlsym failed for %s: %s\n", full_name, dlerror());
-    return -1;
-  }
-  return 0;
-}
-
-template <typename FuncPtr>
-void dlsym_load_optional(FuncPtr& out, void* handle, const char* prefix,
-                         const char* name) {
-  char full_name[256];
-  snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
-}
+using xio_rdma::dlsym_load_prefixed;
+using xio_rdma::dlsym_load_prefixed_optional;
 
 } // anonymous namespace
 
@@ -132,10 +115,10 @@ int IBVWrapper::is_dmabuf_supported() {
 
 int IBVWrapper::init_function_table() {
 #define LOAD_SYM(field, prefix, name)                                          \
-  if (dlsym_load(funcs_.field, ibv_handle_, prefix, name) != 0)                \
+  if (dlsym_load_prefixed(funcs_.field, ibv_handle_, prefix, name) != 0)       \
     return -1;
 #define LOAD_SYM_OPT(field, prefix, name)                                      \
-  dlsym_load_optional(funcs_.field, ibv_handle_, prefix, name);
+  dlsym_load_prefixed_optional(funcs_.field, ibv_handle_, prefix, name);
 
   LOAD_SYM(get_device_list, "ibv_", "get_device_list");
   LOAD_SYM(free_device_list, "ibv_", "free_device_list");

--- a/src/common/rdma-numa-wrapper.cpp
+++ b/src/common/rdma-numa-wrapper.cpp
@@ -12,24 +12,15 @@
 
 #include <dlfcn.h>
 
+#include "xio-rdma-check.h"
+
 namespace rdma_ep {
 
 NUMAWrapper numa;
 
 namespace {
 
-template <typename FuncPtr>
-int dlsym_load(FuncPtr& out, void* handle, const char* prefix,
-               const char* name) {
-  char full_name[256];
-  snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
-  if (!out) {
-    fprintf(stderr, "rdma_ep: dlsym failed for %s: %s\n", full_name, dlerror());
-    return -1;
-  }
-  return 0;
-}
+using xio_rdma::dlsym_load_prefixed;
 
 } // anonymous namespace
 
@@ -63,7 +54,7 @@ NUMAWrapper::~NUMAWrapper() {
 
 int NUMAWrapper::init_function_table() {
 #define LOAD_SYM(field, prefix, name)                                          \
-  if (dlsym_load(funcs_.field, numa_handle_, prefix, name) != 0)               \
+  if (dlsym_load_prefixed(funcs_.field, numa_handle_, prefix, name) != 0)      \
     return -1;
 
   LOAD_SYM(bitmask_isbitset, "numa_", "bitmask_isbitset");

--- a/src/common/xio-rdma-check.h
+++ b/src/common/xio-rdma-check.h
@@ -65,21 +65,19 @@ int dlsym_load(FuncPtr& out, void* handle, const char* name,
 }
 
 template <typename FuncPtr>
-int dlsym_load_optional(FuncPtr& out, void* handle,
-                        const char* name) {
+int dlsym_load_optional(FuncPtr& out, void* handle, const char* name) {
   out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
   return out ? 0 : -1;
 }
 
 template <typename FuncPtr>
-int dlsym_load_prefixed(FuncPtr& out, void* handle,
-                        const char* prefix, const char* name) {
+int dlsym_load_prefixed(FuncPtr& out, void* handle, const char* prefix,
+                        const char* name) {
   char full_name[256];
   snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
   out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
   if (!out) {
-    fprintf(stderr, "rdma_ep: dlsym failed for %s: %s\n",
-            full_name, dlerror());
+    fprintf(stderr, "rdma_ep: dlsym failed for %s: %s\n", full_name, dlerror());
     return -1;
   }
   return 0;
@@ -87,15 +85,13 @@ int dlsym_load_prefixed(FuncPtr& out, void* handle,
 
 template <typename FuncPtr>
 void dlsym_load_prefixed_optional(FuncPtr& out, void* handle,
-                                  const char* prefix,
-                                  const char* name) {
+                                  const char* prefix, const char* name) {
   char full_name[256];
   snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
   out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
 }
 
-inline void* dv_dlopen(const char* lib_name,
-                       const char* vendor_tag,
+inline void* dv_dlopen(const char* lib_name, const char* vendor_tag,
                        const char* const* extra_paths = nullptr,
                        int n_extra = 0) {
   constexpr int flags = RTLD_LAZY | RTLD_DEEPBIND;
@@ -104,8 +100,7 @@ inline void* dv_dlopen(const char* lib_name,
 #ifdef RDMA_CORE_LIB_DIR
   {
     char path[512];
-    snprintf(path, sizeof(path), "%s/%s", RDMA_CORE_LIB_DIR,
-             lib_name);
+    snprintf(path, sizeof(path), "%s/%s", RDMA_CORE_LIB_DIR, lib_name);
     handle = dlopen(path, flags);
   }
 #endif
@@ -115,8 +110,7 @@ inline void* dv_dlopen(const char* lib_name,
 
   for (int i = 0; !handle && i < n_extra; i++) {
     char path[512];
-    snprintf(path, sizeof(path), "%s/%s", extra_paths[i],
-             lib_name);
+    snprintf(path, sizeof(path), "%s/%s", extra_paths[i], lib_name);
     handle = dlopen(path, flags);
   }
 

--- a/src/common/xio-rdma-check.h
+++ b/src/common/xio-rdma-check.h
@@ -1,0 +1,139 @@
+/* Copyright (c) Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Shared error-checking macros and dlsym helpers for
+ * the rdma-ep vendor backends and common wrappers.
+ */
+
+#ifndef XIO_RDMA_CHECK_H
+#define XIO_RDMA_CHECK_H
+
+#include <cstdio>
+#include <cstdlib>
+
+#include <dlfcn.h>
+
+/*
+ * _XIO_CHECK_ZERO -- assert expr == 0, else print
+ *                    and execute 'on_fail'.
+ * _XIO_CHECK_NNULL -- assert expr != NULL, else print
+ *                     and execute 'on_fail'.
+ *
+ * Backends define 2-arg convenience wrappers:
+ *   #define XIO_CHECK_ZERO(expr, msg) \
+ *     _XIO_CHECK_ZERO("rdma_ep::bnxt", (expr), (msg), return)
+ */
+#define _XIO_CHECK_ZERO(prefix, expr, msg, on_fail)                            \
+  do {                                                                         \
+    int _err = (expr);                                                         \
+    if (_err != 0) {                                                           \
+      fprintf(stderr,                                                          \
+              "%s: %s failed: "                                                \
+              "%d at %s:%d\n",                                                 \
+              (prefix), (msg), _err, __FILE__, __LINE__);                      \
+      on_fail;                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define _XIO_CHECK_NNULL(prefix, expr, msg, on_fail)                           \
+  do {                                                                         \
+    if (!(expr)) {                                                             \
+      fprintf(stderr,                                                          \
+              "%s: %s returned "                                               \
+              "null at %s:%d\n",                                               \
+              (prefix), (msg), __FILE__, __LINE__);                            \
+      on_fail;                                                                 \
+    }                                                                          \
+  } while (0)
+
+namespace xio_rdma {
+
+template <typename FuncPtr>
+int dlsym_load(FuncPtr& out, void* handle, const char* name,
+               const char* vendor_tag) {
+  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
+  if (!out) {
+    fprintf(stderr,
+            "%s: dlsym failed for "
+            "%s: %s\n",
+            vendor_tag, name, dlerror());
+    return -1;
+  }
+  return 0;
+}
+
+template <typename FuncPtr>
+int dlsym_load_optional(FuncPtr& out, void* handle,
+                        const char* name) {
+  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
+  return out ? 0 : -1;
+}
+
+template <typename FuncPtr>
+int dlsym_load_prefixed(FuncPtr& out, void* handle,
+                        const char* prefix, const char* name) {
+  char full_name[256];
+  snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
+  out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
+  if (!out) {
+    fprintf(stderr, "rdma_ep: dlsym failed for %s: %s\n",
+            full_name, dlerror());
+    return -1;
+  }
+  return 0;
+}
+
+template <typename FuncPtr>
+void dlsym_load_prefixed_optional(FuncPtr& out, void* handle,
+                                  const char* prefix,
+                                  const char* name) {
+  char full_name[256];
+  snprintf(full_name, sizeof(full_name), "%s%s", prefix, name);
+  out = reinterpret_cast<FuncPtr>(dlsym(handle, full_name));
+}
+
+inline void* dv_dlopen(const char* lib_name,
+                       const char* vendor_tag,
+                       const char* const* extra_paths = nullptr,
+                       int n_extra = 0) {
+  constexpr int flags = RTLD_LAZY | RTLD_DEEPBIND;
+  void* handle = nullptr;
+
+#ifdef RDMA_CORE_LIB_DIR
+  {
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s", RDMA_CORE_LIB_DIR,
+             lib_name);
+    handle = dlopen(path, flags);
+  }
+#endif
+
+  if (!handle)
+    handle = dlopen(lib_name, flags);
+
+  for (int i = 0; !handle && i < n_extra; i++) {
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s", extra_paths[i],
+             lib_name);
+    handle = dlopen(path, flags);
+  }
+
+  if (!handle) {
+    char path[512];
+    snprintf(path, sizeof(path), "/usr/local/lib/%s", lib_name);
+    handle = dlopen(path, flags);
+  }
+
+  if (!handle)
+    fprintf(stderr,
+            "%s: Could not open "
+            "%s: %s\n",
+            vendor_tag, lib_name, dlerror());
+  return handle;
+}
+
+} // namespace xio_rdma
+
+#endif /* XIO_RDMA_CHECK_H */

--- a/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
+++ b/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
@@ -62,8 +62,8 @@ int Backend::bnxt_dv_dl_init() {
     return -1;
 
 #define LOAD(field, name)                                                      \
-  if (dlsym_load(bnxt_re_dv.field, bnxtdv_handle_, name,                       \
-                 "rdma_ep::bnxt") != 0)                                        \
+  if (dlsym_load(bnxt_re_dv.field, bnxtdv_handle_, name, "rdma_ep::bnxt") !=   \
+      0)                                                                       \
     return -1;
 
   LOAD(create_qp, "bnxt_re_dv_create_qp");

--- a/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
+++ b/src/endpoints/rdma-ep/bnxt/bnxt-backend.cpp
@@ -31,47 +31,19 @@
 #include "gda-backend.hpp"
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
+#include "xio-rdma-check.h"
 #include "xio.h"
 
 namespace rdma_ep {
 
 #define XIO_CHECK_ZERO(expr, msg)                                              \
-  do {                                                                         \
-    int _err = (expr);                                                         \
-    if (_err != 0) {                                                           \
-      fprintf(stderr,                                                          \
-              "rdma_ep::bnxt: %s failed: "                                     \
-              "%d at %s:%d\n",                                                 \
-              (msg), _err, __FILE__, __LINE__);                                \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
-
+  _XIO_CHECK_ZERO("rdma_ep::bnxt", (expr), (msg), return)
 #define XIO_CHECK_NNULL(expr, msg)                                             \
-  do {                                                                         \
-    if (!(expr)) {                                                             \
-      fprintf(stderr,                                                          \
-              "rdma_ep::bnxt: %s returned "                                    \
-              "null at %s:%d\n",                                               \
-              (msg), __FILE__, __LINE__);                                      \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
+  _XIO_CHECK_NNULL("rdma_ep::bnxt", (expr), (msg), return)
 
 namespace {
 
-template <typename FuncPtr>
-int dlsym_load(FuncPtr& out, void* handle, const char* name) {
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
-  if (!out) {
-    fprintf(stderr,
-            "rdma_ep::bnxt: dlsym failed for "
-            "%s: %s\n",
-            name, dlerror());
-    return -1;
-  }
-  return 0;
-}
+using xio_rdma::dlsym_load;
 
 bnxtdv_funcs_t bnxt_re_dv{};
 void* bnxtdv_handle_ = nullptr;
@@ -81,21 +53,7 @@ void* bnxtdv_handle_ = nullptr;
 #if defined(GDA_BNXT)
 
 void* Backend::bnxt_dv_dlopen() {
-  constexpr int flags = RTLD_LAZY | RTLD_DEEPBIND;
-  void* handle = nullptr;
-#ifdef RDMA_CORE_LIB_DIR
-  handle = dlopen(RDMA_CORE_LIB_DIR "/libbnxt_re.so", flags);
-#endif
-  if (!handle)
-    handle = dlopen("libbnxt_re.so", flags);
-  if (!handle)
-    handle = dlopen("/usr/local/lib/libbnxt_re.so", flags);
-  if (!handle)
-    fprintf(stderr,
-            "rdma_ep::bnxt: Could not open "
-            "libbnxt_re.so: %s\n",
-            dlerror());
-  return handle;
+  return xio_rdma::dv_dlopen("libbnxt_re.so", "rdma_ep::bnxt");
 }
 
 int Backend::bnxt_dv_dl_init() {
@@ -104,7 +62,8 @@ int Backend::bnxt_dv_dl_init() {
     return -1;
 
 #define LOAD(field, name)                                                      \
-  if (dlsym_load(bnxt_re_dv.field, bnxtdv_handle_, name) != 0)                 \
+  if (dlsym_load(bnxt_re_dv.field, bnxtdv_handle_, name,                       \
+                 "rdma_ep::bnxt") != 0)                                        \
     return -1;
 
   LOAD(create_qp, "bnxt_re_dv_create_qp");

--- a/src/endpoints/rdma-ep/gda-backend.cpp
+++ b/src/endpoints/rdma-ep/gda-backend.cpp
@@ -23,6 +23,7 @@
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
 #include "rdma-topology.hpp"
+#include "xio-rdma-check.h"
 #include "xio.h"
 
 #if defined(GDA_BNXT)
@@ -44,23 +45,9 @@ int ernic_dv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr,
 namespace rdma_ep {
 
 #define XIO_CHECK_ZERO(expr, msg)                                              \
-  do {                                                                         \
-    int _err = (expr);                                                         \
-    if (_err != 0) {                                                           \
-      fprintf(stderr, "rdma_ep: %s failed: %d at %s:%d\n", (msg), _err,        \
-              __FILE__, __LINE__);                                             \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
+  _XIO_CHECK_ZERO("rdma_ep", (expr), (msg), abort())
 #define XIO_CHECK_NNULL(expr, msg)                                             \
-  do {                                                                         \
-    if (!(expr)) {                                                             \
-      fprintf(stderr, "rdma_ep: %s returned null at %s:%d\n", (msg), __FILE__, \
-              __LINE__);                                                       \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+  _XIO_CHECK_NNULL("rdma_ep", (expr), (msg), abort())
 
 Backend::Backend(const BackendConfig& config) : config_(config) {
 }

--- a/src/endpoints/rdma-ep/ionic/ionic-backend.cpp
+++ b/src/endpoints/rdma-ep/ionic/ionic-backend.cpp
@@ -27,46 +27,18 @@
 #include "ibv-wrapper.hpp"
 #include "ionic/ionic-provider.hpp"
 #include "queue-pair.hpp"
+#include "xio-rdma-check.h"
 
 namespace rdma_ep {
 
 #define XIO_CHECK_ZERO(expr, msg)                                              \
-  do {                                                                         \
-    int _err = (expr);                                                         \
-    if (_err != 0) {                                                           \
-      fprintf(stderr,                                                          \
-              "rdma_ep::ionic: %s failed: "                                    \
-              "%d at %s:%d\n",                                                 \
-              (msg), _err, __FILE__, __LINE__);                                \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
-
+  _XIO_CHECK_ZERO("rdma_ep::ionic", (expr), (msg), return)
 #define XIO_CHECK_NNULL(expr, msg)                                             \
-  do {                                                                         \
-    if (!(expr)) {                                                             \
-      fprintf(stderr,                                                          \
-              "rdma_ep::ionic: %s returned "                                   \
-              "null at %s:%d\n",                                               \
-              (msg), __FILE__, __LINE__);                                      \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
+  _XIO_CHECK_NNULL("rdma_ep::ionic", (expr), (msg), return)
 
 namespace {
 
-template <typename FuncPtr>
-int dlsym_load(FuncPtr& out, void* handle, const char* name) {
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
-  if (!out) {
-    fprintf(stderr,
-            "rdma_ep::ionic: dlsym failed for "
-            "%s: %s\n",
-            name, dlerror());
-    return -1;
-  }
-  return 0;
-}
+using xio_rdma::dlsym_load;
 
 ionicdv_funcs_t ionic_dv{};
 void* ionicdv_lib_handle_ = nullptr;
@@ -79,21 +51,7 @@ qp_set_gda_fn ionic_qp_set_gda_ = nullptr;
 #if defined(GDA_IONIC)
 
 void* Backend::ionic_dv_dlopen() {
-  constexpr int flags = RTLD_LAZY | RTLD_DEEPBIND;
-  void* handle = nullptr;
-#ifdef RDMA_CORE_LIB_DIR
-  handle = dlopen(RDMA_CORE_LIB_DIR "/libionic.so", flags);
-#endif
-  if (!handle)
-    handle = dlopen("libionic.so", flags);
-  if (!handle)
-    handle = dlopen("/usr/local/lib/libionic.so", flags);
-  if (!handle)
-    fprintf(stderr,
-            "rdma_ep::ionic: Could not open "
-            "libionic.so: %s\n",
-            dlerror());
-  return handle;
+  return xio_rdma::dv_dlopen("libionic.so", "rdma_ep::ionic");
 }
 
 int Backend::ionic_dv_dl_init() {
@@ -102,7 +60,8 @@ int Backend::ionic_dv_dl_init() {
     return -1;
 
 #define LOAD(field, name)                                                      \
-  if (dlsym_load(ionic_dv.field, ionicdv_lib_handle_, name) != 0)              \
+  if (dlsym_load(ionic_dv.field, ionicdv_lib_handle_, name,                    \
+                 "rdma_ep::ionic") != 0)                                       \
     return -1;
 
   LOAD(get_ctx, "ionic_dv_get_ctx");
@@ -117,7 +76,8 @@ int Backend::ionic_dv_dl_init() {
 #undef LOAD
 
   if (dlsym_load(ionic_qp_set_gda_, ionicdv_lib_handle_,
-                 "ionic_dv_qp_set_gda") != 0)
+                 "ionic_dv_qp_set_gda",
+                 "rdma_ep::ionic") != 0)
     return -1;
 
   ionicdv_handle_ = ionicdv_lib_handle_;

--- a/src/endpoints/rdma-ep/ionic/ionic-backend.cpp
+++ b/src/endpoints/rdma-ep/ionic/ionic-backend.cpp
@@ -75,8 +75,7 @@ int Backend::ionic_dv_dl_init() {
 
 #undef LOAD
 
-  if (dlsym_load(ionic_qp_set_gda_, ionicdv_lib_handle_,
-                 "ionic_dv_qp_set_gda",
+  if (dlsym_load(ionic_qp_set_gda_, ionicdv_lib_handle_, "ionic_dv_qp_set_gda",
                  "rdma_ep::ionic") != 0)
     return -1;
 

--- a/src/endpoints/rdma-ep/mlx5/mlx5-backend.cpp
+++ b/src/endpoints/rdma-ep/mlx5/mlx5-backend.cpp
@@ -60,8 +60,7 @@ void* Backend::mlx5_dv_dlopen() {
     "/usr/lib/aarch64-linux-gnu",
     "/usr/lib64",
   };
-  return xio_rdma::dv_dlopen("libmlx5.so", "rdma_ep::mlx5",
-                             extra, 3);
+  return xio_rdma::dv_dlopen("libmlx5.so", "rdma_ep::mlx5", extra, 3);
 }
 
 int Backend::mlx5_dv_dl_init() {

--- a/src/endpoints/rdma-ep/mlx5/mlx5-backend.cpp
+++ b/src/endpoints/rdma-ep/mlx5/mlx5-backend.cpp
@@ -31,30 +31,15 @@
 #include "ibv-wrapper.hpp"
 #include "mlx5/mlx5-provider.hpp"
 #include "queue-pair.hpp"
+#include "xio-rdma-check.h"
 #include "xio.h"
 
 namespace rdma_ep {
 
 namespace {
 
-template <typename FuncPtr>
-int dlsym_load(FuncPtr& out, void* handle, const char* name) {
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
-  if (!out) {
-    fprintf(stderr,
-            "rdma_ep::mlx5: dlsym failed for "
-            "%s: %s\n",
-            name, dlerror());
-    return -1;
-  }
-  return 0;
-}
-
-template <typename FuncPtr>
-int dlsym_load_optional(FuncPtr& out, void* handle, const char* name) {
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
-  return out ? 0 : -1;
-}
+using xio_rdma::dlsym_load;
+using xio_rdma::dlsym_load_optional;
 
 void* page_align(void* ptr) {
   long page_size = sysconf(_SC_PAGESIZE);
@@ -70,25 +55,13 @@ mlx5dv_funcs_t mlx5_dv{};
 #if defined(GDA_MLX5)
 
 void* Backend::mlx5_dv_dlopen() {
-  constexpr int flags = RTLD_LAZY | RTLD_DEEPBIND;
-  void* handle = nullptr;
-#ifdef RDMA_CORE_LIB_DIR
-  handle = dlopen(RDMA_CORE_LIB_DIR "/libmlx5.so", flags);
-#endif
-  if (!handle)
-    handle = dlopen("libmlx5.so", flags);
-  if (!handle)
-    handle = dlopen("/usr/lib/x86_64-linux-gnu/libmlx5.so", flags);
-  if (!handle)
-    handle = dlopen("/usr/lib/aarch64-linux-gnu/libmlx5.so", flags);
-  if (!handle)
-    handle = dlopen("/usr/lib64/libmlx5.so", flags);
-  if (!handle)
-    fprintf(stderr,
-            "rdma_ep::mlx5: Could not open "
-            "libmlx5.so: %s\n",
-            dlerror());
-  return handle;
+  static const char* const extra[] = {
+    "/usr/lib/x86_64-linux-gnu",
+    "/usr/lib/aarch64-linux-gnu",
+    "/usr/lib64",
+  };
+  return xio_rdma::dv_dlopen("libmlx5.so", "rdma_ep::mlx5",
+                             extra, 3);
 }
 
 int Backend::mlx5_dv_dl_init() {
@@ -96,7 +69,8 @@ int Backend::mlx5_dv_dl_init() {
   if (!mlx5dv_handle_)
     return -1;
 
-  if (dlsym_load(mlx5_dv.init_obj, mlx5dv_handle_, "mlx5dv_init_obj") != 0)
+  if (dlsym_load(mlx5_dv.init_obj, mlx5dv_handle_, "mlx5dv_init_obj",
+                 "rdma_ep::mlx5") != 0)
     return -1;
 
   dlsym_load_optional(mlx5_dv.is_supported, mlx5dv_handle_,

--- a/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
+++ b/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
@@ -25,47 +25,19 @@
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
 #include "rocm-ernic/ernic-provider.hpp"
+#include "xio-rdma-check.h"
 #include "xio.h"
 
 namespace rdma_ep {
 
 #define XIO_CHECK_ZERO(expr, msg)                                              \
-  do {                                                                         \
-    int _err = (expr);                                                         \
-    if (_err != 0) {                                                           \
-      fprintf(stderr,                                                          \
-              "rdma_ep::ernic: %s failed: "                                    \
-              "%d at %s:%d\n",                                                 \
-              (msg), _err, __FILE__, __LINE__);                                \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
-
+  _XIO_CHECK_ZERO("rdma_ep::ernic", (expr), (msg), return)
 #define XIO_CHECK_NNULL(expr, msg)                                             \
-  do {                                                                         \
-    if (!(expr)) {                                                             \
-      fprintf(stderr,                                                          \
-              "rdma_ep::ernic: %s returned "                                   \
-              "null at %s:%d\n",                                               \
-              (msg), __FILE__, __LINE__);                                      \
-      return;                                                                  \
-    }                                                                          \
-  } while (0)
+  _XIO_CHECK_NNULL("rdma_ep::ernic", (expr), (msg), return)
 
 namespace {
 
-template <typename FuncPtr>
-int dlsym_load(FuncPtr& out, void* handle, const char* name) {
-  out = reinterpret_cast<FuncPtr>(dlsym(handle, name));
-  if (!out) {
-    fprintf(stderr,
-            "rdma_ep::ernic: dlsym failed for "
-            "%s: %s\n",
-            name, dlerror());
-    return -1;
-  }
-  return 0;
-}
+using xio_rdma::dlsym_load;
 
 ernicdv_funcs_t ernic_dv{};
 void* ernicdv_handle_ = nullptr;
@@ -75,21 +47,8 @@ void* ernicdv_handle_ = nullptr;
 #if defined(GDA_ERNIC)
 
 void* Backend::ernic_dv_dlopen() {
-  constexpr int flags = RTLD_LAZY | RTLD_DEEPBIND;
-  void* handle = nullptr;
-#ifdef RDMA_CORE_LIB_DIR
-  handle = dlopen(RDMA_CORE_LIB_DIR "/librocm_ernic.so", flags);
-#endif
-  if (!handle)
-    handle = dlopen("librocm_ernic.so", flags);
-  if (!handle)
-    handle = dlopen("/usr/local/lib/librocm_ernic.so", flags);
-  if (!handle)
-    fprintf(stderr,
-            "rdma_ep::ernic: Could not open "
-            "librocm_ernic.so: %s\n",
-            dlerror());
-  return handle;
+  return xio_rdma::dv_dlopen("librocm_ernic.so",
+                             "rdma_ep::ernic");
 }
 
 int Backend::ernic_dv_dl_init() {
@@ -98,7 +57,8 @@ int Backend::ernic_dv_dl_init() {
     return -1;
 
 #define LOAD(field, name)                                                      \
-  if (dlsym_load(ernic_dv.field, ernicdv_handle_, name) != 0)                  \
+  if (dlsym_load(ernic_dv.field, ernicdv_handle_, name,                        \
+                 "rdma_ep::ernic") != 0)                                       \
     return -1;
 
   LOAD(create_qp, "rocm_ernic_dv_create_qp");

--- a/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
+++ b/src/endpoints/rdma-ep/rocm-ernic/ernic-backend.cpp
@@ -47,8 +47,7 @@ void* ernicdv_handle_ = nullptr;
 #if defined(GDA_ERNIC)
 
 void* Backend::ernic_dv_dlopen() {
-  return xio_rdma::dv_dlopen("librocm_ernic.so",
-                             "rdma_ep::ernic");
+  return xio_rdma::dv_dlopen("librocm_ernic.so", "rdma_ep::ernic");
 }
 
 int Backend::ernic_dv_dl_init() {
@@ -57,8 +56,8 @@ int Backend::ernic_dv_dl_init() {
     return -1;
 
 #define LOAD(field, name)                                                      \
-  if (dlsym_load(ernic_dv.field, ernicdv_handle_, name,                        \
-                 "rdma_ep::ernic") != 0)                                       \
+  if (dlsym_load(ernic_dv.field, ernicdv_handle_, name, "rdma_ep::ernic") !=   \
+      0)                                                                       \
     return -1;
 
   LOAD(create_qp, "rocm_ernic_dv_create_qp");

--- a/tests/system/test-ep/test-ep-emulate.hip
+++ b/tests/system/test-ep/test-ep-emulate.hip
@@ -21,21 +21,7 @@
 
 #include "test-ep.h"
 #include "xio.h"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+#include "xio-test-assert.h"
 
 int test_emulate_roundtrip() {
   const unsigned kIter = 10;

--- a/tests/system/test-ep/test-ep-emulate.hip
+++ b/tests/system/test-ep/test-ep-emulate.hip
@@ -20,8 +20,8 @@
 #include <hip/hip_runtime.h>
 
 #include "test-ep.h"
-#include "xio.h"
 #include "xio-test-assert.h"
+#include "xio.h"
 
 int test_emulate_roundtrip() {
   const unsigned kIter = 10;

--- a/tests/unit/common/test-data-pattern.hip
+++ b/tests/unit/common/test-data-pattern.hip
@@ -17,21 +17,7 @@
 #include <hip/hip_runtime.h>
 
 #include "xio-data-pattern.hpp"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+#include "xio-test-assert.h"
 
 int test_generate_nonzero() {
   const size_t sz = 64;

--- a/tests/unit/common/test-extract-endpoint.hip
+++ b/tests/unit/common/test-extract-endpoint.hip
@@ -13,21 +13,7 @@
 #include <string>
 
 #include "xio.h"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+#include "xio-test-assert.h"
 
 int test_short_flag() {
   const char* argv[] = {"prog", "-e", "nvme"};

--- a/tests/unit/common/test-extract-endpoint.hip
+++ b/tests/unit/common/test-extract-endpoint.hip
@@ -12,8 +12,8 @@
 #include <cstdlib>
 #include <string>
 
-#include "xio.h"
 #include "xio-test-assert.h"
+#include "xio.h"
 
 int test_short_flag() {
   const char* argv[] = {"prog", "-e", "nvme"};

--- a/tests/unit/common/test-rdma-topology.hip
+++ b/tests/unit/common/test-rdma-topology.hip
@@ -13,23 +13,9 @@
 #include <cstdlib>
 
 #include "rdma-topology.hpp"
+#include "xio-test-assert.h"
 
 using namespace rdma_ep;
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_GE(a, b)                                                        \
-  do {                                                                         \
-    if (!((a) >= (b))) {                                                       \
-      printf("ASSERT_GE failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
 
 int test_extract_bus_number() {
   ASSERT_EQ(ExtractBusNumber("0000:01:00.0"), 1);

--- a/tests/unit/common/xio-test-assert.h
+++ b/tests/unit/common/xio-test-assert.h
@@ -1,0 +1,88 @@
+/* Copyright (c) Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Shared test assertion macros for rocm-xio unit and
+ * system tests.  Include this header instead of
+ * defining per-file ASSERT_* macros.
+ */
+
+#ifndef XIO_TEST_ASSERT_H
+#define XIO_TEST_ASSERT_H
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#define ASSERT_EQ(a, b)                                                        \
+  do {                                                                         \
+    if ((a) != (b)) {                                                          \
+      printf("ASSERT_EQ failed: %s:%d: "                                       \
+             "%s != %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_NE(a, b)                                                        \
+  do {                                                                         \
+    if ((a) == (b)) {                                                          \
+      printf("ASSERT_NE failed: %s:%d: "                                       \
+             "%s == %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_TRUE(x)                                                         \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      printf("ASSERT_TRUE failed: %s:%d: "                                     \
+             "%s\n",                                                           \
+             __FILE__, __LINE__, #x);                                          \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_STREQ(a, b)                                                     \
+  do {                                                                         \
+    if (strcmp((a), (b)) != 0) {                                               \
+      printf("ASSERT_STREQ failed: %s:%d: "                                    \
+             "%s != %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_GE(a, b)                                                        \
+  do {                                                                         \
+    if (!((a) >= (b))) {                                                       \
+      printf("ASSERT_GE failed: %s:%d: "                                       \
+             "%s < %s\n",                                                      \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_LE(a, b)                                                        \
+  do {                                                                         \
+    if (!((a) <= (b))) {                                                       \
+      printf("ASSERT_LE failed: %s:%d: "                                       \
+             "%s > %s\n",                                                      \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_GT(a, b)                                                        \
+  do {                                                                         \
+    if (!((a) > (b))) {                                                        \
+      printf("ASSERT_GT failed: %s:%d: "                                       \
+             "%s <= %s\n",                                                     \
+             __FILE__, __LINE__, #a, #b);                                      \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+
+#endif /* XIO_TEST_ASSERT_H */

--- a/tests/unit/nvme-ep/test-nvme-config.hip
+++ b/tests/unit/nvme-ep/test-nvme-config.hip
@@ -16,26 +16,9 @@
 #include <hip/hip_runtime.h>
 
 #include "nvme-ep.h"
+#include "xio-test-assert.h"
 
 using namespace xio::nvme_ep;
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d: "                                       \
-             "%s != %s\n",                                                     \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d: %s\n", __FILE__, __LINE__, #x);       \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
 
 int test_struct_sizes() {
   ASSERT_EQ(sizeof(struct nvme_sqe), 64u);

--- a/tests/unit/nvme-ep/test-nvme-hardware.hip
+++ b/tests/unit/nvme-ep/test-nvme-hardware.hip
@@ -27,56 +27,9 @@
 #include <unistd.h>
 
 #include "nvme-ep.h"
+#include "xio-test-assert.h"
 
 using namespace xio::nvme_ep;
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d: "                                       \
-             "%s != %s\n",                                                     \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d: %s\n", __FILE__, __LINE__, #x);       \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_GE(a, b)                                                        \
-  do {                                                                         \
-    if (!((a) >= (b))) {                                                       \
-      printf("ASSERT_GE failed: %s:%d: "                                       \
-             "%s < %s\n",                                                      \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_LE(a, b)                                                        \
-  do {                                                                         \
-    if (!((a) <= (b))) {                                                       \
-      printf("ASSERT_LE failed: %s:%d: "                                       \
-             "%s > %s\n",                                                      \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_GT(a, b)                                                        \
-  do {                                                                         \
-    if (!((a) > (b))) {                                                        \
-      printf("ASSERT_GT failed: %s:%d: "                                       \
-             "%s <= %s\n",                                                     \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
 
 static std::string g_controller;
 

--- a/tests/unit/nvme-ep/test-nvme-helpers.hip
+++ b/tests/unit/nvme-ep/test-nvme-helpers.hip
@@ -19,36 +19,9 @@
 #include <hip/hip_runtime.h>
 
 #include "nvme-ep.h"
+#include "xio-test-assert.h"
 
 using namespace xio::nvme_ep;
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d: "                                       \
-             "%s != %s\n",                                                     \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d: %s\n", __FILE__, __LINE__, #x);       \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-
-#define ASSERT_NE(a, b)                                                        \
-  do {                                                                         \
-    if ((a) == (b)) {                                                          \
-      printf("ASSERT_NE failed: %s:%d: "                                       \
-             "%s == %s\n",                                                     \
-             __FILE__, __LINE__, #a, #b);                                      \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
 
 /* ---- sqeSetup tests ---- */
 

--- a/tests/unit/rdma-ep/test-bnxt-sizing.hip
+++ b/tests/unit/rdma-ep/test-bnxt-sizing.hip
@@ -15,30 +15,9 @@
 #include <unistd.h>
 
 #include "bnxt/bnxt-dv-sizing.hpp"
+#include "xio-test-assert.h"
 
 using namespace rdma_ep::bnxt_sizing;
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_GT(a, b)                                                        \
-  do {                                                                         \
-    if (!((a) > (b))) {                                                        \
-      printf("ASSERT_GT failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
 
 int test_roundup_pow2() {
   ASSERT_EQ(roundup_pow2(0), 1u);

--- a/tests/unit/rdma-ep/test-rdma-config.hip
+++ b/tests/unit/rdma-ep/test-rdma-config.hip
@@ -15,28 +15,7 @@
 
 #include "rdma-ep.h"
 #include "vendor-ops.hpp"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_STREQ(a, b)                                                     \
-  do {                                                                         \
-    if (strcmp((a), (b)) != 0) {                                               \
-      printf("ASSERT_STREQ failed: %s:%d\n", __FILE__, __LINE__);              \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+#include "xio-test-assert.h"
 
 int test_provider_enum() {
   ASSERT_EQ(static_cast<uint8_t>(rdma_ep::Provider::BNXT), 0);

--- a/tests/unit/rdma-ep/test-rdma-endian.hip
+++ b/tests/unit/rdma-ep/test-rdma-endian.hip
@@ -14,15 +14,8 @@
 #include <hip/hip_runtime.h>
 
 #include "endian.hpp"
+#include "xio-test-assert.h"
 #include "xio.h"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
 
 int test_byteswap_16() {
   uint16_t val = 0x1234;

--- a/tests/unit/rdma-ep/test-rdma-vendors.hip
+++ b/tests/unit/rdma-ep/test-rdma-vendors.hip
@@ -13,21 +13,7 @@
 #include <hip/hip_runtime.h>
 
 #include "vendor-ops.hpp"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+#include "xio-test-assert.h"
 
 int test_vendor_ids() {
   ASSERT_EQ(rdma_ep::VENDOR_ID_BROADCOM, 0x14E4u);

--- a/tests/unit/test-ep/test-ep-config.hip
+++ b/tests/unit/test-ep/test-ep-config.hip
@@ -15,21 +15,7 @@
 #include <hip/hip_runtime.h>
 
 #include "test-ep.h"
-
-#define ASSERT_EQ(a, b)                                                        \
-  do {                                                                         \
-    if ((a) != (b)) {                                                          \
-      printf("ASSERT_EQ failed: %s:%d\n", __FILE__, __LINE__);                 \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
-#define ASSERT_TRUE(x)                                                         \
-  do {                                                                         \
-    if (!(x)) {                                                                \
-      printf("ASSERT_TRUE failed: %s:%d\n", __FILE__, __LINE__);               \
-      abort();                                                                 \
-    }                                                                          \
-  } while (0)
+#include "xio-test-assert.h"
 
 int test_magic_constants() {
   ASSERT_EQ(xio::test_ep::magicId, 0xDEADBEEFCAFEBABEULL);


### PR DESCRIPTION
Extract repeated boilerplate into shared utilities to reduce maintenance burden and improve consistency.

Changes by area:

- tests: create xio-test-assert.h with unified ASSERT_EQ/TRUE/ NE/STREQ/GE/LE/GT macros; replace inline definitions in 12 .hip test files.  Add tests/unit/common/ to the default include path in xio_add_test().

- rdma-ep: create xio-rdma-check.h with parametric _XIO_CHECK_ZERO/_XIO_CHECK_NNULL macros, shared xio_rdma::dlsym_load templates, and xio_rdma::dv_dlopen helper.  Replace per-file copies in all 4 vendor backends plus ibv-wrapper.cpp and rdma-numa-wrapper.cpp.

- kernel: create kernel/dkms-common.sh with shared DKMS lifecycle functions (uninstall guard, skip-if-installed, kernel-headers check, detect_kernel_tag, build/install). Refactor bnxt, ionic, and ernic setup scripts to source it.

- alola: add nvme_ep_test(), rdma_alola_build(), and detect_rdma_nic() helpers to rocm-xio-tests.common. Refactor nvme-ep.sbatch test_run blocks and rdma-ep sbatch build/detect sections to use them.

- cmake: use CMakePresets.json testPresets inherits to eliminate repeated output configuration blocks.

Net: -1117 lines removed, +684 lines added (31 files).
