### PR TITLE
alola: add --exclude-tests option and node exclusions

### DIFF
--- a/.alola/.alola-exclude
+++ b/.alola/.alola-exclude
@@ -38,3 +38,7 @@ banff-cyxtera-s81-1  sdma-ep,rdma-ep,nvme-ep
 
 # SDMA P2P kernel hang during 1MB GPU-to-GPU transfer
 #ctr-cx63-mi300x-21  sdma-ep
+
+# Radeon 8060S hangs on test-ep doorbell poll and
+# test-rdma-endian times out in ctest unit suite
+ctr-halo-b48-02  test-ep,basic-tests

--- a/.alola/rocm-xio-alola.py
+++ b/.alola/rocm-xio-alola.py
@@ -72,6 +72,27 @@ def set_test_filter(names):
     TESTS = [
         t for t in ALL_TESTS if t[0] in names]
 
+
+def set_test_exclude(names):
+    """Remove named tests from TESTS.
+
+    Validates each name against ALL_TESTS and
+    exits on unknown names.
+    """
+    global TESTS
+    unknown = [
+        n for n in names if n not in ALL_TEST_NAMES]
+    if unknown:
+        print(red(
+            f"ERROR: unknown test(s): "
+            f"{', '.join(unknown)}"))
+        print(
+            f"Available: "
+            f"{', '.join(ALL_TEST_NAMES)}")
+        sys.exit(1)
+    TESTS = [
+        t for t in TESTS if t[0] not in names]
+
 STATUS_PASS = 0
 STATUS_FAIL = 1
 STATUS_UNKNOWN = 2
@@ -1400,8 +1421,15 @@ def cmd_run(args):
 
     if args.tests:
         set_test_filter(
-            [t.strip() for t in
-             args.tests.split(",")])
+            [t for t in
+             (s.strip() for s in
+              args.tests.split(",")) if t])
+
+    if args.exclude_tests:
+        set_test_exclude(
+            [t for t in
+             (s.strip() for s in
+              args.exclude_tests.split(",")) if t])
 
     os.chdir(SCRIPT_DIR)
 
@@ -1884,6 +1912,14 @@ def main():
             "Available: "
             + ",".join(ALL_TEST_NAMES)
             + ". Default: all."),
+    )
+    p_run.add_argument(
+        "--exclude-tests", type=str,
+        default=None, metavar="LIST",
+        help=(
+            "Comma-separated list of tests to "
+            "exclude (e.g. rdma-ep). Applied "
+            "after --tests."),
     )
     p_run.add_argument(
         "--exclude-nodes", type=str,


### PR DESCRIPTION
- rocm-xio-alola.py: add --exclude-tests flag to omit specific tests from a run (e.g. --exclude-tests rdma-ep).  Applied after --tests so the two can be combined.

- .alola-exclude: exclude ctr-halo-b48-02 (Radeon 8060S) from test-ep and basic-tests -- HIP tests hang or timeout on this GPU inside the container.
