### PR TITLE
ci: install rocm-kpack from GitHub instead of PyPI

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -45,7 +45,8 @@ jobs:
 
     - name: Install rocm-kpack Python tools
       run: |
-        pip install --break-system-packages rocm-kpack
+        pip install --break-system-packages \
+          "rocm-kpack @ git+https://github.com/ROCm/rocm-kpack.git@main"
 
     - name: Generate debian/changelog
       run: debian/gen-changelog.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
 
     - name: Install rocm-kpack Python tools
       run: |
-        pip install --break-system-packages rocm-kpack
+        pip install --break-system-packages \
+          "rocm-kpack @ git+https://github.com/ROCm/rocm-kpack.git@main"
 
     - name: Generate debian/changelog
       run: debian/gen-changelog.sh

--- a/scripts/build/kpack-split.py
+++ b/scripts/build/kpack-split.py
@@ -15,7 +15,8 @@ Usage:
         --output-dir build/kpack \
         [--strip] [--verbose]
 
-Requires the rocm_kpack Python package (pip install rocm-kpack).
+Requires the rocm_kpack Python package:
+    pip install "rocm-kpack @ git+https://github.com/ROCm/rocm-kpack.git@main"
 """
 
 import argparse
@@ -30,8 +31,10 @@ try:
 except ImportError:
     print(
         "ERROR: rocm_kpack package not found.\n"
-        "Install it with: pip install rocm-kpack\n"
-        "Or from source: pip install -e /path/to/rocm-kpack",
+        "Install from GitHub:\n"
+        '  pip install "rocm-kpack @ git+https://github.com/ROCm/rocm-kpack.git@main"\n'
+        "Or from a local clone:\n"
+        "  pip install -e /path/to/rocm-kpack",
         file=sys.stderr,
     )
     sys.exit(1)


### PR DESCRIPTION
rocm-kpack is not published to PyPI, so `pip install rocm-kpack` fails in both the deb-build and release workflows. Install it directly from the ROCm/rocm-kpack GitHub repo using a PEP 440 direct reference. Update the install instructions in kpack-split.py to match.
