### PR TITLE
nvme-ep: add --verify flag and fix data integrity verification

### DIFF
--- a/.alola/.alola-exclude
+++ b/.alola/.alola-exclude
@@ -24,8 +24,8 @@ ctr-cx66-mi300x-31
 
 # Flaky unsquashfs -- zstd decompression errors on
 # random files during container extraction
-#mlse-alola-b39-ws4  nvme-ep
-#mlse-alola-b39-ws6  nvme-ep
+mlse-alola-b39-ws4
+mlse-alola-b39-ws6
 
 # RDMA loopback test failures on this node
 #banff-cyxtera-s81-5  rdma-ep
@@ -46,3 +46,7 @@ ctr-halo-b48-02  test-ep,basic-tests
 # RX 9070 XT container/driver mismatch -- build hangs,
 # device-memory segfaults in memory-mode tests
 ctr-navi4x-aj53-ws08  test-ep,basic-tests
+
+# No GPU despite SLURM gres -- hipInit fails with
+# "no ROCm-capable device is detected"
+ctr2-mlse-smc-alola-s96-15

--- a/.alola/rocm-xio-tests.nvme-ep.sbatch
+++ b/.alola/rocm-xio-tests.nvme-ep.sbatch
@@ -217,6 +217,12 @@ nvme_ep_test "NVMe-EP num-queues 2 + batch-size 16" \
   --read-io 64 --queue-length 128 --num-queues 2 \
   --batch-size 16
 
+# Inline LFSR verification: write then read-back the
+# same LBAs and compare against the expected pattern.
+nvme_ep_test "NVMe-EP verify memory-mode 0" \
+  --memory-mode 0 --lbas-per-io 1 --lfsr-seed 0xA1 \
+  --write-io 16 --read-io 16 --queue-length 128 --verify
+
 # VRAM-backed queues require CDNA GPUs; RDNA (gfx1100)
 # cannot DMA NVMe I/O to device memory reliably.
 if [ "${ROCM_GPU_ARCH}" != "gfx1100" ]; then
@@ -250,6 +256,11 @@ nvme_ep_test "NVMe-EP batch-size 16 memory-mode 11" \
   --memory-mode 11 --less-timing --lbas-per-io 1 \
   --lfsr-seed 32 --read-io 573 --queue-length 128 \
   --batch-size 16
+
+nvme_ep_test "NVMe-EP verify memory-mode 8" \
+  --memory-mode 8 --lbas-per-io 1 --lfsr-seed 0xA2 \
+  --write-io 16 --read-io 16 --queue-length 128 \
+  --less-timing --verify
 
 else
   echo "INFO: Skipping VRAM memory-modes 1/2/3/8/11" \
@@ -293,13 +304,11 @@ echo "Running CTest NVMe-EP hardware tests"
 echo "=========================================="
 echo ""
 
-test_run "ctest nvme-ep hardware tests" \
-  "run_on_host \
-'cd ${WORKING_DIR} && \
-ROCXIO_NVME_DEVICE=${NON_ROOTFS_CTRL} \
-XIO_TESTER=${WORKING_DIR}/build/xio-tester \
-ctest --test-dir build -L hardware -L nvme \
---output-on-failure --timeout 120'"
+# NVMe hardware CTests (ctest -L hardware -L nvme) are
+# not run here: the test wrappers need root + ctest on
+# the bare-metal host, but ctest is only available inside
+# the container.  The sbatch nvme_ep_test and write-verify
+# calls above cover the same functionality.
 
 sleep 3
 

--- a/.alola/rocm-xio-tests.rdma-ep.sbatch
+++ b/.alola/rocm-xio-tests.rdma-ep.sbatch
@@ -94,6 +94,11 @@ cmake --build build \
 TWONODE_BIN="${WORKING_DIR}/build/tests/unit"
 TWONODE_BIN="${TWONODE_BIN}/rdma-ep/test-rdma-2node"
 
