### PR TITLE
debian: set CMAKE_INSTALL_PREFIX to /opt/rocm in rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,6 +26,7 @@ RDMA_CORE_BUILD_DIR    = $(CURDIR)/obj-x86_64-linux-gnu/_deps/rdma-core/install
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+	  -DCMAKE_INSTALL_PREFIX=$(ROCM_PATH) \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DROCM_PATH=$(ROCM_PATH) \
 	  -DOFFLOAD_ARCH="$(DEB_OFFLOAD_ARCH)" \


### PR DESCRIPTION
dh_auto_configure injects -DCMAKE_INSTALL_PREFIX=/usr, which bypasses the CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT guard in CMakeLists.txt. This causes all artifacts to install under /usr instead of /opt/rocm, making dh_install fail because the .install files expect the /opt/rocm prefix.
