### PR TITLE
tests: migrate all tests to xio memory abstraction

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -12,6 +12,8 @@ HSACO
 hsaco
 
 # ===== NVMe and Storage =====
+MTR
+rootfs
 CQE
 cqe
 cqeGenFromSqe

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -29,7 +29,7 @@ Test Environment
    * - **ROCm**
      - 7.2.0
    * - **Commit**
-     - ``3411d80``
+     - ``a1ad2a9``
 
 Test Methodology
 ----------------
@@ -41,6 +41,13 @@ GPU kernel posts a single WQE, rings the doorbell from
 device code, then spin-polls the CQ for completion. The
 GPU wall clock measures the elapsed time from WQE post
 to CQE arrival.
+
+All test programs allocate memory through the
+``xio::allocHostMemory`` / ``xio::allocDeviceMemory``
+abstraction rather than calling ``posix_memalign``,
+``hipHostMalloc``, or ``hipMalloc`` directly. This
+ensures the same allocation flags and pinning semantics
+used by the production endpoint code paths.
 
 Ten iterations are run per (vendor, transfer size) pair,
 each with a distinct LFSR seed for data verification.
@@ -376,6 +383,51 @@ Current status:
    to time out.  This matches the nvme-ep queue
    allocation path which also uses coherent memory.
 
+NVMe-EP Smoke Test
+------------------
+
+The ``xio-tester nvme-ep`` smoke test validates the
+GPU-initiated NVMe read path end to end: admin queue
+setup, I/O queue creation, SQE construction from GPU
+device code, doorbell ring, CQE polling, and LFSR data
+verification.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - **NVMe Device**
+     - ``/dev/nvme2`` (MTR_SLC_16GB, FW 2.0.1.06)
+   * - **LBA Size**
+     - 512 bytes
+   * - **Namespace Capacity**
+     - 28,191,632 LBAs (~13.4 GiB)
+   * - **Max Queue ID**
+     - 32
+   * - **PCI BDF**
+     - ``0000:85:00.0``
+
+Results (4 sequential 512-byte reads, batch size 1):
+
+.. list-table::
+   :widths: 20 20 20 20
+   :header-rows: 1
+
+   * - Min (us)
+     - Mean (us)
+     - Std (us)
+     - Max (us)
+   * - 29.6
+     - 30.0
+     - 0.5
+     - 30.6
+
+The unit tests (``test-nvme-config``,
+``test-nvme-helpers``, ``test-nvme-hardware``) validate
+struct layout, helper functions, and hardware queries
+(LBA size, namespace capacity, SMART log, queue ID
+enumeration) without issuing I/O.
+
 Reproducing These Results
 -------------------------
 
@@ -436,3 +488,21 @@ multiple seeds and computes statistics automatically:
 
    VENDOR=bnxt TEST_SIZE=4096 ITERATIONS=10 \
      ./run-test-rdma-loopback.sh
+
+NVMe-EP smoke test (requires root and an NVMe device
+that is **not** the rootfs):
+
+.. code-block:: bash
+
+   # Unit tests (no hardware required for config/helpers)
+   build/tests/unit/nvme-ep/test-nvme-config
+   build/tests/unit/nvme-ep/test-nvme-helpers
+
+   # Hardware query test
+   sudo build/tests/unit/nvme-ep/test-nvme-hardware \
+     --controller /dev/nvme2
+
+   # Full data-path smoke test (4 reads)
+   sudo build/xio-tester nvme-ep \
+     --controller /dev/nvme2 \
+     --read-io 4 --batch-size 1

--- a/tests/system/coherence/test-doorbell-coherence.hip
+++ b/tests/system/coherence/test-doorbell-coherence.hip
@@ -142,13 +142,16 @@ static int run_test(const char* label, bool use_fenced) {
   CoherenceCpl* cq = nullptr;
   uint32_t* doorbell = nullptr;
 
-  HIP_CHECK(hipHostMalloc(&sq, sizeof(CoherenceCmd), hipHostMallocDefault));
-  HIP_CHECK(hipHostMalloc(&cq, sizeof(CoherenceCpl), hipHostMallocDefault));
-  HIP_CHECK(hipHostMalloc(&doorbell, sizeof(uint32_t), hipHostMallocDefault));
-
-  memset((void*)sq, 0, sizeof(CoherenceCmd));
-  memset((void*)cq, 0, sizeof(CoherenceCpl));
-  *doorbell = 0;
+  HIP_CHECK(xio::allocHostMemory(sizeof(CoherenceCmd),
+                                 (void**)&sq, "coherence SQ",
+                                 XIO_HOST_MEM_DEFAULT));
+  HIP_CHECK(xio::allocHostMemory(sizeof(CoherenceCpl),
+                                 (void**)&cq, "coherence CQ",
+                                 XIO_HOST_MEM_DEFAULT));
+  HIP_CHECK(xio::allocHostMemory(sizeof(uint32_t),
+                                 (void**)&doorbell,
+                                 "coherence doorbell",
+                                 XIO_HOST_MEM_DEFAULT));
 
   SharedState state;
   state.sq = sq;
@@ -204,9 +207,9 @@ static int run_test(const char* label, bool use_fenced) {
     printf("%s: PASSED (%u iterations)\n", label, kIterations);
   }
 
-  HIP_CHECK(hipHostFree(sq));
-  HIP_CHECK(hipHostFree(cq));
-  HIP_CHECK(hipHostFree(doorbell));
+  xio::freeHostMemory(sq, XIO_HOST_MEM_DEFAULT);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_DEFAULT);
+  xio::freeHostMemory(doorbell, XIO_HOST_MEM_DEFAULT);
 
   return result;
 }