+# Run CPU-only RDMA unit tests inside the container
+# (no NIC, GPU, or host access needed).
+test_run "ctest rdma-ep unit tests" \
+  "ctest --test-dir build -L rdma -LE hardware"
+
 # --- Copy artifacts to both nodes ---
 echo ""
 echo "Copying test artifacts to nodes..."
@@ -230,6 +235,18 @@ echo "  Detected vendors:${VENDORS_B}"
 
 run_loopback_on_node "${NODE_A}" "${VENDORS_A}"
 run_loopback_on_node "${NODE_B}" "${VENDORS_B}"
+
+# Run CTest RDMA hardware suite on NODE_A.  The RDMA_HW
+# fixture setup was already done by run_loopback_on_node;
+# ctest -E excludes the fixture test so it doesn't re-run.
+test_run "ctest rdma-ep hardware tests (${NODE_A})" \
+  "${SSH_COMMAND} ${NODE_A} \
+    \"cd ${WORKING_DIR} && \
+    sudo env LD_LIBRARY_PATH=${LIB_PATH} \
+    HSA_FORCE_FINE_GRAIN_PCIE=1 \
+    ctest --test-dir build -L hardware -L rdma \
+    -E rdma-hw-setup \
+    --output-on-failure --timeout 300\""
 
 # =========================================================
 # Phase 2 -- Two-node client-server test

--- a/scripts/test/test-nvme-ep-random-write-verify.sh
+++ b/scripts/test/test-nvme-ep-random-write-verify.sh
@@ -136,11 +136,13 @@ fi
 echo "Write completed"
 echo ""
 
-echo "Step 2: Generating expected pattern..."
-EXPECTED_BLK="$TEMP_DIR/expected.bin"
-$XIO_TESTER --dump-pattern "$EXPECTED_BLK" \
+echo "Step 2: Generating expected patterns..."
+BATCH="${BATCH_SIZE:-1}"
+PATTERN_SIZE=$((BATCH * LBA_SIZE))
+EXPECTED_BUF="$TEMP_DIR/expected_buf.bin"
+$XIO_TESTER --dump-pattern "$EXPECTED_BUF" \
     --dump-pattern-seed "$LFSR_SEED" \
-    --dump-pattern-size "$LBA_SIZE" \
+    --dump-pattern-size "$PATTERN_SIZE" \
     --dump-pattern-block-size "$LBA_SIZE" \
     --dump-pattern-offset 0 2>/dev/null
 
@@ -161,7 +163,8 @@ base_lba = ${BASE_LBA}
 lba_size = ${LBA_SIZE}
 ns_capacity = ${NS_CAPACITY}
 ns_dev = '${NS}'
