### PR TITLE
nvme-ep: add PRP list support for multi-page data transfers

### DIFF
--- a/scripts/test/test-xio-tester-nvme-ep.sh
+++ b/scripts/test/test-xio-tester-nvme-ep.sh
@@ -22,6 +22,7 @@ BATCH_SIZE=${BATCH_SIZE:-16}
 QUEUE_LENGTH=${QUEUE_LENGTH:-1024}
 NUM_QUEUES=${NUM_QUEUES:-16}
 BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/build}"
+LBAS_PER_IO=${LBAS_PER_IO:-1}
 
 sudo LD_LIBRARY_PATH=/opt/rocm/lib \
   HSA_FORCE_FINE_GRAIN_PCIE=1 \
@@ -33,4 +34,5 @@ sudo LD_LIBRARY_PATH=/opt/rocm/lib \
   --queue-length ${QUEUE_LENGTH} \
   --num-queues ${NUM_QUEUES} \
   --less-timing \
+  --lbas-per-io ${LBAS_PER_IO} \
   --infinite

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -2451,6 +2451,8 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
   bufferInfo->gpuPtr = nullptr;
   bufferInfo->dmaAddr = 0;
   bufferInfo->isDeviceMemory = false;
+  bufferInfo->pagePhysAddrs = nullptr;
+  bufferInfo->numPages = 0;
 
   bool dataBufferOnDevice = (memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
@@ -2501,13 +2503,52 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
     if (buf_err != hipSuccess)
       return buf_err;
 
-    // Get physical address for host memory using /proc/self/pagemap
     bufferInfo->dmaAddr = getPhysAddr(bufferInfo->hostPtr);
     if (!bufferInfo->dmaAddr) {
       ROCXIO_LOG_ERROR("Failed to get buffer physical address\n");
       (void)hipHostFree(bufferInfo->hostPtr);
       bufferInfo->hostPtr = nullptr;
       return hipErrorInvalidValue;
+    }
+
+    {
+      constexpr size_t nvme_page = 4096;
+      long ps = sysconf(_SC_PAGESIZE);
+      size_t sys_page = (ps > 0) ? (size_t)ps : 4096;
+      uint32_t sys_np = (uint32_t)((size + sys_page - 1) / sys_page);
+      uint32_t nvme_np = (uint32_t)((size + nvme_page - 1) / nvme_page);
+      size_t pa_bytes = nvme_np * sizeof(uint64_t);
+      uint64_t* pa = nullptr;
+      hipError_t pa_err = hipHostMalloc((void**)&pa, pa_bytes,
+                                        hipHostMallocMapped);
+      if (pa_err == hipSuccess && pa) {
+        memset(pa, 0, pa_bytes);
+        uint64_t sys_addrs[1024];
+        uint32_t max_sys = (sys_np <= 1024) ? sys_np : 1024;
+        int ret = getPagePhysAddrs(bufferInfo->hostPtr, size, sys_addrs,
+                                   max_sys);
+        if (ret < 0) {
+          ROCXIO_LOG_WARN("Failed to resolve per-page "
+                          "phys addrs: %s\n",
+                          strerror(-ret));
+          (void)hipHostFree(pa);
+        } else {
+          uint32_t ratio = (uint32_t)(sys_page / nvme_page);
+          for (uint32_t s = 0; s < sys_np; s++) {
+            for (uint32_t sub = 0; sub < ratio; sub++) {
+              uint32_t idx = s * ratio + sub;
+              if (idx >= nvme_np)
+                break;
+              pa[idx] = sys_addrs[s] + sub * nvme_page;
+            }
+          }
+          bufferInfo->pagePhysAddrs = pa;
+          bufferInfo->numPages = nvme_np;
+          ROCXIO_LOG_INFO("  Resolved %u NVMe-page phys "
+                          "addrs for host buffer\n",
+                          nvme_np);
+        }
+      }
     }
 
     ROCXIO_LOG_INFO("  Data buffer virtual:  %p\n", bufferInfo->hostPtr);
@@ -2560,10 +2601,16 @@ __host__ void freeGpuAccessibleBuffer(struct xioBufferInfo* bufferInfo) {
     freeHostMemory(bufferInfo->hostPtr, XIO_HOST_MEM_MAPPED);
   }
 
+  if (bufferInfo->pagePhysAddrs) {
+    (void)hipHostFree(bufferInfo->pagePhysAddrs);
+  }
+
   bufferInfo->hostPtr = nullptr;
   bufferInfo->gpuPtr = nullptr;
   bufferInfo->dmaAddr = 0;
   bufferInfo->isDeviceMemory = false;
+  bufferInfo->pagePhysAddrs = nullptr;
+  bufferInfo->numPages = 0;
 }
 
 __host__ bool validateGpuPointer(void* ptr, const char* name,

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -100,6 +100,13 @@ struct nvmeBufferParams {
   size_t bufferSize;       // Size of buffers in bytes
   uint64_t readBufferDma;  // DMA address for read buffer
   uint64_t writeBufferDma; // DMA address for write buffer
+  uint64_t* readPagePhysAddrs;
+  uint64_t* writePagePhysAddrs;
+  uint32_t readNumPages;
+  uint32_t writeNumPages;
+  uint64_t* prpListPool;
+  uint64_t prpListPoolDma;
+  uint32_t prpEntriesPerCmd;
 };
 
 /**
@@ -553,34 +560,81 @@ __host__ __device__ static inline uint8_t cqeStatusType(
 }
 
 /**
- * Calculate Physical Region Page (PRP) entries for NVMe data transfer
+ * Calculate PRP entries for an NVMe data transfer with
+ * full PRP list support for transfers spanning > 2 pages.
  *
- * Computes the PRP1 and PRP2 entries needed for an NVMe read or write
- * command based on the buffer address and size. PRPs are used to describe
- * the physical memory layout of data buffers to the NVMe controller.
+ * Per NVMe spec section 4.4:
+ * - <= 1 page:  PRP1 = buffer addr, PRP2 = 0
+ * - <= 2 pages: PRP1 = first page, PRP2 = second page
+ * - > 2 pages:  PRP1 = first page, PRP2 = physical
+ *   address of a PRP list (page-aligned array of
+ *   uint64_t physical page addresses for pages 2..N)
  *
- * The function handles three cases:
- * 1. Single page: Buffer fits entirely within one 4KB page. Only PRP1 is
- *    set (PRP2 = 0).
- * 2. Two pages: Buffer spans exactly two pages. PRP1 points to the first
- *    page, PRP2 points to the second page.
- * 3. Multiple pages: Buffer spans more than two pages. PRP1 points to the
- *    first page, PRP2 points to the second page (simplified implementation
- *    - does not create PRP lists for >2 pages).
- *
- * @param bufferAddr Physical/DMA address of the data buffer
- * @param bufferSize Size of the buffer in bytes
- * @param sqe Pointer to the NVMe SQE structure where PRP1 and PRP2 entries
- *            will be written to sqe->dptr.prp.prp1 and sqe->dptr.prp.prp2
- *
- * @note This function safely handles unaligned buffer addresses by calculating
- *       the offset within the first page.
- * @note For buffers spanning more than 2 pages, this is a simplified
- *       implementation that only sets PRP2 to the second page. Full PRP list
- *       support would require additional logic.
- * @note This function can be called from both host and device code.
- * @note The buffer address should be a physical/DMA address, not a virtual
- *       address.
+ * @param bufferAddr  Physical/DMA address of the buffer
+ * @param bufferSize  Transfer size in bytes
+ * @param sqe         SQE to fill (prp1/prp2)
+ * @param prpList     Writable PRP list memory (GPU or
+ *                    host accessible). May be nullptr
+ *                    when transfer fits in <= 2 pages.
+ * @param prpListDma  Physical address of prpList
+ * @param pagePhysAddrs  Per-page physical addresses for
+ *                       non-contiguous buffers. nullptr
+ *                       means contiguous from bufferAddr
+ * @param bufPageOffset  Page index of the first buffer
+ *                       page within pagePhysAddrs (the
+ *                       buffer may start partway into
+ *                       the allocation)
+ */
+__host__ __device__ static inline void calculatePrps(
+  uint64_t bufferAddr, uint32_t bufferSize, struct nvme_sqe* sqe,
+  uint64_t* prpList, uint64_t prpListDma, const uint64_t* pagePhysAddrs,
+  uint32_t bufPageOffset) {
+  sqe->dptr.prp.prp1 = bufferAddr;
+  sqe->dptr.prp.prp2 = 0;
+
+  uint64_t offset_in_page = bufferAddr & (NVME_PAGE_SIZE - 1);
+  uint64_t first_page_size = NVME_PAGE_SIZE - offset_in_page;
+
+  if (bufferSize <= first_page_size) {
+    return;
+  }
+
+  uint32_t remaining = (uint32_t)(bufferSize - first_page_size);
+  uint32_t num_remaining_pages = (remaining + NVME_PAGE_SIZE - 1) /
+                                 NVME_PAGE_SIZE;
+
+  constexpr uint32_t kMaxPrpListEntries = NVME_PAGE_SIZE / sizeof(uint64_t);
+  if (num_remaining_pages > kMaxPrpListEntries) {
+    num_remaining_pages = kMaxPrpListEntries;
+  }
+
+  if (num_remaining_pages == 1) {
+    if (pagePhysAddrs) {
+      sqe->dptr.prp.prp2 = pagePhysAddrs[bufPageOffset + 1];
+    } else {
+      sqe->dptr.prp.prp2 = (bufferAddr + first_page_size) &
+                           ~((uint64_t)(NVME_PAGE_SIZE - 1));
+    }
+    return;
+  }
+
+  for (uint32_t i = 0; i < num_remaining_pages; i++) {
+    if (pagePhysAddrs) {
+      prpList[i] = pagePhysAddrs[bufPageOffset + 1 + i];
+    } else {
+      prpList[i] = ((bufferAddr + first_page_size) &
+                    ~((uint64_t)(NVME_PAGE_SIZE - 1))) +
+                   (uint64_t)i * NVME_PAGE_SIZE;
+    }
+  }
+
+  sqe->dptr.prp.prp2 = prpListDma;
+}
+
+/**
+ * Backward-compatible calculatePrps for transfers that
+ * fit within at most 2 NVMe pages (up to 8KB at 4KB
+ * page size). Does not support PRP lists.
  */
 __host__ __device__ static inline void calculatePrps(uint64_t bufferAddr,
                                                      uint32_t bufferSize,
@@ -588,18 +642,15 @@ __host__ __device__ static inline void calculatePrps(uint64_t bufferAddr,
   sqe->dptr.prp.prp1 = bufferAddr;
   sqe->dptr.prp.prp2 = 0;
 
-  // Calculate how much data the first page can hold
   uint64_t offset_in_page = bufferAddr & (NVME_PAGE_SIZE - 1);
   uint64_t first_page_size = NVME_PAGE_SIZE - offset_in_page;
 
-  // If buffer fits in first page, we're done
   if (bufferSize <= first_page_size) {
     return;
   }
 
-  // Buffer spans multiple pages - set PRP2 to next page
-  // (Simplified: doesn't handle PRP lists for >2 pages)
-  sqe->dptr.prp.prp2 = (bufferAddr + first_page_size) & ~(NVME_PAGE_SIZE - 1);
+  sqe->dptr.prp.prp2 = (bufferAddr + first_page_size) &
+                       ~((uint64_t)(NVME_PAGE_SIZE - 1));
 }
 
 /**

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -302,20 +302,39 @@ __device__ static void driveEndpointSingle(
       uint64_t buf_off = (uint64_t)b * transfer_size;
       bool prp_valid = false;
 
+      uint32_t prpOff = b * bufferParams.prpEntriesPerCmd;
+      uint64_t* prpSlot = bufferParams.prpListPool
+                            ? bufferParams.prpListPool + prpOff
+                            : nullptr;
+      uint64_t prpSlotDma = bufferParams.prpListPoolDma
+                              ? bufferParams.prpListPoolDma +
+                                  prpOff * sizeof(uint64_t)
+                              : 0;
+      uint32_t pageOff = (uint32_t)(buf_off / NVME_PAGE_SIZE);
+      uint64_t intraPageOff = buf_off % NVME_PAGE_SIZE;
+
       if (is_read_op && has_read_buffer) {
         if (buf_off + transfer_size <= bufferParams.bufferSize) {
-          uint64_t addr = bufferParams.readBufferDma
+          uint64_t addr = bufferParams.readPagePhysAddrs
+                            ? bufferParams.readPagePhysAddrs[pageOff] +
+                                intraPageOff
+                          : bufferParams.readBufferDma
                             ? (bufferParams.readBufferDma + buf_off)
                             : (uint64_t)(bufferParams.readBuffer + buf_off);
-          calculatePrps(addr, transfer_size, sqe);
+          calculatePrps(addr, transfer_size, sqe, prpSlot, prpSlotDma,
+                        bufferParams.readPagePhysAddrs, pageOff);
           prp_valid = true;
         }
       } else if (!is_read_op && has_write_buffer) {
         if (buf_off + transfer_size <= bufferParams.bufferSize) {
-          uint64_t addr = bufferParams.writeBufferDma
+          uint64_t addr = bufferParams.writePagePhysAddrs
+                            ? bufferParams.writePagePhysAddrs[pageOff] +
+                                intraPageOff
+                          : bufferParams.writeBufferDma
                             ? (bufferParams.writeBufferDma + buf_off)
                             : (uint64_t)(bufferParams.writeBuffer + buf_off);
-          calculatePrps(addr, transfer_size, sqe);
+          calculatePrps(addr, transfer_size, sqe, prpSlot, prpSlotDma,
+                        bufferParams.writePagePhysAddrs, pageOff);
           prp_valid = true;
         }
       }
@@ -511,20 +530,39 @@ __device__ static void driveEndpointWavefront(
         uint64_t buf_off = (uint64_t)b * transfer_size;
         bool prp_valid = false;
 
+        uint32_t prpOff = b * bufferParams.prpEntriesPerCmd;
+        uint64_t* prpSlot = bufferParams.prpListPool
+                              ? bufferParams.prpListPool + prpOff
+                              : nullptr;
+        uint64_t prpSlotDma = bufferParams.prpListPoolDma
+                                ? bufferParams.prpListPoolDma +
+                                    prpOff * sizeof(uint64_t)
+                                : 0;
+        uint32_t pageOff = (uint32_t)(buf_off / NVME_PAGE_SIZE);
+        uint64_t intraPageOff = buf_off % NVME_PAGE_SIZE;
+
         if (is_read_op && has_read_buffer) {
           if (buf_off + transfer_size <= bufferParams.bufferSize) {
-            uint64_t addr = bufferParams.readBufferDma
+            uint64_t addr = bufferParams.readPagePhysAddrs
+                              ? bufferParams.readPagePhysAddrs[pageOff] +
+                                  intraPageOff
+                            : bufferParams.readBufferDma
                               ? (bufferParams.readBufferDma + buf_off)
                               : (uint64_t)(bufferParams.readBuffer + buf_off);
-            calculatePrps(addr, transfer_size, sqe);
+            calculatePrps(addr, transfer_size, sqe, prpSlot, prpSlotDma,
+                          bufferParams.readPagePhysAddrs, pageOff);
             prp_valid = true;
           }
         } else if (!is_read_op && has_write_buffer) {
           if (buf_off + transfer_size <= bufferParams.bufferSize) {
-            uint64_t addr = bufferParams.writeBufferDma
+            uint64_t addr = bufferParams.writePagePhysAddrs
+                              ? bufferParams.writePagePhysAddrs[pageOff] +
+                                  intraPageOff
+                            : bufferParams.writeBufferDma
                               ? (bufferParams.writeBufferDma + buf_off)
                               : (uint64_t)(bufferParams.writeBuffer + buf_off);
-            calculatePrps(addr, transfer_size, sqe);
+            calculatePrps(addr, transfer_size, sqe, prpSlot, prpSlotDma,
+                          bufferParams.writePagePhysAddrs, pageOff);
             prp_valid = true;
           }
         }
@@ -1087,6 +1125,46 @@ __host__ hipError_t run(XioEndpointConfig* config) {
   std::vector<hipStream_t> streams(numQueues, nullptr);
   std::vector<XioTimingStats*> perQueueStats(numQueues, nullptr);
 
+  uint64_t xfer_size = (uint64_t)nvmeConfig->ioParams.lbasPerIo *
+                       nvmeConfig->ioParams.lbaSize;
+  constexpr uint32_t kMaxPrpListEntries = NVME_PAGE_SIZE / sizeof(uint64_t);
+  uint32_t xfer_pages = (uint32_t)((xfer_size + NVME_PAGE_SIZE - 1) /
+                                   NVME_PAGE_SIZE);
+  if (xfer_pages > kMaxPrpListEntries + 1) {
+    ROCXIO_LOG_ERROR("Transfer size %llu bytes (%u pages) "
+                     "exceeds single PRP list page limit "
+                     "(%u + 1 pages). Reduce --lbas-per-io.\n",
+                     (unsigned long long)xfer_size, xfer_pages,
+                     kMaxPrpListEntries);
+    return hipErrorInvalidValue;
+  }
+  uint32_t prpEntriesPerCmd = (xfer_size > NVME_PAGE_SIZE)
+                                ? (uint32_t)((xfer_size / NVME_PAGE_SIZE) + 1)
+                                : 0;
+  uint32_t prpStridePerCmd = prpEntriesPerCmd;
+  if (prpStridePerCmd > 0) {
+    uint32_t s = 1;
+    while (s < prpStridePerCmd)
+      s <<= 1;
+    prpStridePerCmd = s;
+  }
+  uint32_t prpPoolEntriesPerQueue = prpStridePerCmd * effBatch;
+  size_t prpPoolBytes = (size_t)prpPoolEntriesPerQueue * sizeof(uint64_t);
+  long sys_page_sz = sysconf(_SC_PAGESIZE);
+  size_t host_page = (sys_page_sz > 0) ? (size_t)sys_page_sz : 4096;
+  if (prpPoolBytes > 0) {
+    prpPoolBytes = (prpPoolBytes + host_page - 1) & ~(host_page - 1);
+  }
+
+  struct PrpPool {
+    void* ptr = nullptr;
+    void* gpuPtr = nullptr;
+    uint64_t dma = 0;
+    size_t size = 0;
+    bool hipAllocated = false;
+  };
+  std::vector<PrpPool> prpPools(numQueues);
+
   // Allocate per-queue timing stats when forcing
   // less-timing or when the caller already set up
   // less-timing mode (timingStats != null).
@@ -1230,6 +1308,48 @@ __host__ hipError_t run(XioEndpointConfig* config) {
       }
     }
 
+    if (prpPoolBytes > 0) {
+      void* pool = nullptr;
+      hipError_t alloc_err = hipHostMalloc(&pool, prpPoolBytes,
+                                           hipHostMallocMapped);
+      if (alloc_err != hipSuccess || !pool) {
+        ROCXIO_LOG_ERROR("Failed to allocate PRP list pool "
+                         "for queue %u: %s\n",
+                         qid, hipGetErrorString(alloc_err));
+        result = hipErrorMemoryAllocation;
+        goto cleanup;
+      }
+      memset(pool, 0, prpPoolBytes);
+
+      uint64_t pool_dma = getPhysAddr(pool);
+      if (pool_dma == 0) {
+        ROCXIO_LOG_ERROR("Failed to get PRP pool phys addr "
+                         "for queue %u\n",
+                         qid);
+        (void)hipHostFree(pool);
+        result = hipErrorInvalidValue;
+        goto cleanup;
+      }
+
+      void* gpu_pool = nullptr;
+      (void)hipHostGetDevicePointer(&gpu_pool, pool, 0);
+      if (!gpu_pool) {
+        gpu_pool = pool;
+      }
+
+      prpPools[q].ptr = pool;
+      prpPools[q].gpuPtr = gpu_pool;
+      prpPools[q].dma = pool_dma;
+      prpPools[q].size = prpPoolBytes;
+      prpPools[q].hipAllocated = true;
+
+      ROCXIO_LOG_INFO("  PRP pool queue %u: virt=%p "
+                      "gpu=%p phys=0x%016llx (%zu bytes, "
+                      "%u entries/cmd)\n",
+                      qid, pool, gpu_pool, (unsigned long long)pool_dma,
+                      prpPoolBytes, prpEntriesPerCmd);
+    }
+
     // Create HIP stream for this queue
     if (numQueues > 1) {
       hipError_t s_err = hipStreamCreate(&streams[q]);
@@ -1253,7 +1373,7 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     qDoorbellParams.nvmeBar0Gpu = nvmeBar0Gpu;
     qDoorbellParams.usePciMmioBridge = usePciMmioBridge;
 
-    nvme_ep::nvmeBufferParams qBufParams;
+    nvme_ep::nvmeBufferParams qBufParams = {};
     qBufParams.readBuffer = readBufs[q].gpuPtr
                               ? static_cast<uint8_t*>(readBufs[q].gpuPtr)
                               : static_cast<uint8_t*>(readBufs[q].hostPtr);
@@ -1263,6 +1383,15 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     qBufParams.bufferSize = nvmeConfig->bufferParams.bufferSize;
     qBufParams.readBufferDma = readBufs[q].dmaAddr;
     qBufParams.writeBufferDma = writeBufs[q].dmaAddr;
+    qBufParams.readPagePhysAddrs = readBufs[q].pagePhysAddrs;
+    qBufParams.writePagePhysAddrs = writeBufs[q].pagePhysAddrs;
+    qBufParams.readNumPages = readBufs[q].numPages;
+    qBufParams.writeNumPages = writeBufs[q].numPages;
+    qBufParams.prpListPool = prpPools[q].gpuPtr
+                               ? static_cast<uint64_t*>(prpPools[q].gpuPtr)
+                               : static_cast<uint64_t*>(prpPools[q].ptr);
+    qBufParams.prpListPoolDma = prpPools[q].dma;
+    qBufParams.prpEntriesPerCmd = prpStridePerCmd;
 
     XioEndpointConfig kernelConfig = *config;
     kernelConfig.endpointConfig = nullptr;
@@ -1388,6 +1517,13 @@ cleanup:
       ROCXIO_LOG_WARN("Could not reopen NVMe "
                       "device for queue cleanup: %s\n",
                       strerror(errno));
+    }
+  }
+
+  // Free per-queue PRP list pools
+  for (uint16_t q = 0; q < numQueues; q++) {
+    if (prpPools[q].ptr && prpPools[q].hipAllocated) {
+      (void)hipHostFree(prpPools[q].ptr);
     }
   }
 

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -597,6 +597,8 @@ struct xioBufferInfo {
   void* gpuPtr;
   uint64_t dmaAddr;
   bool isDeviceMemory;
+  uint64_t* pagePhysAddrs;
+  uint32_t numPages;
 };
 
 /**

--- a/tests/system/nvme-ep/CMakeLists.txt
+++ b/tests/system/nvme-ep/CMakeLists.txt
@@ -28,19 +28,13 @@ set(_xio_tester
 
 # --- Sequential data verification -----------------------
 
-# Known failure: MEMORY_MODE=0 (host memory) with
-# lbas-per-io > page_size/lba_size uses linear DMA
-# address arithmetic (writeBufferDma + offset) which
-# breaks across page boundaries because hipHostMalloc
-# does not guarantee physical contiguity.  The NVMe
-# controller reads stale data from the wrong physical
-# page for commands beyond the first.  Device memory
-# modes (8, 11) are unaffected because GPU VRAM is
-# physically contiguous.
+# Host memory with PRP list support: per-page physical
+# addresses are resolved via pagemap so multi-LBA
+# transfers across non-contiguous pages work correctly.
 xio_add_script_test(
   NAME nvme-verify-seq-host-mem
   SCRIPT ${_verify_wrapper}
-  LABELS hardware nvme verify known-fail
+  LABELS hardware nvme verify
   TIMEOUT 120
   ARGS ${_seq_script}
   ENVIRONMENT
@@ -50,8 +44,6 @@ xio_add_script_test(
     "USE_PCI_MMIO_BRIDGE=0"
     "XIO_TESTER=${_xio_tester}"
 )
-set_tests_properties(nvme-verify-seq-host-mem
-  PROPERTIES DISABLED TRUE)
 
 xio_add_script_test(
   NAME nvme-verify-seq-device-mem
@@ -220,6 +212,76 @@ xio_add_script_test(
   ARGS ${_smoke_common}
     -m 3 --less-timing --batch-size 4
   ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+# --- Multi-LBA PRP list smoke tests ---------------------
+# Exercise PRP list construction for transfers spanning
+# more than two NVMe pages.  Uses device memory (VRAM)
+# which is physically contiguous.
+
+set(_smoke_multi_lba
+  --access-pattern random --lfsr-seed 42
+  --read-io 16 --queue-length 128)
+
+xio_add_script_test(
+  NAME nvme-smoke-lbas-per-io-8-device
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme smoke
+  TIMEOUT 30
+  ARGS ${_smoke_multi_lba}
+    --lbas-per-io 8 -m 8
+    --data-buffer-size 524288
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-smoke-lbas-per-io-32-device
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme smoke
+  TIMEOUT 30
+  ARGS ${_smoke_multi_lba}
+    --lbas-per-io 32 -m 8
+    --data-buffer-size 2097152
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-smoke-lbas-per-io-8-host
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme smoke
+  TIMEOUT 30
+  ARGS ${_smoke_multi_lba}
+    --lbas-per-io 8 -m 0
+    --data-buffer-size 524288
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-smoke-lbas-per-io-32-host
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme smoke
+  TIMEOUT 30
+  ARGS ${_smoke_multi_lba}
+    --lbas-per-io 32 -m 0
+    --data-buffer-size 2097152
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+# Multi-LBA data verification with device memory
+xio_add_script_test(
+  NAME nvme-verify-seq-device-mem-multi-lba
+  SCRIPT ${_verify_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 120
+  ARGS ${_seq_script}
+  ENVIRONMENT
+    "MEMORY_MODE=8"
+    "WRITE_IO=4"
+    "BLOCKS_PER_CMD=32"
+    "LFSR_SEED=0xCAFE"
+    "BASE_LBA=2048"
+    "USE_PCI_MMIO_BRIDGE=0"
+    "XIO_TESTER=${_xio_tester}"
 )
 
 # --- Negative tests (expected failures) -----------------

--- a/tests/unit/nvme-ep/test-nvme-helpers.hip
+++ b/tests/unit/nvme-ep/test-nvme-helpers.hip
@@ -598,6 +598,146 @@ int test_dataPattern_corruption_at_lba_boundary() {
   return 0;
 }
 
+/* ---- PRP list tests (7-arg calculatePrps) ---- */
+
+int test_prp_list_three_pages_contiguous() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {};
+  uint64_t addr = 0x100000;
+  uint32_t size = 3 * NVME_PAGE_SIZE;
+
+  calculatePrps(addr, size, &sqe, prpList, 0xDEAD000, nullptr, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xDEAD000);
+  ASSERT_EQ(prpList[0], (uint64_t)0x101000);
+  ASSERT_EQ(prpList[1], (uint64_t)0x102000);
+  return 0;
+}
+
+int test_prp_list_eight_pages_contiguous() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[16] = {};
+  uint64_t addr = 0x200000;
+  uint32_t size = 8 * NVME_PAGE_SIZE;
+
+  calculatePrps(addr, size, &sqe, prpList, 0xBEEF000, nullptr, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xBEEF000);
+  for (uint32_t i = 0; i < 7; i++) {
+    ASSERT_EQ(prpList[i], (uint64_t)(0x201000 + i * NVME_PAGE_SIZE));
+  }
+  return 0;
+}
+
+int test_prp_list_unaligned_four_pages() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {};
+  uint64_t addr = 0x300800;
+  uint32_t first_page = NVME_PAGE_SIZE - 0x800;
+  uint32_t size = first_page + 3 * NVME_PAGE_SIZE;
+
+  calculatePrps(addr, size, &sqe, prpList, 0xAAA000, nullptr, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xAAA000);
+  ASSERT_EQ(prpList[0], (uint64_t)0x301000);
+  ASSERT_EQ(prpList[1], (uint64_t)0x302000);
+  ASSERT_EQ(prpList[2], (uint64_t)0x303000);
+  return 0;
+}
+
+int test_prp_list_noncontiguous_pages() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {};
+  uint64_t pageAddrs[4] = {0xA0000, 0xC0000, 0xE0000, 0x120000};
+  uint32_t size = 4 * NVME_PAGE_SIZE;
+
+  calculatePrps(pageAddrs[0], size, &sqe, prpList, 0xFFF000, pageAddrs, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, (uint64_t)0xA0000);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xFFF000);
+  ASSERT_EQ(prpList[0], (uint64_t)0xC0000);
+  ASSERT_EQ(prpList[1], (uint64_t)0xE0000);
+  ASSERT_EQ(prpList[2], (uint64_t)0x120000);
+  return 0;
+}
+
+int test_prp_list_noncontiguous_two_pages() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {};
+  uint64_t pageAddrs[2] = {0x50000, 0x90000};
+  uint32_t size = 2 * NVME_PAGE_SIZE;
+
+  calculatePrps(pageAddrs[0], size, &sqe, prpList, 0, pageAddrs, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, (uint64_t)0x50000);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0x90000);
+  return 0;
+}
+
+int test_prp_list_single_page_no_list() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {0xBB};
+  uint64_t pageAddrs[1] = {0x70000};
+  uint32_t size = 512;
+
+  calculatePrps(pageAddrs[0], size, &sqe, prpList, 0, pageAddrs, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, (uint64_t)0x70000);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0);
+  ASSERT_EQ(prpList[0], (uint64_t)0xBB);
+  return 0;
+}
+
+int test_prp_list_contiguous_with_offset() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {};
+  uint64_t addr = 0x403000;
+  uint32_t size = 3 * NVME_PAGE_SIZE;
+
+  calculatePrps(addr, size, &sqe, prpList, 0xCC0000, nullptr, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xCC0000);
+  ASSERT_EQ(prpList[0], (uint64_t)0x404000);
+  ASSERT_EQ(prpList[1], (uint64_t)0x405000);
+  return 0;
+}
+
+int test_prp_list_max_transfer_32_pages() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[64] = {};
+  uint64_t addr = 0x500000;
+  uint32_t size = 32 * NVME_PAGE_SIZE;
+
+  calculatePrps(addr, size, &sqe, prpList, 0xDD0000, nullptr, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xDD0000);
+  for (uint32_t i = 0; i < 31; i++) {
+    ASSERT_EQ(prpList[i], (uint64_t)(0x501000 + i * NVME_PAGE_SIZE));
+  }
+  return 0;
+}
+
+int test_prp_list_noncontiguous_page_offset() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[8] = {};
+  uint64_t pageAddrs[8] = {0x10000, 0x30000, 0x50000, 0x70000,
+                           0x90000, 0xB0000, 0xD0000, 0xF0000};
+  uint32_t size = 3 * NVME_PAGE_SIZE;
+
+  calculatePrps(pageAddrs[4], size, &sqe, prpList, 0xEE0000, pageAddrs, 4);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, (uint64_t)0x90000);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0xEE0000);
+  ASSERT_EQ(prpList[0], (uint64_t)0xB0000);
+  ASSERT_EQ(prpList[1], (uint64_t)0xD0000);
+  return 0;
+}
+
 int main() {
   int failures = 0;
 
@@ -612,6 +752,16 @@ int main() {
   failures += test_prp_unaligned_within_page();
   failures += test_prp_at_page_boundary();
   failures += test_prp_two_full_pages();
+
+  failures += test_prp_list_three_pages_contiguous();
+  failures += test_prp_list_eight_pages_contiguous();
+  failures += test_prp_list_unaligned_four_pages();
+  failures += test_prp_list_noncontiguous_pages();
+  failures += test_prp_list_noncontiguous_two_pages();
+  failures += test_prp_list_single_page_no_list();
+  failures += test_prp_list_contiguous_with_offset();
+  failures += test_prp_list_max_transfer_32_pages();
+  failures += test_prp_list_noncontiguous_page_offset();
 
   failures += test_cqeOk_success();
   failures += test_cqeOk_success_with_phase();


### PR DESCRIPTION
Previously calculatePrps() only handled transfers spanning at most two 4KB NVMe pages, silently producing incorrect PRP2 values for larger transfers.  This limited --lbas-per-io to 16 (512B LBAs) or 2 (4KB LBAs) before data corruption would occur.

Add full PRP list support per NVMe spec section 4.4:
- Transfers <= 1 page: PRP1 only (unchanged)
- Transfers <= 2 pages: PRP1 + PRP2 direct (unchanged)
- Transfers > 2 pages: PRP1 + PRP2 points to a PRP list (page-aligned array of physical page addresses)

For device memory (VRAM), PRP list entries are computed arithmetically from the contiguous DMA base address.  For host memory, per-page physical addresses are resolved via /proc/self/pagemap at buffer allocation time, fixing the documented known-fail for non-contiguous hipHostMalloc pages.

Implementation details:
- Extend xioBufferInfo with pagePhysAddrs/numPages for per-page physical address tracking (GPU-accessible via hipHostMalloc)
- Extend nvmeBufferParams with PRP list pool pointers and per-page physical address arrays passed to GPU kernels
- Add 7-argument calculatePrps() overload that builds PRP lists; retain 3-argument overload for backward compatibility
- Allocate per-queue PRP list pools as pinned host memory (hipHostMalloc + hipHostMallocMapped) sized for batch depth
- Update both driveEndpoint (single-threaded) and gpuKernel (multi-threaded) call sites to use PRP list-aware path
- Resolve per-page physical addresses for host-memory data buffers in allocateGpuAccessibleBuffer via getPagePhysAddrs

Tests:
- 9 new unit tests covering 3-page, 8-page, 32-page contiguous, non-contiguous, unaligned, and page-offset PRP list construction
- 5 new system smoke/verify tests for multi-LBA transfers (8 and 32 LBAs/IO) in both host and device memory modes
- Re-enable nvme-verify-seq-host-mem (previously disabled as known-fail due to host memory non-contiguity)
- Add LBAS_PER_IO env var to benchmark script

No kernel module changes required: all PRP list and page physical addresses are resolved to real physical addresses in userspace.