--- a/tests/system/coherence/test-doorbell-coherence.hip
+++ b/tests/system/coherence/test-doorbell-coherence.hip
@@ -142,16 +142,12 @@ static int run_test(const char* label, bool use_fenced) {
   CoherenceCpl* cq = nullptr;
   uint32_t* doorbell = nullptr;
 
-  HIP_CHECK(xio::allocHostMemory(sizeof(CoherenceCmd),
-                                 (void**)&sq, "coherence SQ",
-                                 XIO_HOST_MEM_DEFAULT));
-  HIP_CHECK(xio::allocHostMemory(sizeof(CoherenceCpl),
-                                 (void**)&cq, "coherence CQ",
-                                 XIO_HOST_MEM_DEFAULT));
-  HIP_CHECK(xio::allocHostMemory(sizeof(uint32_t),
-                                 (void**)&doorbell,
-                                 "coherence doorbell",
-                                 XIO_HOST_MEM_DEFAULT));
+  HIP_CHECK(xio::allocHostMemory(sizeof(CoherenceCmd), (void**)&sq,
+                                 "coherence SQ", XIO_HOST_MEM_DEFAULT));
+  HIP_CHECK(xio::allocHostMemory(sizeof(CoherenceCpl), (void**)&cq,
+                                 "coherence CQ", XIO_HOST_MEM_DEFAULT));
+  HIP_CHECK(xio::allocHostMemory(sizeof(uint32_t), (void**)&doorbell,
+                                 "coherence doorbell", XIO_HOST_MEM_DEFAULT));
 
   SharedState state;
   state.sq = sq;

--- a/tests/system/test-ep/test-ep-emulate.hip
+++ b/tests/system/test-ep/test-ep-emulate.hip
@@ -53,11 +53,13 @@ int test_emulate_roundtrip() {
   size_t cqSize = kThreads * sizeof(xio::test_ep::test_cqe);
 
   void *sq = nullptr, *cq = nullptr;
-  sq = calloc(1, sqSize);
-  cq = calloc(1, cqSize);
-  if (!sq || !cq) {
-    free(sq);
-    free(cq);
+  hipError_t sq_err = xio::allocHostMemory(
+    sqSize, &sq, "emulate SQ", XIO_HOST_MEM_PLAIN);
+  hipError_t cq_err = xio::allocHostMemory(
+    cqSize, &cq, "emulate CQ", XIO_HOST_MEM_PLAIN);
+  if (sq_err != hipSuccess || cq_err != hipSuccess) {
+    xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
     fprintf(stderr, "Allocation failed\n");
     return 1;
   }
@@ -67,8 +69,8 @@ int test_emulate_roundtrip() {
 
   hipError_t err = xio::test_ep::run(&cfg);
 
-  free(sq);
-  free(cq);
+  xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
 
   if (err != hipSuccess) {
     fprintf(stderr, "test-ep emulate run failed: %d\n", static_cast<int>(err));

--- a/tests/system/test-ep/test-ep-emulate.hip
+++ b/tests/system/test-ep/test-ep-emulate.hip
@@ -53,10 +53,10 @@ int test_emulate_roundtrip() {
   size_t cqSize = kThreads * sizeof(xio::test_ep::test_cqe);
 
   void *sq = nullptr, *cq = nullptr;
-  hipError_t sq_err = xio::allocHostMemory(
-    sqSize, &sq, "emulate SQ", XIO_HOST_MEM_PLAIN);
-  hipError_t cq_err = xio::allocHostMemory(
-    cqSize, &cq, "emulate CQ", XIO_HOST_MEM_PLAIN);
+  hipError_t sq_err = xio::allocHostMemory(sqSize, &sq, "emulate SQ",
+                                           XIO_HOST_MEM_PLAIN);
+  hipError_t cq_err = xio::allocHostMemory(cqSize, &cq, "emulate CQ",
+                                           XIO_HOST_MEM_PLAIN);
   if (sq_err != hipSuccess || cq_err != hipSuccess) {
     xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
     xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);

--- a/tests/unit/rdma-ep/test-rdma-2node.hip
+++ b/tests/unit/rdma-ep/test-rdma-2node.hip
@@ -339,15 +339,13 @@ int main(int argc, char** argv) {
   size_t pp_send_offset = WRITE_SIZE;
   size_t pp_recv_offset = WRITE_SIZE + pp_size;
   size_t total_reg_size = WRITE_SIZE + pp_size * 2 + 4096;
-  static constexpr unsigned kRegBufFlags =
-    XIO_HOST_MEM_MAPPED | XIO_HOST_MEM_COHERENT;
+  static constexpr unsigned kRegBufFlags = XIO_HOST_MEM_MAPPED |
+                                           XIO_HOST_MEM_COHERENT;
   void* reg_buf = nullptr;
-  herr = xio::allocHostMemory(total_reg_size, &reg_buf,
-                               "2-node data",
-                               kRegBufFlags);
+  herr = xio::allocHostMemory(total_reg_size, &reg_buf, "2-node data",
+                              kRegBufFlags);
   if (herr != hipSuccess) {
-    fprintf(stderr,
-            "allocHostMemory(coherent) failed\n");
+    fprintf(stderr, "allocHostMemory(coherent) failed\n");
     return 1;
   }
 
@@ -509,13 +507,10 @@ int main(int argc, char** argv) {
   // Allocate device-side error counter and elapsed timer
   uint32_t* d_errors = nullptr;
   unsigned long long* d_elapsed = nullptr;
-  (void)xio::allocDeviceMemory(
-    sizeof(uint32_t), (void**)&d_errors,
-    "2node errors", XIO_DEVICE_MEM_HIP);
-  (void)xio::allocDeviceMemory(
-    sizeof(unsigned long long),
-    (void**)&d_elapsed, "2node elapsed",
-    XIO_DEVICE_MEM_HIP);
+  (void)xio::allocDeviceMemory(sizeof(uint32_t), (void**)&d_errors,
+                               "2node errors", XIO_DEVICE_MEM_HIP);
+  (void)xio::allocDeviceMemory(sizeof(unsigned long long), (void**)&d_elapsed,
+                               "2node elapsed", XIO_DEVICE_MEM_HIP);
   uint32_t h_errors = 0;
   unsigned long long h_elapsed = 0;
   (void)hipMemcpy(d_errors, &h_errors, sizeof(h_errors), hipMemcpyHostToDevice);

--- a/tests/unit/rdma-ep/test-rdma-2node.hip
+++ b/tests/unit/rdma-ep/test-rdma-2node.hip
@@ -31,6 +31,7 @@
 #include "tcp-exchange.hpp"
 #include "vendor-ops.hpp"
 #include "xio-data-pattern.hpp"
+#include "xio.h"
 
 #if !defined(GDA_BNXT) && !defined(GDA_MLX5) && !defined(GDA_IONIC) &&         \
   !defined(GDA_ERNIC)
@@ -334,19 +335,21 @@ int main(int argc, char** argv) {
 
   // --- Allocate registered region ---
   // Layout: [data (WRITE_SIZE) | pp_send (pp_size) | pp_recv (pp_size) | pad]
-  // Uses hipHostMallocCoherent so GPU sees RDMA writes from remote NIC.
+  // Uses coherent mapped host memory so GPU sees RDMA writes from remote NIC.
   size_t pp_send_offset = WRITE_SIZE;
   size_t pp_recv_offset = WRITE_SIZE + pp_size;
   size_t total_reg_size = WRITE_SIZE + pp_size * 2 + 4096;
+  static constexpr unsigned kRegBufFlags =
+    XIO_HOST_MEM_MAPPED | XIO_HOST_MEM_COHERENT;
   void* reg_buf = nullptr;
-  herr = hipHostMalloc(&reg_buf, total_reg_size,
-                       hipHostMallocMapped | hipHostMallocCoherent);
+  herr = xio::allocHostMemory(total_reg_size, &reg_buf,
+                               "2-node data",
+                               kRegBufFlags);
   if (herr != hipSuccess) {
-    fprintf(stderr, "hipHostMalloc(coherent) failed: %s\n",
-            hipGetErrorString(herr));
+    fprintf(stderr,
+            "allocHostMemory(coherent) failed\n");
     return 1;
   }
-  memset(reg_buf, 0, total_reg_size);
 
   uint8_t* data_region = static_cast<uint8_t*>(reg_buf);
   uint8_t* pp_send_buf = data_region + pp_send_offset;
@@ -506,8 +509,13 @@ int main(int argc, char** argv) {
   // Allocate device-side error counter and elapsed timer
   uint32_t* d_errors = nullptr;
   unsigned long long* d_elapsed = nullptr;
-  (void)hipMalloc(&d_errors, sizeof(uint32_t));
-  (void)hipMalloc(&d_elapsed, sizeof(unsigned long long));
+  (void)xio::allocDeviceMemory(
+    sizeof(uint32_t), (void**)&d_errors,
+    "2node errors", XIO_DEVICE_MEM_HIP);
+  (void)xio::allocDeviceMemory(
+    sizeof(unsigned long long),
+    (void**)&d_elapsed, "2node elapsed",
+    XIO_DEVICE_MEM_HIP);
   uint32_t h_errors = 0;
   unsigned long long h_elapsed = 0;
   (void)hipMemcpy(d_errors, &h_errors, sizeof(h_errors), hipMemcpyHostToDevice);
@@ -516,8 +524,8 @@ int main(int argc, char** argv) {
 
   if (xio::tcp_sync(tcp_fd) != 0) {
     fprintf(stderr, "tcp_sync failed.\n");
-    (void)hipFree(d_errors);
-    (void)hipFree(d_elapsed);
+    xio::freeDeviceMemory(d_errors, XIO_DEVICE_MEM_HIP);
+    xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
     close(tcp_fd);
     return 1;
   }
@@ -553,8 +561,8 @@ int main(int argc, char** argv) {
     if (h_errors > 0) {
       fprintf(stderr, "[CLIENT] FAILED: %u LFSR verification errors\n",
               h_errors);
-      (void)hipFree(d_errors);
-      (void)hipFree(d_elapsed);
+      xio::freeDeviceMemory(d_errors, XIO_DEVICE_MEM_HIP);
+      xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
       close(tcp_fd);
       return 1;
     }
@@ -578,8 +586,8 @@ int main(int argc, char** argv) {
     if (h_errors > 0) {
       fprintf(stderr, "[SERVER] FAILED: %u LFSR verification errors\n",
               h_errors);
-      (void)hipFree(d_errors);
-      (void)hipFree(d_elapsed);
+      xio::freeDeviceMemory(d_errors, XIO_DEVICE_MEM_HIP);
+      xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
       close(tcp_fd);
       return 1;
     }
@@ -587,16 +595,16 @@ int main(int argc, char** argv) {
            pp_iters);
   }
 
-  (void)hipFree(d_errors);
-  (void)hipFree(d_elapsed);
+  xio::freeDeviceMemory(d_errors, XIO_DEVICE_MEM_HIP);
+  xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
 
   if (xio::tcp_sync(tcp_fd) != 0)
     fprintf(stderr, "final tcp_sync failed (non-fatal)\n");
 
   // --- Cleanup ---
   close(tcp_fd);
-  (void)hipHostFree(reg_buf);
   backend.shutdown();
+  xio::freeHostMemory(reg_buf, kRegBufFlags);
 
   printf("\n=== 2-Node RDMA Test [%s] PASSED ===\n", role);
   return 0;

--- a/tests/unit/rdma-ep/test-rdma-endian.hip
+++ b/tests/unit/rdma-ep/test-rdma-endian.hip
@@ -106,9 +106,10 @@ int test_endian_on_gpu() {
   }
 
   bool* device_results = nullptr;
-  hsa_status_t hsa_ret = xio::allocDeviceMemory(
-    sizeof(bool), (void**)&device_results,
-    "endian results", XIO_DEVICE_MEM_HIP);
+  hsa_status_t hsa_ret = xio::allocDeviceMemory(sizeof(bool),
+                                                (void**)&device_results,
+                                                "endian results",
+                                                XIO_DEVICE_MEM_HIP);
   if (hsa_ret != HSA_STATUS_SUCCESS)
     return 1;
 
@@ -120,15 +121,13 @@ int test_endian_on_gpu() {
 
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
-    xio::freeDeviceMemory(device_results,
-                          XIO_DEVICE_MEM_HIP);
+    xio::freeDeviceMemory(device_results, XIO_DEVICE_MEM_HIP);
     return 1;
   }
 
   (void)hipMemcpy(&host_result, device_results, sizeof(bool),
                   hipMemcpyDeviceToHost);
-  xio::freeDeviceMemory(device_results,
-                        XIO_DEVICE_MEM_HIP);
+  xio::freeDeviceMemory(device_results, XIO_DEVICE_MEM_HIP);
 
   return host_result ? 0 : 1;
 }

--- a/tests/unit/rdma-ep/test-rdma-endian.hip
+++ b/tests/unit/rdma-ep/test-rdma-endian.hip
@@ -14,6 +14,7 @@
 #include <hip/hip_runtime.h>
 
 #include "endian.hpp"
+#include "xio.h"
 
 #define ASSERT_EQ(a, b)                                                        \
   do {                                                                         \
@@ -105,8 +106,10 @@ int test_endian_on_gpu() {
   }
 
   bool* device_results = nullptr;
-  err = hipMalloc(&device_results, sizeof(bool));
-  if (err != hipSuccess)
+  hsa_status_t hsa_ret = xio::allocDeviceMemory(
+    sizeof(bool), (void**)&device_results,
+    "endian results", XIO_DEVICE_MEM_HIP);
+  if (hsa_ret != HSA_STATUS_SUCCESS)
     return 1;
 
   bool host_result = false;
@@ -117,13 +120,15 @@ int test_endian_on_gpu() {
 
   err = hipDeviceSynchronize();
   if (err != hipSuccess) {
-    (void)hipFree(device_results);
+    xio::freeDeviceMemory(device_results,
+                          XIO_DEVICE_MEM_HIP);
     return 1;
   }
 
   (void)hipMemcpy(&host_result, device_results, sizeof(bool),
                   hipMemcpyDeviceToHost);
-  (void)hipFree(device_results);
+  xio::freeDeviceMemory(device_results,
+                        XIO_DEVICE_MEM_HIP);
 
   return host_result ? 0 : 1;
 }

--- a/tests/unit/rdma-ep/test-rdma-ernic-loopback.hip
+++ b/tests/unit/rdma-ep/test-rdma-ernic-loopback.hip
@@ -127,9 +127,8 @@ int main(int argc, char** argv) {
 
   size_t buf_size = xfer_size * 2;
   void* buf = nullptr;
-  herr = xio::allocHostMemory(buf_size, &buf,
-                               "ernic loopback data",
-                               XIO_HOST_MEM_MAPPED);
+  herr = xio::allocHostMemory(buf_size, &buf, "ernic loopback data",
+                              XIO_HOST_MEM_MAPPED);
   if (herr != hipSuccess) {
     fprintf(stderr, "allocHostMemory failed\n");
     return 1;
@@ -175,25 +174,21 @@ int main(int argc, char** argv) {
 
   int* d_result = nullptr;
   unsigned long long* d_elapsed = nullptr;
-  hsa_status_t hsa_ret = xio::allocDeviceMemory(
-    sizeof(int), (void**)&d_result,
-    "ernic result", XIO_DEVICE_MEM_HIP);
+  hsa_status_t hsa_ret = xio::allocDeviceMemory(sizeof(int), (void**)&d_result,
+                                                "ernic result",
+                                                XIO_DEVICE_MEM_HIP);
   if (hsa_ret != HSA_STATUS_SUCCESS) {
-    fprintf(stderr,
-            "allocDeviceMemory(result) failed.\n");
+    fprintf(stderr, "allocDeviceMemory(result) failed.\n");
     backend.shutdown();
     xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
-  hsa_ret = xio::allocDeviceMemory(
-    sizeof(unsigned long long),
-    (void**)&d_elapsed, "ernic elapsed",
-    XIO_DEVICE_MEM_HIP);
+  hsa_ret = xio::allocDeviceMemory(sizeof(unsigned long long),
+                                   (void**)&d_elapsed, "ernic elapsed",
+                                   XIO_DEVICE_MEM_HIP);
   if (hsa_ret != HSA_STATUS_SUCCESS) {
-    fprintf(stderr,
-            "allocDeviceMemory(elapsed) failed.\n");
-    xio::freeDeviceMemory(d_result,
-                          XIO_DEVICE_MEM_HIP);
+    fprintf(stderr, "allocDeviceMemory(elapsed) failed.\n");
+    xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
     backend.shutdown();
     xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;

--- a/tests/unit/rdma-ep/test-rdma-ernic-loopback.hip
+++ b/tests/unit/rdma-ep/test-rdma-ernic-loopback.hip
@@ -127,9 +127,11 @@ int main(int argc, char** argv) {
 
   size_t buf_size = xfer_size * 2;
   void* buf = nullptr;
-  herr = hipHostMalloc(&buf, buf_size, hipHostMallocMapped);
+  herr = xio::allocHostMemory(buf_size, &buf,
+                               "ernic loopback data",
+                               XIO_HOST_MEM_MAPPED);
   if (herr != hipSuccess) {
-    fprintf(stderr, "hipHostMalloc failed: %s\n", hipGetErrorString(herr));
+    fprintf(stderr, "allocHostMemory failed\n");
     return 1;
   }
 
@@ -148,7 +150,7 @@ int main(int argc, char** argv) {
   ret = backend.register_data_buffer(buf, buf_size);
   if (ret != 0) {
     fprintf(stderr, "register_data_buffer failed.\n");
-    (void)hipHostFree(buf);
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
   printf("Buffer registered: "
@@ -162,7 +164,8 @@ int main(int argc, char** argv) {
             "hipHostGetDevicePointer "
             "failed: %s\n",
             hipGetErrorString(herr));
-    (void)hipHostFree(buf);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
 
@@ -172,17 +175,27 @@ int main(int argc, char** argv) {
 
   int* d_result = nullptr;
   unsigned long long* d_elapsed = nullptr;
-  herr = hipMalloc(&d_result, sizeof(int));
-  if (herr != hipSuccess) {
-    fprintf(stderr, "hipMalloc(result) failed.\n");
-    (void)hipHostFree(buf);
+  hsa_status_t hsa_ret = xio::allocDeviceMemory(
+    sizeof(int), (void**)&d_result,
+    "ernic result", XIO_DEVICE_MEM_HIP);
+  if (hsa_ret != HSA_STATUS_SUCCESS) {
+    fprintf(stderr,
+            "allocDeviceMemory(result) failed.\n");
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
-  herr = hipMalloc(&d_elapsed, sizeof(unsigned long long));
-  if (herr != hipSuccess) {
-    fprintf(stderr, "hipMalloc(elapsed) failed.\n");
-    (void)hipFree(d_result);
-    (void)hipHostFree(buf);
+  hsa_ret = xio::allocDeviceMemory(
+    sizeof(unsigned long long),
+    (void**)&d_elapsed, "ernic elapsed",
+    XIO_DEVICE_MEM_HIP);
+  if (hsa_ret != HSA_STATUS_SUCCESS) {
+    fprintf(stderr,
+            "allocDeviceMemory(elapsed) failed.\n");
+    xio::freeDeviceMemory(d_result,
+                          XIO_DEVICE_MEM_HIP);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
   int h_result = -1;
@@ -206,30 +219,33 @@ int main(int argc, char** argv) {
   herr = hipGetLastError();
   if (herr != hipSuccess) {
     fprintf(stderr, "Kernel launch failed: %s\n", hipGetErrorString(herr));
-    (void)hipFree(d_elapsed);
-    (void)hipFree(d_result);
-    (void)hipHostFree(buf);
+    xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
+    xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
 
   herr = hipDeviceSynchronize();
   if (herr != hipSuccess) {
     fprintf(stderr, "Kernel sync failed: %s\n", hipGetErrorString(herr));
-    (void)hipFree(d_elapsed);
-    (void)hipFree(d_result);
-    (void)hipHostFree(buf);
+    xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
+    xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
 
   (void)hipMemcpy(&h_result, d_result, sizeof(int), hipMemcpyDeviceToHost);
   (void)hipMemcpy(&h_elapsed, d_elapsed, sizeof(h_elapsed),
                   hipMemcpyDeviceToHost);
-  (void)hipFree(d_elapsed);
-  (void)hipFree(d_result);
+  xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
+  xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
 
   if (h_result != 0) {
     fprintf(stderr, "Kernel reported error: %d\n", h_result);
-    (void)hipHostFree(buf);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
 
@@ -256,13 +272,13 @@ int main(int argc, char** argv) {
             "\nFAILED: LFSR mismatch at offset "
             "%zu (got 0x%02x).\n",
             err_offset, dst[err_offset]);
-    (void)hipHostFree(buf);
     backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
     return 1;
   }
 
-  (void)hipHostFree(buf);
   backend.shutdown();
+  xio::freeHostMemory(buf, XIO_HOST_MEM_MAPPED);
 
   printf("\nPASSED: All %u bytes LFSR-verified "
          "via RDMA WRITE loopback.\n",

--- a/tests/unit/rdma-ep/test-rdma-loopback.hip
+++ b/tests/unit/rdma-ep/test-rdma-loopback.hip
@@ -378,8 +378,11 @@ int main(int argc, char** argv) {
 
   size_t buf_size = xfer_size > 0 ? xfer_size * 2 : 4096;
   void* buf = nullptr;
-  if (posix_memalign(&buf, 4096, buf_size)) {
-    fprintf(stderr, "posix_memalign failed\n");
+  herr = xio::allocHostMemory(buf_size, &buf,
+                               "loopback data",
+                               XIO_HOST_MEM_PINNED);
+  if (herr != hipSuccess) {
+    fprintf(stderr, "allocHostMemory failed\n");
     return 1;
   }
 
@@ -400,7 +403,7 @@ int main(int argc, char** argv) {
   ret = backend.register_data_buffer(buf, buf_size);
   if (ret != 0) {
     fprintf(stderr, "register_data_buffer failed.\n");
-    free(buf);
+    xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
   printf("Buffer registered: lkey=0x%x,"
@@ -411,17 +414,27 @@ int main(int argc, char** argv) {
 
   int* d_result = nullptr;
   unsigned long long* d_elapsed = nullptr;
-  herr = hipMalloc(&d_result, sizeof(int));
-  if (herr != hipSuccess) {
-    fprintf(stderr, "hipMalloc(result) failed.\n");
-    free(buf);
+  hsa_status_t hsa_ret = xio::allocDeviceMemory(
+    sizeof(int), (void**)&d_result,
+    "loopback result", XIO_DEVICE_MEM_HIP);
+  if (hsa_ret != HSA_STATUS_SUCCESS) {
+    fprintf(stderr,
+            "allocDeviceMemory(result) failed.\n");
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
-  herr = hipMalloc(&d_elapsed, sizeof(unsigned long long));
-  if (herr != hipSuccess) {
-    fprintf(stderr, "hipMalloc(elapsed) failed.\n");
-    (void)hipFree(d_result);
-    free(buf);
+  hsa_ret = xio::allocDeviceMemory(
+    sizeof(unsigned long long),
+    (void**)&d_elapsed, "loopback elapsed",
+    XIO_DEVICE_MEM_HIP);
+  if (hsa_ret != HSA_STATUS_SUCCESS) {
+    fprintf(stderr,
+            "allocDeviceMemory(elapsed) failed.\n");
+    xio::freeDeviceMemory(d_result,
+                          XIO_DEVICE_MEM_HIP);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
   int h_result = -1;
@@ -440,12 +453,14 @@ int main(int argc, char** argv) {
     if (!src_ok) {
       fprintf(stderr, "Pre-check LFSR failed"
                       " on source buffer.\n");
-      free(buf);
+      backend.shutdown();
+      xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
       return 1;
     }
     if (dst[0] != 0x00) {
       fprintf(stderr, "Pre-check dst not zeroed.\n");
-      free(buf);
+      backend.shutdown();
+      xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
       return 1;
     }
   }
@@ -486,7 +501,8 @@ int main(int argc, char** argv) {
       int rrc = ibv_post_recv(backend.get_ibv_qp(), &recv_wr, &bad_wr);
       if (rrc != 0) {
         fprintf(stderr, "ibv_post_recv failed: %d\n", rrc);
-        free(buf);
+        backend.shutdown();
+        xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
         return 1;
       }
       printf("Posted receive WQE for"
@@ -497,8 +513,8 @@ int main(int argc, char** argv) {
       fprintf(stderr, "SKIP: WRITE_IMM not supported"
                       " for this provider (no"
                       " ibv_post_recv support).\n");
-      free(buf);
       backend.shutdown();
+      xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
       return 77;
     }
   }
@@ -527,18 +543,20 @@ int main(int argc, char** argv) {
   herr = hipGetLastError();
   if (herr != hipSuccess) {
     fprintf(stderr, "Kernel launch failed: %s\n", hipGetErrorString(herr));
-    (void)hipFree(d_elapsed);
-    (void)hipFree(d_result);
-    free(buf);
+    xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
+    xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
 
   herr = hipDeviceSynchronize();
   if (herr != hipSuccess) {
     fprintf(stderr, "Kernel sync failed: %s\n", hipGetErrorString(herr));
-    (void)hipFree(d_elapsed);
-    (void)hipFree(d_result);
-    free(buf);
+    xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
+    xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
 
@@ -571,8 +589,8 @@ int main(int argc, char** argv) {
   (void)hipMemcpy(&h_result, d_result, sizeof(int), hipMemcpyDeviceToHost);
   (void)hipMemcpy(&h_elapsed, d_elapsed, sizeof(h_elapsed),
                   hipMemcpyDeviceToHost);
-  (void)hipFree(d_elapsed);
-  (void)hipFree(d_result);
+  xio::freeDeviceMemory(d_elapsed, XIO_DEVICE_MEM_HIP);
+  xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
 
   if (h_result != 0) {
     if (h_result == -2) {
@@ -600,7 +618,8 @@ int main(int argc, char** argv) {
               "Kernel reported error:"
               " %d\n",
               h_result);
-    free(buf);
+    backend.shutdown();
+    xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
 
@@ -628,14 +647,14 @@ int main(int argc, char** argv) {
               "\nFAILED: LFSR mismatch at "
               "offset %zu (got 0x%02x).\n",
               err_offset, dst[err_offset]);
-      free(buf);
       backend.shutdown();
+      xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
       return 1;
     }
   }
 
-  free(buf);
   backend.shutdown();
+  xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
 
   if (write_imm && xfer_size == 0) {
     printf("\nPASSED: %u zero-length WRITE_IMM"

--- a/tests/unit/rdma-ep/test-rdma-loopback.hip
+++ b/tests/unit/rdma-ep/test-rdma-loopback.hip
@@ -378,9 +378,8 @@ int main(int argc, char** argv) {
 
   size_t buf_size = xfer_size > 0 ? xfer_size * 2 : 4096;
   void* buf = nullptr;
-  herr = xio::allocHostMemory(buf_size, &buf,
-                               "loopback data",
-                               XIO_HOST_MEM_PINNED);
+  herr = xio::allocHostMemory(buf_size, &buf, "loopback data",
+                              XIO_HOST_MEM_PINNED);
   if (herr != hipSuccess) {
     fprintf(stderr, "allocHostMemory failed\n");
     return 1;
@@ -414,25 +413,21 @@ int main(int argc, char** argv) {
 
   int* d_result = nullptr;
   unsigned long long* d_elapsed = nullptr;
-  hsa_status_t hsa_ret = xio::allocDeviceMemory(
-    sizeof(int), (void**)&d_result,
-    "loopback result", XIO_DEVICE_MEM_HIP);
+  hsa_status_t hsa_ret = xio::allocDeviceMemory(sizeof(int), (void**)&d_result,
+                                                "loopback result",
+                                                XIO_DEVICE_MEM_HIP);
   if (hsa_ret != HSA_STATUS_SUCCESS) {
-    fprintf(stderr,
-            "allocDeviceMemory(result) failed.\n");
+    fprintf(stderr, "allocDeviceMemory(result) failed.\n");
     backend.shutdown();
     xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;
   }
-  hsa_ret = xio::allocDeviceMemory(
-    sizeof(unsigned long long),
-    (void**)&d_elapsed, "loopback elapsed",
-    XIO_DEVICE_MEM_HIP);
+  hsa_ret = xio::allocDeviceMemory(sizeof(unsigned long long),
+                                   (void**)&d_elapsed, "loopback elapsed",
+                                   XIO_DEVICE_MEM_HIP);
   if (hsa_ret != HSA_STATUS_SUCCESS) {
-    fprintf(stderr,
-            "allocDeviceMemory(elapsed) failed.\n");
-    xio::freeDeviceMemory(d_result,
-                          XIO_DEVICE_MEM_HIP);
+    fprintf(stderr, "allocDeviceMemory(elapsed) failed.\n");
+    xio::freeDeviceMemory(d_result, XIO_DEVICE_MEM_HIP);
     backend.shutdown();
     xio::freeHostMemory(buf, XIO_HOST_MEM_PINNED);
     return 1;


### PR DESCRIPTION
Replace raw posix_memalign, hipHostMalloc, hipMalloc, calloc, and their corresponding free calls with xio::allocHostMemory / xio::freeHostMemory and xio::allocDeviceMemory /
xio::freeDeviceMemory across all six test programs that were bypassing the library abstraction.

This fixes two concrete bugs in the RDMA data-path tests:

- test-rdma-loopback used posix_memalign without hipHostRegister, so the data buffer was never pinned or GPU-registered. The XIO_HOST_MEM_PINNED path does both automatically.

- All three RDMA tests freed the data buffer before calling backend.shutdown(), which deregisters the MR against a freed VA. Cleanup ordering is now shutdown-then-free on all paths where register_data_buffer succeeded.

Files changed:
- tests/unit/rdma-ep/test-rdma-loopback.hip
- tests/unit/rdma-ep/test-rdma-2node.hip
- tests/unit/rdma-ep/test-rdma-ernic-loopback.hip
- tests/unit/rdma-ep/test-rdma-endian.hip
- tests/system/coherence/test-doorbell-coherence.hip
- tests/system/test-ep/test-ep-emulate.hip
- docs/performance.rst (NVMe-EP results, memory abstraction note)

Tested: BNXT and IONIC loopback RDMA WRITE (PASSED), endian, doorbell coherence, test-ep emulate, NVMe-EP hardware + smoke (all PASSED).