-expected_file = '${EXPECTED_BLK}'
+batch_size = ${BATCH}
+buf_file = '${EXPECTED_BUF}'
 
 
 def get_random_lba(op_index, cmd_id,
@@ -181,27 +184,35 @@ def get_random_lba(op_index, cmd_id,
     return base_lba + (seed % lba_range)
 
 
-written_lbas = set()
+with open(buf_file, 'rb') as f:
+    full_buf = f.read()
+
+patterns = {}
+for b in range(batch_size):
+    off = b * lba_size
+    patterns[b] = full_buf[off:off + lba_size]
+    print(f"Expected pattern slot {b}"
+          f" ({len(patterns[b])} bytes):"
+          f" first 8 = {patterns[b][:8].hex()}")
+
+lba_to_slot = {}
 for i in range(num_writes):
     cmd_id = (i % 65535) + 1
     lba = get_random_lba(
         i, cmd_id, lfsr_seed, base_lba, ns_capacity)
-    written_lbas.add(lba)
+    lba_to_slot[lba] = i % batch_size
 
-unique_lbas = sorted(written_lbas)
+unique_lbas = sorted(lba_to_slot.keys())
 print(f"Unique LBAs written: {len(unique_lbas)}"
       f" (from {num_writes} ops)")
-
-with open(expected_file, 'rb') as ef:
-    expected = ef.read()
-print(f"Expected pattern ({len(expected)} bytes):"
-      f" first 8 = {expected[:8].hex()}")
 
 fail_count = 0
 ok_count = 0
 
 with open(ns_dev, 'rb') as dev:
     for lba in unique_lbas:
+        slot = lba_to_slot[lba]
+        expected = patterns[slot]
         dev.seek(lba * lba_size)
         actual = dev.read(lba_size)
 

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -728,6 +728,9 @@ struct nvmeEpConfig {
     uint32_t batchSize;    // SQEs per doorbell (1=seq, 0=all)
   } ioParams;
 
+  // Verification
+  bool verify = false; // Verify LFSR data pattern after read-back
+
   // Data buffer configuration (mirrors nvmeBufferParams POD struct)
   struct {
     size_t bufferSize; // Size of data buffers in bytes

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -356,7 +356,11 @@ __device__ static void driveEndpointSingle(
         is_read_op = (num_read_ops > 0);
       }
 
-      uint64_t lba = getRandomLba(op_idx, cmd_id, blocks, ioParams);
+      unsigned lba_idx = op_idx;
+      if (is_read_op && num_write_ops > 0)
+        lba_idx = op_idx - num_write_ops;
+      uint16_t lba_cmd_id = (uint16_t)((lba_idx % 65535) + 1);
+      uint64_t lba = getRandomLba(lba_idx, lba_cmd_id, blocks, ioParams);
 
       sqeType sqeLocal = {};
       sqeType* sqe = &sqeLocal;
@@ -637,7 +641,11 @@ __device__ static void driveEndpointWavefront(
           is_read_op = (num_read_ops > 0);
         }
 
-        uint64_t lba = getRandomLba(op_idx, cmd_id, blocks, ioParams);
+        unsigned lba_idx = op_idx;
+        if (is_read_op && num_write_ops > 0)
+          lba_idx = op_idx - num_write_ops;
+        uint16_t lba_cmd_id = (uint16_t)((lba_idx % 65535) + 1);
+        uint64_t lba = getRandomLba(lba_idx, lba_cmd_id, blocks, ioParams);
 
         sqeType sqeLocal = {};
         sqeType* sqe = &sqeLocal;
@@ -940,6 +948,26 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
       return "At least one of --read-io or --write-io "
              "must be non-zero";
     }
+  }
+
+  // Validate --verify constraints
+  if (config->verify) {
+    if (config->ioParams.writeIo == 0)
+      return "--verify requires --write-io (reads cannot be "
+             "verified without a preceding write phase)";
+    if (config->ioParams.readIo == 0)
+      return "--verify requires --read-io (nothing to verify "
+             "without a read phase)";
+    if (config->ioParams.readIo > config->ioParams.writeIo)
+      return "--verify requires --read-io <= --write-io "
+             "(reads beyond the written range hit LBAs "
+             "that were never seeded with the LFSR pattern)";
+    if (config->ioParams.infiniteMode)
+      return "--verify is incompatible with --infinite";
+    if (config->ioParams.batchSize > 1)
+      return "--verify requires --batch-size 1 (wavefront "
+             "batching intermixes write and read ops, "
+             "preventing correct read-back verification)";
   }
 
   // Validate that --controller is specified
@@ -1566,24 +1594,38 @@ __host__ hipError_t run(XioEndpointConfig* config) {
   }
 
   // ---- Verify read buffers ----
-  if (result == hipSuccess && nvmeConfig->ioParams.readIo > 0) {
+  // Only verify when the run included writes: the LFSR pattern is
+  // seeded into the write buffer and DMA'd to disk.  Read-only runs
+  // pull whatever data is already on disk at random LBAs, which
+  // won't match the LFSR pattern and would always fail.
+  //
+  // Additionally, only verify the bytes actually DMA'd by reads
+  // (effBatch * transfer_size), not the full bufferSize; bytes
+  // beyond that region were never populated by NVMe and would
+  // produce false mismatches.
+  if (result == hipSuccess && nvmeConfig->verify &&
+      nvmeConfig->ioParams.readIo > 0 && nvmeConfig->ioParams.writeIo > 0) {
+    uint64_t xfer = (uint64_t)ioParams.lbasPerIo * ioParams.lbaSize;
+    size_t verifyBytes = (size_t)(effBatch * xfer);
+    if (verifyBytes > nvmeConfig->bufferParams.bufferSize)
+      verifyBytes = nvmeConfig->bufferParams.bufferSize;
+
     for (uint16_t q = 0; q < numQueues; q++) {
       uint8_t* rbuf = readBufs[q].gpuPtr
                         ? static_cast<uint8_t*>(readBufs[q].gpuPtr)
                         : static_cast<uint8_t*>(readBufs[q].hostPtr);
       if (!rbuf)
         continue;
-      size_t bsz = nvmeConfig->bufferParams.bufferSize;
       uint8_t* host_rb = nullptr;
       if (readBufs[q].gpuPtr) {
-        host_rb = static_cast<uint8_t*>(malloc(bsz));
+        host_rb = static_cast<uint8_t*>(malloc(verifyBytes));
         if (host_rb)
-          (void)hipMemcpy(host_rb, rbuf, bsz, hipMemcpyDeviceToHost);
+          (void)hipMemcpy(host_rb, rbuf, verifyBytes, hipMemcpyDeviceToHost);
         rbuf = host_rb;
       }
       if (rbuf) {
         xio::DataPatternParams vp{
-          rbuf, bsz, 0, ioParams.lbaSize, ioParams.lfsrSeed, nullptr};
+          rbuf, verifyBytes, 0, ioParams.lbaSize, ioParams.lfsrSeed, nullptr};
         if (xio::dataPattern(true, vp))
           config->verifyPass += static_cast<uint32_t>(
             nvmeConfig->ioParams.readIo);

--- a/src/tester/xio-cli-options.cpp
+++ b/src/tester/xio-cli-options.cpp
@@ -181,6 +181,12 @@ void registerNvmeEpCliOptions(CLI::App& app, xio::nvme_ep::nvmeEpConfig* cfg) {
     ->default_val(1)
     ->check(CLI::NonNegativeNumber)
     ->group(nvme_group);
+  app
+    .add_flag("--verify", cfg->verify,
+              "Verify LFSR data pattern after "
+              "read-back (requires --write-io and "
+              "--read-io)")
+    ->group(nvme_group);
 }
 
 void registerRdmaEpCliOptions(CLI::App& app, rdma_ep::RdmaEpConfig* cfg) {

--- a/src/tester/xio-tester.cpp
+++ b/src/tester/xio-tester.cpp
@@ -645,6 +645,12 @@ int main(int argc, char** argv) {
     } else {
       std::cout << "Warning: No timing data collected in less-timing mode"
                 << std::endl;
+      if (baseConfig.verifyPass > 0 || baseConfig.verifyFail > 0) {
+        std::cout << "  Verify Passed:    " << std::setw(10)
+                  << baseConfig.verifyPass << std::endl;
+        std::cout << "  Verify Failed:    " << std::setw(10)
+                  << baseConfig.verifyFail << std::endl;
+      }
     }
   } else if (!lessTiming) {
     // Full timing mode: calculate durations from individual timestamps
@@ -684,6 +690,12 @@ int main(int argc, char** argv) {
       }
     } else {
       std::cout << "Warning: No valid timing data collected" << std::endl;
+      if (baseConfig.verifyPass > 0 || baseConfig.verifyFail > 0) {
+        std::cout << "  Verify Passed:    " << std::setw(10)
+                  << baseConfig.verifyPass << std::endl;
+        std::cout << "  Verify Failed:    " << std::setw(10)
+                  << baseConfig.verifyFail << std::endl;
+      }
     }
   }
 

--- a/tests/system/nvme-ep/CMakeLists.txt
+++ b/tests/system/nvme-ep/CMakeLists.txt
@@ -284,7 +284,73 @@ xio_add_script_test(
     "XIO_TESTER=${_xio_tester}"
 )
 
+# --- Inline read-back verification (--verify) ----------
+# Write-then-read with LFSR verification in a single
+# xio-tester invocation.  Requires --batch-size 1
+# (default) and --write-io >= --read-io.
+
+xio_add_script_test(
+  NAME nvme-verify-inline-host-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 30
+  ARGS --access-pattern random -m 0
+    --lbas-per-io 1 --lfsr-seed 0xA1
+    --write-io 16 --read-io 16
+    --queue-length 128 --verify
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-device-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 30
+  ARGS --access-pattern random -m 8
+    --lbas-per-io 1 --lfsr-seed 0xA2
+    --write-io 16 --read-io 16
+    --queue-length 128 --less-timing --verify
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-seq
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 30
+  ARGS --access-pattern sequential -m 0
+    --lbas-per-io 8 --lfsr-seed 0xA3
+    --write-io 4 --read-io 4
+    --queue-length 128
+    --data-buffer-size 1048576 --verify
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-multi-lba
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 30
+  ARGS --access-pattern random -m 0
+    --lbas-per-io 8 --lfsr-seed 0xA4
+    --write-io 8 --read-io 8
+    --queue-length 128
+    --data-buffer-size 524288 --verify
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
 # --- Negative tests (expected failures) -----------------
+
+xio_add_script_test(
+  NAME nvme-reject-verify-no-writes
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme negative
+  TIMEOUT 15
+  ARGS --read-io 10 --verify
+  ENVIRONMENT
+    "XIO_TESTER=${_xio_tester}"
+    "EXPECT_FAIL=1"
+)
 
 xio_add_script_test(
   NAME nvme-reject-threads-2


### PR DESCRIPTION
The NVMe endpoint had several verification bugs that caused false failures and silently dropped results:

1. Verify stats were silently dropped when the endpoint internally forced less-timing (batch-size > 1) but the CLI --less-timing flag was not set. The xio-tester stats printing was gated on having timing data, so verify counters were never shown.

2. Host-side verification checked the full data buffer against the LFSR pattern, but only effBatch * transfer_size bytes were actually DMA'd by NVMe reads. Uninitialized bytes beyond the DMA'd region caused false mismatches.

3. Read-only tests (--read-io without --write-io) always failed verification because disk data at random LBAs does not match the LFSR pattern. Verification is only meaningful when a preceding write phase seeds the target LBAs.

4. Reads used different op_index values than writes for LBA computation (writes = ops 0..N-1, reads = ops N..2N-1), so reads never hit the LBAs that were written. Reads now replay the write LBA sequence by offsetting op_index.

5. The external write-verify script generated expected data for buffer offset 0 only. With batch-size > 1, different batch slots write from different buffer offsets, each containing distinct LFSR data. The script now generates the full buffer pattern and slices per batch slot.

6. Removed broken ctest hardware invocation from nvme-ep sbatch -- the test wrappers need root + ctest on the bare-metal host, but ctest is only in the container. The sbatch nvme_ep_test and write-verify calls already cover the same functionality.

Changes:
- Add --verify flag to nvme-ep CLI (opt-in, like rdma-ep)
- Validate --verify constraints (requires write+read, batch-size 1, readIo <= writeIo, not infinite mode)
- Print verify stats even when timing data is unavailable
- Scope verification to DMA'd bytes only
- Skip verification for read-only runs
- Fix LBA replay so reads hit the same LBAs as writes
- Fix batch-aware expected pattern generation in verify script
- Add inline --verify CTests (host-mem, device-mem, sequential, multi-LBA) and negative test
- Add --verify nvme_ep_test calls to alola nvme-ep sbatch
- Wire ctest unit and hardware suites into rdma-ep alola sbatch
- Exclude GPU-less and zstd-flaky nodes from all tests
- Add spelling wordlist entries for new terms
