### PR TITLE
Refactor RDMA endpoint common helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,9 @@ install(FILES
 # Install endpoint headers
 foreach(ep ${VALID_ENDPOINTS})
     file(GLOB EP_HEADERS ${ENDPOINTS_DIR}/${ep}/*.h)
+    if(ep STREQUAL "rdma-ep")
+        list(FILTER EP_HEADERS EXCLUDE REGEX ".*/rdma-common\\.h$")
+    endif()
     if(EP_HEADERS)
         install(FILES ${EP_HEADERS}
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocm-xio/endpoints/${ep}

--- a/scripts/test/setup-rdma-loopback.sh
+++ b/scripts/test/setup-rdma-loopback.sh
@@ -16,6 +16,22 @@ set -euo pipefail
 
 VENDOR=${VENDOR:-all}
 
+require_named_netdev() {
+  local vendor="$1"
+  local nic_if="$2"
+
+  if [ -d "/sys/class/net/${nic_if}" ]; then
+    return 0
+  fi
+
+  echo "ERROR: expected ${vendor} net device '${nic_if}' not found."
+  echo "  Install and trigger the rocm-xio udev naming rules:"
+  echo "    sudo udev/setup-udev-rules.sh --install"
+  echo "    sudo udevadm trigger"
+  echo "  Then reload the ${vendor} RDMA driver or rerun this fixture."
+  return 1
+}
+
 setup_vendor() {
   local vendor="$1"
   local nic_if rdma_dev nic_ip
@@ -51,10 +67,12 @@ setup_vendor() {
       sleep 3
       modprobe bnxt_re
       sleep 5
+      require_named_netdev "${vendor}" "${nic_if}" || return 1
       ip link set "${nic_if}" up 2>/dev/null || true
       sleep 3
       ;;
     ionic)
+      require_named_netdev "${vendor}" "${nic_if}" || return 1
       local pci_bdf
       pci_bdf=$(basename "$(readlink -f \
         "/sys/class/net/${nic_if}/device" \

--- a/scripts/test/test-nvme-ep-data-verification.sh
+++ b/scripts/test/test-nvme-ep-data-verification.sh
@@ -29,6 +29,25 @@ XIO_TESTER="${XIO_TESTER:-./build/xio-tester}"
 TEMP_DIR="${TEMP_DIR:-/tmp/nvme-ep-test}"
 NVME_CMD="${NVME_CMD:-nvme}"
 
+resolve_nvme_paths() {
+    local device="$1"
+    local real
+    real="$(readlink -f "$device")" || return 1
+    local node
+    node="$(basename "$real")"
+
+    if [[ "$node" =~ ^nvme[0-9]+n[0-9]+$ ]]; then
+        local controller
+        controller="$(basename "$(readlink -f \
+            "/sys/class/block/$node/device")")" || return 1
+        NVME_CONTROLLER="/dev/$controller"
+        NVME_NAMESPACE="$device"
+    else
+        NVME_CONTROLLER="$real"
+        NVME_NAMESPACE="${device}n1"
+    fi
+}
+
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <nvme-controller> [OPTIONS]"
     echo ""
@@ -98,8 +117,7 @@ if ! command -v "$NVME_CMD" &> /dev/null; then
 fi
 
 get_lba_size() {
-    local device=$1
-    local ns="${device}n1"
+    local ns=$1
 
     local lbaf_line
     lbaf_line=$($NVME_CMD id-ns "$ns" 2>/dev/null \
@@ -133,16 +151,25 @@ get_lba_size() {
 
 test_device() {
     local device=$1
-    local ns="${device}n1"
+    local NVME_CONTROLLER=""
+    local NVME_NAMESPACE=""
+    if ! resolve_nvme_paths "$device"; then
+        echo "Error: failed to resolve NVMe paths for $device"
+        return 1
+    fi
+    local ns="$NVME_NAMESPACE"
+    local controller="$NVME_CONTROLLER"
     local device_name
     device_name=$(basename "$device")
 
     echo "========================================"
     echo "Testing NVMe: $device"
+    echo "Controller: $controller"
+    echo "Namespace: $ns"
     echo "========================================"
 
     local lba_size
-    lba_size=$(get_lba_size "$device")
+    lba_size=$(get_lba_size "$ns")
     echo "LBA size: $lba_size bytes"
 
     local total_blocks=$((WRITE_IO * BLOCKS_PER_CMD))
@@ -160,7 +187,7 @@ test_device() {
     if [ "$WRITE_IO" -gt 0 ]; then
         write_cmd="$write_cmd --write-io $WRITE_IO"
     fi
-    write_cmd="$write_cmd --controller $device"
+    write_cmd="$write_cmd --controller $controller"
     if [ "$USE_PCI_MMIO_BRIDGE" = "1" ]; then
         write_cmd="$write_cmd --pci-mmio-bridge"
     fi
@@ -171,6 +198,9 @@ test_device() {
     write_cmd="$write_cmd --access-pattern sequential"
     write_cmd="$write_cmd --batch-size 0"
     write_cmd="$write_cmd -m $MEMORY_MODE"
+    if [ -n "${ROCXIO_NVME_QUEUE_ID:-}" ]; then
+        write_cmd="$write_cmd --queue-id $ROCXIO_NVME_QUEUE_ID"
+    fi
 
     echo "Command: $write_cmd"
 

--- a/scripts/test/test-nvme-ep-random-write-verify.sh
+++ b/scripts/test/test-nvme-ep-random-write-verify.sh
@@ -29,6 +29,25 @@ NUM_QUEUES="${NUM_QUEUES:-}"
 XIO_TESTER="${XIO_TESTER:-./build/xio-tester}"
 TEMP_DIR="${TEMP_DIR:-/tmp/nvme-ep-rw-verify}"
 
+resolve_nvme_paths() {
+    local device="$1"
+    local real
+    real="$(readlink -f "$device")" || return 1
+    local node
+    node="$(basename "$real")"
+
+    if [[ "$node" =~ ^nvme[0-9]+n[0-9]+$ ]]; then
+        local controller
+        controller="$(basename "$(readlink -f \
+            "/sys/class/block/$node/device")")" || return 1
+        NVME_CONTROLLER="/dev/$controller"
+        NVME_NAMESPACE="$device"
+    else
+        NVME_CONTROLLER="$real"
+        NVME_NAMESPACE="${device}n1"
+    fi
+}
+
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <nvme-controller>"
     echo ""
@@ -81,7 +100,14 @@ if ! command -v python3 &>/dev/null; then
     exit 1
 fi
 
-NS="${NVME_DEVICE}n1"
+NVME_CONTROLLER=""
+NVME_NAMESPACE=""
+if ! resolve_nvme_paths "$NVME_DEVICE"; then
+    echo "Error: failed to resolve NVMe paths for $NVME_DEVICE"
+    exit 1
+fi
+
+NS="$NVME_NAMESPACE"
 if [ ! -e "$NS" ]; then
     echo "Error: namespace $NS not found"
     exit 1
@@ -96,7 +122,7 @@ NS_CAPACITY=$((NS_BYTES / LBA_SIZE))
 echo "========================================"
 echo "Random write-verify test"
 echo "========================================"
-echo "Controller:    $NVME_DEVICE"
+echo "Controller:    $NVME_CONTROLLER"
 echo "Namespace:     $NS"
 echo "LFSR seed:     $LFSR_SEED"
 echo "Base LBA:      $BASE_LBA"
@@ -111,7 +137,7 @@ echo ""
 echo "Step 1: Writing $NUM_WRITES random LBAs..."
 write_cmd="$XIO_TESTER nvme-ep"
 write_cmd="$write_cmd --write-io ${NUM_WRITES}"
-write_cmd="$write_cmd --controller $NVME_DEVICE"
+write_cmd="$write_cmd --controller $NVME_CONTROLLER"
 write_cmd="$write_cmd --access-pattern random"
 write_cmd="$write_cmd --lbas-per-io 1"
 write_cmd="$write_cmd --lfsr-seed $LFSR_SEED"
@@ -123,6 +149,9 @@ if [ -n "$BATCH_SIZE" ]; then
 fi
 if [ -n "$NUM_QUEUES" ]; then
     write_cmd="$write_cmd --num-queues $NUM_QUEUES"
+fi
+if [ -n "${ROCXIO_NVME_QUEUE_ID:-}" ]; then
+    write_cmd="$write_cmd --queue-id $ROCXIO_NVME_QUEUE_ID"
 fi
 
 echo "Command: $write_cmd"

--- a/scripts/test/test-rdma-ep-write-bw-loopback.sh
+++ b/scripts/test/test-rdma-ep-write-bw-loopback.sh
@@ -166,6 +166,14 @@ if grep -qi "Couldn't create QP\|create_qp\|Failed to modify QP" \
     exit 77
 fi
 
+if grep -qi "Port number .* state is Down\|Couldn't set the link layer\|Couldn't get context for the device" \
+    "$SRV_LOG" "$CLT_LOG" 2>/dev/null; then
+    echo "SKIP: ib_write_bw cannot open the RDMA port" \
+        "while loopback mode is active" \
+        "(GDA RDMA WRITE loopback is covered by rdma-ep tests)"
+    exit 77
+fi
+
 echo "FAILED: ib_write_bw loopback" \
     "(server=$SERVER_RC, client=$CLIENT_RC)"
 exit 1

--- a/scripts/test/test-xio-tester-nvme-ep.sh
+++ b/scripts/test/test-xio-tester-nvme-ep.sh
@@ -30,6 +30,9 @@ EXTRA_FLAGS=()
 if [ "${INFINITE}" = "true" ]; then
   EXTRA_FLAGS+=(--infinite)
 fi
+if [ -n "${ROCXIO_NVME_QUEUE_ID:-}" ]; then
+  EXTRA_FLAGS+=(--queue-id "${ROCXIO_NVME_QUEUE_ID}")
+fi
 
 sudo LD_LIBRARY_PATH=/opt/rocm/lib \
   HSA_FORCE_FINE_GRAIN_PCIE=1 \

--- a/scripts/test/test-xio-tester-rdma-ep.sh
+++ b/scripts/test/test-xio-tester-rdma-ep.sh
@@ -45,6 +45,7 @@ if [ -z "${VENDOR:-}" ]; then
   fi
 fi
 
+RDMA_DEVICE="${ROCXIO_RDMA_DEVICE:-rocm-rdma-${VENDOR}0}"
 NIC="rocm-${VENDOR}0"
 
 # Loopback IP per vendor (matches
@@ -88,7 +89,7 @@ sudo LD_LIBRARY_PATH="${LIB}" \
 HSA_FORCE_FINE_GRAIN_PCIE=1 \
 "${BUILD_DIR}/xio-tester" rdma-ep \
   --provider "${VENDOR}" \
-  --device "rocm-rdma-${VENDOR}0" \
+  --device "${RDMA_DEVICE}" \
   --loopback \
   --iterations "${ITERATIONS}" \
   --batch-size "${BATCH_SIZE}" \

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -1319,11 +1319,10 @@ __host__ int detectEmulatedNvme(const char* device_path,
   *is_emulated_out = is_emulated;
 
   std::cout << "NVMe controller " << device_path << " ("
-            << nvme_path.controllerPath << ", PCI " << pci_addr
-            << "): VID=0x" << std::hex << std::setfill('0') << std::setw(4)
-            << vendor_id << ", DID=0x" << std::setw(4) << device_id << std::dec
-            << " -> " << (is_emulated ? "EMULATED" : "PASSTHROUGH")
-            << std::endl;
+            << nvme_path.controllerPath << ", PCI " << pci_addr << "): VID=0x"
+            << std::hex << std::setfill('0') << std::setw(4) << vendor_id
+            << ", DID=0x" << std::setw(4) << device_id << std::dec << " -> "
+            << (is_emulated ? "EMULATED" : "PASSTHROUGH") << std::endl;
 
   return 0;
 }

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -1056,23 +1056,96 @@ int detectPciMmioBridgeBdf(uint16_t* bdf_out) {
   return 0;
 }
 
+static std::string xioBasename(const std::string& path) {
+  size_t slash = path.find_last_of('/');
+  if (slash == std::string::npos)
+    return path;
+  return path.substr(slash + 1);
+}
+
+static bool isNvmeNamespaceName(const std::string& name) {
+  if (name.rfind("nvme", 0) != 0)
+    return false;
+
+  size_t pos = 4;
+  while (pos < name.size() && name[pos] >= '0' && name[pos] <= '9')
+    pos++;
+
+  if (pos == 4 || pos >= name.size() || name[pos] != 'n')
+    return false;
+
+  pos++;
+  size_t ns_start = pos;
+  while (pos < name.size() && name[pos] >= '0' && name[pos] <= '9')
+    pos++;
+
+  return pos > ns_start && pos == name.size();
+}
+
+static std::string realpathOrOriginal(const char* path) {
+  char resolved[PATH_MAX];
+  if (realpath(path, resolved) != nullptr)
+    return resolved;
+  return path ? std::string(path) : std::string();
+}
+
+__host__ int resolveNvmeDevicePath(const char* device_path, uint32_t nsid,
+                                   NvmeDevicePath* resolved) {
+  if (!device_path || !resolved || device_path[0] == '\0')
+    return -EINVAL;
+
+  std::string real_path = realpathOrOriginal(device_path);
+  std::string node_name = xioBasename(real_path);
+  if (node_name.empty())
+    return -EINVAL;
+
+  resolved->namespacePath.clear();
+  resolved->controllerPath.clear();
+  resolved->controllerName.clear();
+
+  if (isNvmeNamespaceName(node_name)) {
+    std::string ns_sysfs = "/sys/class/block/" + node_name + "/device";
+    char controller_real[PATH_MAX];
+    if (realpath(ns_sysfs.c_str(), controller_real) == nullptr) {
+      std::cerr << "Error: Failed to resolve " << ns_sysfs << ": "
+                << strerror(errno) << std::endl;
+      return -errno;
+    }
+
+    resolved->namespacePath = device_path;
+    resolved->controllerName = xioBasename(controller_real);
+    resolved->controllerPath = "/dev/" + resolved->controllerName;
+  } else {
+    std::string controller_sysfs = "/sys/class/nvme/" + node_name;
+    char controller_real[PATH_MAX];
+    if (realpath(controller_sysfs.c_str(), controller_real) == nullptr) {
+      std::cerr << "Error: Failed to resolve " << controller_sysfs << ": "
+                << strerror(errno) << std::endl;
+      return -errno;
+    }
+
+    resolved->controllerName = xioBasename(controller_real);
+    resolved->controllerPath = "/dev/" + resolved->controllerName;
+    resolved->namespacePath = resolved->controllerPath + "n" +
+                              std::to_string(nsid);
+  }
+
+  return 0;
+}
+
 __host__ int detectBdfFromDevice(const char* device_path, uint16_t* bdf_out) {
   if (!device_path || !bdf_out) {
     return -EINVAL;
   }
 
-  // Extract device name from path (e.g., "nvme0" from "/dev/nvme0")
-  std::string dev_path = device_path;
-  size_t last_slash = dev_path.find_last_of('/');
-  if (last_slash == std::string::npos || last_slash == dev_path.length() - 1) {
-    std::cerr << "Error: Invalid device path: " << device_path << std::endl;
-    return -EINVAL;
-  }
-
-  std::string device_name = dev_path.substr(last_slash + 1);
+  NvmeDevicePath nvme_path;
+  int resolve_ret = resolveNvmeDevicePath(device_path, 1, &nvme_path);
+  if (resolve_ret != 0)
+    return resolve_ret;
 
   // Build sysfs device symlink path: /sys/class/nvme/nvme0/device
-  std::string sysfs_path = "/sys/class/nvme/" + device_name + "/device";
+  std::string sysfs_path = "/sys/class/nvme/" + nvme_path.controllerName +
+                           "/device";
 
   // Read the symlink to get PCI device path
   char link_target[256];
@@ -1129,7 +1202,8 @@ __host__ int detectBdfFromDevice(const char* device_path, uint16_t* bdf_out) {
 
   *bdf_out = bdf;
 
-  std::cout << "Detected PCI BDF for " << device_path << ": 0000:" << std::hex
+  std::cout << "Detected PCI BDF for " << device_path << " ("
+            << nvme_path.controllerPath << "): 0000:" << std::hex
             << std::setfill('0') << std::setw(2) << static_cast<unsigned>(bus)
             << ":" << std::setw(2) << static_cast<unsigned>(device) << "."
             << std::dec << static_cast<unsigned>(function) << " (BDF: 0x"
@@ -1145,18 +1219,14 @@ __host__ int detectEmulatedNvme(const char* device_path,
     return -EINVAL;
   }
 
-  // Extract device name from path (e.g., "nvme0" from "/dev/nvme0")
-  std::string dev_path = device_path;
-  size_t last_slash = dev_path.find_last_of('/');
-  if (last_slash == std::string::npos || last_slash == dev_path.length() - 1) {
-    std::cerr << "Error: Invalid device path: " << device_path << std::endl;
-    return -EINVAL;
-  }
-
-  std::string device_name = dev_path.substr(last_slash + 1);
+  NvmeDevicePath nvme_path;
+  int resolve_ret = resolveNvmeDevicePath(device_path, 1, &nvme_path);
+  if (resolve_ret != 0)
+    return resolve_ret;
 
   // Build sysfs device symlink path: /sys/class/nvme/nvme0/device
-  std::string sysfs_path = "/sys/class/nvme/" + device_name + "/device";
+  std::string sysfs_path = "/sys/class/nvme/" + nvme_path.controllerName +
+                           "/device";
 
   // Read the symlink to get PCI device path
   char link_target[256];
@@ -1248,7 +1318,8 @@ __host__ int detectEmulatedNvme(const char* device_path,
 
   *is_emulated_out = is_emulated;
 
-  std::cout << "NVMe controller " << device_path << " (PCI " << pci_addr
+  std::cout << "NVMe controller " << device_path << " ("
+            << nvme_path.controllerPath << ", PCI " << pci_addr
             << "): VID=0x" << std::hex << std::setfill('0') << std::setw(4)
             << vendor_id << ", DID=0x" << std::setw(4) << device_id << std::dec
             << " -> " << (is_emulated ? "EMULATED" : "PASSTHROUGH")

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -11,13 +11,13 @@
 // Host-only includes for IOCTL and file operations
 #ifndef __HIP_DEVICE_COMPILE__
 #include <errno.h>
+#include <limits.h>
 
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 
 #include <fcntl.h>
-#include <limits.h>
 #include <linux/nvme_ioctl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -17,6 +17,7 @@
 #include <cstring>
 
 #include <fcntl.h>
+#include <limits.h>
 #include <linux/nvme_ioctl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -876,12 +877,29 @@ static int ioctlEintrSafe(int fd, unsigned long request, void* arg) {
  * @return Empty string if valid, error message otherwise
  */
 __host__ std::string validateConfig(nvmeEpConfig* config) {
+  // Validate and normalize --controller before querying controller sysfs.
+  if (config->controller.empty()) {
+    return "--controller must be specified";
+  }
+
+  NvmeDevicePath nvme_path;
+  int path_ret = xio::resolveNvmeDevicePath(config->controller.c_str(),
+                                            config->ioParams.nsid, &nvme_path);
+  if (path_ret != 0) {
+    return "Failed to resolve NVMe device path: " +
+           std::string(strerror(-path_ret));
+  }
+  if (config->controller != nvme_path.controllerPath) {
+    ROCXIO_LOG_INFO("Resolved NVMe path %s to controller %s "
+                    "(namespace %s)\n",
+                    config->controller.c_str(),
+                    nvme_path.controllerPath.c_str(),
+                    nvme_path.namespacePath.c_str());
+    config->controller = nvme_path.controllerPath;
+  }
+
   // Auto-detect maximum queue ID if queueId is 0 (default)
   if (config->queueId == 0) {
-    if (config->controller.empty()) {
-      return "Cannot auto-detect queue ID: "
-             "--controller not specified";
-    }
     uint16_t max_queue_id = 0;
     int ret = queryMaxQueueId(config->controller.c_str(), &max_queue_id);
     if (ret != 0) {
@@ -968,11 +986,6 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
       return "--verify requires --batch-size 1 (wavefront "
              "batching intermixes write and read ops, "
              "preventing correct read-back verification)";
-  }
-
-  // Validate that --controller is specified
-  if (config->controller.empty()) {
-    return "--controller must be specified";
   }
 
   // Detect LBA size from controller/namespace
@@ -1729,6 +1742,11 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
     return -EINVAL;
   }
 
+  NvmeDevicePath nvme_path;
+  ret = xio::resolveNvmeDevicePath(nvme_device, nsid, &nvme_path);
+  if (ret != 0)
+    return ret;
+
   {
     hipError_t herr = xio::allocHostMemory(nvme_ep::nvmeAdminRespSize,
                                            (void**)&id_ns, "Identify Namespace",
@@ -1737,7 +1755,8 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
       return -ENOMEM;
   }
 
-  nvme_fd = openDeviceWithRetry(nvme_device, O_RDONLY, "NVMe device", 5, 100);
+  nvme_fd = openDeviceWithRetry(nvme_path.controllerPath.c_str(), O_RDONLY,
+                                "NVMe device", 5, 100);
   if (nvme_fd < 0) {
     ret = -errno;
     goto cleanup;
@@ -1856,6 +1875,11 @@ __host__ int queryNamespaceCapacity(const char* nvme_device, uint32_t nsid,
     return -EINVAL;
   }
 
+  NvmeDevicePath nvme_path;
+  ret = xio::resolveNvmeDevicePath(nvme_device, nsid, &nvme_path);
+  if (ret != 0)
+    return ret;
+
   {
     hipError_t herr = xio::allocHostMemory(nvme_ep::nvmeAdminRespSize,
                                            (void**)&id_ns,
@@ -1865,7 +1889,8 @@ __host__ int queryNamespaceCapacity(const char* nvme_device, uint32_t nsid,
       return -ENOMEM;
   }
 
-  nvme_fd = openDeviceWithRetry(nvme_device, O_RDONLY, "NVMe device", 5, 100);
+  nvme_fd = openDeviceWithRetry(nvme_path.controllerPath.c_str(), O_RDONLY,
+                                "NVMe device", 5, 100);
   if (nvme_fd < 0) {
     ret = -errno;
     goto cleanup;
@@ -1947,8 +1972,19 @@ cleanup:
 }
 
 __host__ int checkRootfs(const char* nvme_device) {
-  char ns_device[256];
-  snprintf(ns_device, sizeof(ns_device), "%sn1", nvme_device);
+  NvmeDevicePath nvme_path;
+  int resolve_ret = xio::resolveNvmeDevicePath(nvme_device, 1, &nvme_path);
+  if (resolve_ret != 0) {
+    ROCXIO_LOG_WARN("Failed to resolve NVMe path %s for rootfs check: %s\n",
+                    nvme_device, strerror(-resolve_ret));
+    return 0;
+  }
+
+  char ns_real[PATH_MAX] = {};
+  const char* ns_device = nvme_path.namespacePath.c_str();
+  const char* ns_compare = ns_device;
+  if (realpath(ns_device, ns_real) != nullptr)
+    ns_compare = ns_real;
 
   // Check /proc/mounts for root mount
   FILE* f = fopen("/proc/mounts", "r");
@@ -1966,7 +2002,8 @@ __host__ int checkRootfs(const char* nvme_device) {
       if (strcmp(mount_point, "/") == 0) {
         // Check if this device matches our NVMe device
         if (strstr(device, ns_device) != nullptr ||
-            strstr(device, nvme_device) != nullptr) {
+            strstr(device, ns_compare) != nullptr ||
+            strstr(device, nvme_path.controllerPath.c_str()) != nullptr) {
           is_rootfs = true;
           break;
         }
@@ -1977,7 +2014,7 @@ __host__ int checkRootfs(const char* nvme_device) {
 
   if (is_rootfs) {
     ROCXIO_LOG_ERROR("NVMe device %s appears to be the root filesystem!\n",
-                     nvme_device);
+                     ns_device);
     ROCXIO_LOG_ERROR("This operation will NOT proceed on rootfs to prevent "
                      "data corruption.\n");
     ROCXIO_LOG_ERROR("Please specify a different NVMe device.\n");
@@ -1990,8 +2027,14 @@ __host__ int checkRootfs(const char* nvme_device) {
 __host__ int readSmartLog(const char* nvme_device,
                           struct nvme_smart_log* smart_log) {
   int nvme_fd = -1;
+  NvmeDevicePath nvme_path;
+  int resolve_ret = xio::resolveNvmeDevicePath(nvme_device, 1, &nvme_path);
+  if (resolve_ret != 0)
+    return resolve_ret;
+
   // Open NVMe device with retry (device may be temporarily busy)
-  nvme_fd = openDeviceWithRetry(nvme_device, O_RDONLY, "NVMe device", 5, 100);
+  nvme_fd = openDeviceWithRetry(nvme_path.controllerPath.c_str(), O_RDONLY,
+                                "NVMe device", 5, 100);
   if (nvme_fd < 0) {
     return -errno;
   }
@@ -2049,18 +2092,15 @@ __host__ int queryMaxQueueId(const char* nvme_device, uint16_t* max_queue_id) {
     return -EINVAL;
   }
 
-  // Extract device name from path (e.g., "/dev/nvme1" -> "nvme1")
-  const char* device_name = strrchr(nvme_device, '/');
-  if (!device_name) {
-    device_name = nvme_device;
-  } else {
-    device_name++; // Skip the '/'
-  }
+  NvmeDevicePath nvme_path;
+  int resolve_ret = xio::resolveNvmeDevicePath(nvme_device, 1, &nvme_path);
+  if (resolve_ret != 0)
+    return resolve_ret;
 
   // Build sysfs path: /sys/class/nvme/nvme1/queue_count
   char sysfs_path[256];
   snprintf(sysfs_path, sizeof(sysfs_path), "/sys/class/nvme/%s/queue_count",
-           device_name);
+           nvme_path.controllerName.c_str());
 
   FILE* f = fopen(sysfs_path, "r");
   if (!f) {

--- a/src/endpoints/rdma-ep/gda-backend.cpp
+++ b/src/endpoints/rdma-ep/gda-backend.cpp
@@ -17,33 +17,21 @@
 #include <hip/hip_runtime.h>
 
 #include <dlfcn.h>
-#include <endian.h>
 #include <unistd.h>
 
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
+#include "rdma-common.h"
 #include "rdma-topology.hpp"
 #include "xio-rdma-check.h"
 #include "xio.h"
 
 #if defined(GDA_BNXT)
 #include "bnxt/bnxt-provider.hpp"
-namespace xio {
-namespace rdma_ep {
-int bnxt_dv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr,
-                      int attr_mask);
-} // namespace rdma_ep
-} // namespace xio
 #endif
 
 #if defined(GDA_ERNIC)
 #include "rocm-ernic/ernic-provider.hpp"
-namespace xio {
-namespace rdma_ep {
-int ernic_dv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr,
-                       int attr_mask);
-} // namespace rdma_ep
-} // namespace xio
 #endif
 
 namespace xio {
@@ -324,20 +312,8 @@ void Backend::create_queues() {
     }
 
     struct ibv_qp_init_attr_ex qp_init;
-    memset(&qp_init, 0, sizeof(qp_init));
-    qp_init.send_cq = cq_;
-    qp_init.recv_cq = cq_;
-    qp_init.srq = nullptr;
-    qp_init.cap.max_send_wr = config_.sq_depth;
-    // ionic_rdma kernel driver requires >= 1 recv WR
-    qp_init.cap.max_recv_wr = 1;
-    qp_init.cap.max_send_sge = 1;
-    qp_init.cap.max_recv_sge = 1;
-    qp_init.cap.max_inline_data = config_.inline_threshold;
-    qp_init.qp_type = IBV_QPT_RC;
-    qp_init.sq_sig_all = 0;
-    qp_init.comp_mask = IBV_QP_INIT_ATTR_PD;
-    qp_init.pd = pd_parent_ ? pd_parent_ : pd_;
+    fill_rc_qp_init_attr(&qp_init, pd_parent_ ? pd_parent_ : pd_, cq_,
+                         config_.sq_depth, 1, 1, config_.inline_threshold);
 
     errno = 0;
     qp_ = ibv.create_qp_ex(context_, &qp_init);
@@ -362,19 +338,8 @@ void Backend::create_queues() {
   XIO_CHECK_NNULL(cq_, "ibv_create_cq");
 
   struct ibv_qp_init_attr_ex qp_init;
-  memset(&qp_init, 0, sizeof(qp_init));
-  qp_init.send_cq = cq_;
-  qp_init.recv_cq = cq_;
-  qp_init.srq = nullptr;
-  qp_init.cap.max_send_wr = config_.sq_depth;
-  qp_init.cap.max_recv_wr = 0;
-  qp_init.cap.max_send_sge = 1;
-  qp_init.cap.max_recv_sge = 0;
-  qp_init.cap.max_inline_data = config_.inline_threshold;
-  qp_init.qp_type = IBV_QPT_RC;
-  qp_init.sq_sig_all = 0;
-  qp_init.comp_mask = IBV_QP_INIT_ATTR_PD;
-  qp_init.pd = pd_;
+  fill_rc_qp_init_attr(&qp_init, pd_, cq_, config_.sq_depth, 0, 0,
+                       config_.inline_threshold);
 
   errno = 0;
   qp_ = ibv.create_qp_ex(context_, &qp_init);
@@ -421,18 +386,7 @@ void Backend::modify_qp_reset_to_init() {
   int attr_mask = IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                   IBV_QP_ACCESS_FLAGS;
 
-  int err;
-#if defined(GDA_BNXT)
-  if (provider_ == Provider::BNXT)
-    err = bnxt_dv_modify_qp(qp_, &attr, attr_mask);
-  else
-#endif
-#if defined(GDA_ERNIC)
-    if (provider_ == Provider::ROCM_ERNIC)
-    err = ernic_dv_modify_qp(qp_, &attr, attr_mask);
-  else
-#endif
-    err = ibv.modify_qp(qp_, &attr, attr_mask);
+  int err = modify_qp_dispatch(provider_, qp_, &attr, attr_mask);
   XIO_CHECK_ZERO(err, "modify_qp (RESET->INIT)");
 }
 
@@ -447,14 +401,7 @@ void Backend::modify_qp_init_to_rtr(const DestInfo& remote) {
   attr.rq_psn = remote.psn;
   attr.dest_qp_num = remote.qpn;
 
-  if (provider_ == Provider::IONIC) {
-    attr.max_dest_rd_atomic = 15;
-  } else if (device_attr_.max_qp_rd_atom > 0) {
-    attr.max_dest_rd_atomic = static_cast<uint8_t>(
-      device_attr_.max_qp_rd_atom > 255 ? 255 : device_attr_.max_qp_rd_atom);
-  } else {
-    attr.max_dest_rd_atomic = 1;
-  }
+  attr.max_dest_rd_atomic = rd_atomic_cap(provider_, device_attr_);
 
   if (port_attr_.link_layer == IBV_LINK_LAYER_ETHERNET) {
     attr.ah_attr.grh.sgid_index = gid_index_;
@@ -477,18 +424,7 @@ void Backend::modify_qp_init_to_rtr(const DestInfo& remote) {
                   IBV_QP_DEST_QPN | IBV_QP_AV | IBV_QP_MAX_DEST_RD_ATOMIC |
                   IBV_QP_MIN_RNR_TIMER;
 
-  int err;
-#if defined(GDA_BNXT)
-  if (provider_ == Provider::BNXT)
-    err = bnxt_dv_modify_qp(qp_, &attr, attr_mask);
-  else
-#endif
-#if defined(GDA_ERNIC)
-    if (provider_ == Provider::ROCM_ERNIC)
-    err = ernic_dv_modify_qp(qp_, &attr, attr_mask);
-  else
-#endif
-    err = ibv.modify_qp(qp_, &attr, attr_mask);
+  int err = modify_qp_dispatch(provider_, qp_, &attr, attr_mask);
   XIO_CHECK_ZERO(err, "modify_qp (INIT->RTR)");
 }
 
@@ -502,30 +438,12 @@ void Backend::modify_qp_rtr_to_rts() {
   attr.retry_cnt = 7;
   attr.rnr_retry = 7;
 
-  if (provider_ == Provider::IONIC) {
-    attr.max_rd_atomic = 15;
-  } else if (device_attr_.max_qp_rd_atom > 0) {
-    attr.max_rd_atomic = static_cast<uint8_t>(
-      device_attr_.max_qp_rd_atom > 255 ? 255 : device_attr_.max_qp_rd_atom);
-  } else {
-    attr.max_rd_atomic = 1;
-  }
+  attr.max_rd_atomic = rd_atomic_cap(provider_, device_attr_);
 
   int attr_mask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC |
                   IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY;
 
-  int err;
-#if defined(GDA_BNXT)
-  if (provider_ == Provider::BNXT)
-    err = bnxt_dv_modify_qp(qp_, &attr, attr_mask);
-  else
-#endif
-#if defined(GDA_ERNIC)
-    if (provider_ == Provider::ROCM_ERNIC)
-    err = ernic_dv_modify_qp(qp_, &attr, attr_mask);
-  else
-#endif
-    err = ibv.modify_qp(qp_, &attr, attr_mask);
+  int err = modify_qp_dispatch(provider_, qp_, &attr, attr_mask);
   XIO_CHECK_ZERO(err, "modify_qp (RTR->RTS)");
 }
 
@@ -697,10 +615,7 @@ DestInfo Backend::get_local_dest_info() const {
 int Backend::set_remote_rkey(uint32_t remote_rkey) {
   if (!host_qp_ || !gpu_qp_)
     return -1;
-  if (provider_ == Provider::MLX5)
-    host_qp_->rkey_ = htobe32(remote_rkey);
-  else
-    host_qp_->rkey_ = remote_rkey;
+  host_qp_->rkey_ = normalize_qp_key(provider_, remote_rkey);
   hipError_t err = hipMemcpy(gpu_qp_, host_qp_, sizeof(QueuePair),
                              hipMemcpyDefault);
   if (err != hipSuccess) {
@@ -735,13 +650,8 @@ int Backend::register_data_buffer(void* buf, size_t size) {
     return -1;
   }
 
-  if (provider_ == Provider::MLX5) {
-    host_qp_->lkey_ = htobe32(heap_mr_->lkey);
-    host_qp_->rkey_ = htobe32(heap_mr_->rkey);
-  } else {
-    host_qp_->lkey_ = heap_mr_->lkey;
-    host_qp_->rkey_ = heap_mr_->rkey;
-  }
+  normalize_mr_keys(provider_, heap_mr_->lkey, heap_mr_->rkey, &host_qp_->lkey_,
+                    &host_qp_->rkey_);
   rkey_ = heap_mr_->rkey;
   lkey_ = heap_mr_->lkey;
 

--- a/src/endpoints/rdma-ep/gda-backend.hpp
+++ b/src/endpoints/rdma-ep/gda-backend.hpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  *
  * Derived from ROCm/rocSHMEM src/gda/backend_gda.hpp, adapted for rocm-xio.
+ * Common config mapping, key normalization, QP init, and QP modify dispatch
+ * live in rdma-common.h.
  * Simplified from full-mesh PE topology to single-endpoint model:
  *   - 1 QP + 1 CQ pair per Backend instance (not num_pes * num_contexts)
  *   - No MPI, no team/context multiplexing
@@ -32,6 +34,13 @@ struct DestInfo {
   union ibv_gid gid;
 };
 
+/**
+ * @brief Runtime configuration consumed by the RDMA backend.
+ *
+ * This structure is derived from RdmaEpConfig and XioEndpointConfig by
+ * make_backend_config(). It contains only values needed to open a provider,
+ * create QPs/CQs, allocate queue memory, and connect the local or remote peer.
+ */
 struct BackendConfig {
   Provider provider{Provider::BNXT};
   int gpu_device_id{0};

--- a/src/endpoints/rdma-ep/gda-backend.hpp
+++ b/src/endpoints/rdma-ep/gda-backend.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "ibv-core.hpp"
+#include "rdma-ep.h"
 #include "vendor-ops.hpp"
 
 namespace xio {

--- a/src/endpoints/rdma-ep/queue-pair.hip
+++ b/src/endpoints/rdma-ep/queue-pair.hip
@@ -12,6 +12,7 @@
 
 #include "ibv-wrapper.hpp"
 #include "queue-pair.hpp"
+#include "rdma-common.h"
 #include "xio.h"
 
 #if defined(GDA_BNXT)
@@ -62,8 +63,10 @@ QueuePair::QueuePair(struct ibv_pd* pd, Provider provider)
       op_rdma_read_ = BNXT_RE_WR_OPCD_RDMA_READ;
       op_atomic_fa_ = BNXT_RE_WR_OPCD_ATOMIC_FA;
       op_atomic_cs_ = BNXT_RE_WR_OPCD_ATOMIC_CS;
-      nonfetching_atomic_lkey_ = mr_nonfetching_atomic_->lkey;
-      fetching_atomic_lkey_ = mr_fetching_atomic_->lkey;
+      nonfetching_atomic_lkey_ = normalize_qp_key(provider,
+                                                  mr_nonfetching_atomic_->lkey);
+      fetching_atomic_lkey_ = normalize_qp_key(provider,
+                                               mr_fetching_atomic_->lkey);
       break;
 #endif
 #if defined(GDA_MLX5)
@@ -73,8 +76,10 @@ QueuePair::QueuePair(struct ibv_pd* pd, Provider provider)
       op_rdma_read_ = 0x10;      // MLX5_OPCODE_RDMA_READ
       op_atomic_fa_ = 0x13;      // MLX5_OPCODE_ATOMIC_FA
       op_atomic_cs_ = 0x12;      // MLX5_OPCODE_ATOMIC_CS
-      nonfetching_atomic_lkey_ = htobe32(mr_nonfetching_atomic_->lkey);
-      fetching_atomic_lkey_ = htobe32(mr_fetching_atomic_->lkey);
+      nonfetching_atomic_lkey_ = normalize_qp_key(provider,
+                                                  mr_nonfetching_atomic_->lkey);
+      fetching_atomic_lkey_ = normalize_qp_key(provider,
+                                               mr_fetching_atomic_->lkey);
       break;
 #endif
 #if defined(GDA_IONIC)
@@ -92,8 +97,10 @@ QueuePair::QueuePair(struct ibv_pd* pd, Provider provider)
       op_atomic_fa_ = IONIC_V1_OP_ATOMIC_FA;
       op_atomic_cs_ = IONIC_V1_OP_ATOMIC_CS;
 #endif
-      nonfetching_atomic_lkey_ = mr_nonfetching_atomic_->lkey;
-      fetching_atomic_lkey_ = mr_fetching_atomic_->lkey;
+      nonfetching_atomic_lkey_ = normalize_qp_key(provider,
+                                                  mr_nonfetching_atomic_->lkey);
+      fetching_atomic_lkey_ = normalize_qp_key(provider,
+                                               mr_fetching_atomic_->lkey);
       break;
 #endif
 #if defined(GDA_ERNIC)
@@ -103,8 +110,10 @@ QueuePair::QueuePair(struct ibv_pd* pd, Provider provider)
       op_rdma_read_ = 4;      // ROCM_ERNIC_WR_RDMA_READ
       op_atomic_fa_ = 6;      // ROCM_ERNIC_WR_ATOMIC_FA
       op_atomic_cs_ = 5;      // ROCM_ERNIC_WR_ATOMIC_CS
-      nonfetching_atomic_lkey_ = mr_nonfetching_atomic_->lkey;
-      fetching_atomic_lkey_ = mr_fetching_atomic_->lkey;
+      nonfetching_atomic_lkey_ = normalize_qp_key(provider,
+                                                  mr_nonfetching_atomic_->lkey);
+      fetching_atomic_lkey_ = normalize_qp_key(provider,
+                                               mr_fetching_atomic_->lkey);
       break;
 #endif
     default:

--- a/src/endpoints/rdma-ep/queue-pair.hpp
+++ b/src/endpoints/rdma-ep/queue-pair.hpp
@@ -19,6 +19,7 @@
 
 #include "endian.hpp"
 #include "ibv-core.hpp"
+#include "rdma-ep.h"
 #include "vendor-ops.hpp"
 
 #if defined(GDA_BNXT)

--- a/src/endpoints/rdma-ep/rdma-common.h
+++ b/src/endpoints/rdma-ep/rdma-common.h
@@ -23,8 +23,14 @@
 
 #include <hip/hip_runtime.h>
 
-#include "ibv-core.hpp"
-#include "vendor-ops.hpp"
+#include "rdma-ep.h"
+
+struct ibv_cq;
+struct ibv_device_attr;
+struct ibv_pd;
+struct ibv_qp;
+struct ibv_qp_attr;
+struct ibv_qp_init_attr_ex;
 
 namespace xio {
 

--- a/src/endpoints/rdma-ep/rdma-common.h
+++ b/src/endpoints/rdma-ep/rdma-common.h
@@ -1,0 +1,158 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+/**
+ * @file rdma-common.h
+ * @brief Shared RDMA endpoint helpers used by host and device code.
+ *
+ * This header contains the vendor-independent parts of the RDMA endpoint:
+ * provider metadata, RDMA-to-backend config mapping, key normalization, common
+ * RC QP setup, QP modification dispatch, and small device verification helpers.
+ * Vendor-specific WQE construction, doorbell programming, CQE parsing, and DV
+ * object layout remain in the provider directories.
+ */
+
+#ifndef RDMA_EP_RDMA_COMMON_H
+#define RDMA_EP_RDMA_COMMON_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include <hip/hip_runtime.h>
+
+#include "ibv-core.hpp"
+#include "vendor-ops.hpp"
+
+namespace xio {
+
+struct XioEndpointConfig;
+
+namespace rdma_ep {
+
+struct BackendConfig;
+struct RdmaEpConfig;
+
+/**
+ * @brief Return the supported provider names for diagnostics and Doxygen.
+ *
+ * The returned string is the single user-facing list used by config
+ * validation. Provider aliases remain accepted by provider_from_string().
+ *
+ * @return Comma-separated canonical provider names.
+ */
+__host__ const char* provider_allowed_names();
+
+/**
+ * @brief Build runtime backend config from the public RDMA endpoint config.
+ *
+ * @param config Common xio endpoint configuration.
+ * @param rdmaConfig User-facing RDMA endpoint configuration.
+ * @param loopback True for loopback setup, false for 2-node setup.
+ * @return Runtime BackendConfig consumed by Backend.
+ */
+__host__ BackendConfig make_backend_config(const XioEndpointConfig& config,
+                                           const RdmaEpConfig& rdmaConfig,
+                                           bool loopback);
+
+/**
+ * @brief Convert a key into the device format expected by a provider.
+ *
+ * MLX5 WQEs expect keys in big-endian order. Other supported providers consume
+ * the native libibverbs key value.
+ *
+ * @param provider Active RDMA provider.
+ * @param key Local or remote memory key from libibverbs.
+ * @return Provider-specific key value to store in QueuePair device state.
+ */
+__host__ uint32_t normalize_qp_key(Provider provider, uint32_t key);
+
+/**
+ * @brief Normalize local and remote memory keys for QueuePair device state.
+ *
+ * @param provider Active RDMA provider.
+ * @param lkey Local memory key from the registered memory region.
+ * @param rkey Remote memory key from the registered memory region.
+ * @param normalizedLkey Output local key in provider device format.
+ * @param normalizedRkey Output remote key in provider device format.
+ */
+__host__ void normalize_mr_keys(Provider provider, uint32_t lkey, uint32_t rkey,
+                                uint32_t* normalizedLkey,
+                                uint32_t* normalizedRkey);
+
+/**
+ * @brief Select the RD atomic depth for RTR and RTS transitions.
+ *
+ * IONIC requires the maximum value used by its driver path. Other providers use
+ * the device-reported max_qp_rd_atom, clamped to the 8-bit ibv_qp_attr field.
+ *
+ * @param provider Active RDMA provider.
+ * @param deviceAttr Device attributes returned by ibv_query_device().
+ * @return RD atomic depth for max_rd_atomic or max_dest_rd_atomic.
+ */
+__host__ uint8_t rd_atomic_cap(Provider provider,
+                               const struct ibv_device_attr& deviceAttr);
+
+/**
+ * @brief Fill common RC QP creation attributes.
+ *
+ * @param attr Attribute structure to zero and populate.
+ * @param pd Protection domain for the QP.
+ * @param cq Send and receive completion queue.
+ * @param sqDepth Send queue depth.
+ * @param recvWr Receive work request depth.
+ * @param recvSge Receive scatter-gather entry depth.
+ * @param inlineThreshold Maximum inline data size.
+ */
+__host__ void fill_rc_qp_init_attr(struct ibv_qp_init_attr_ex* attr,
+                                   struct ibv_pd* pd, struct ibv_cq* cq,
+                                   int sqDepth, int recvWr, int recvSge,
+                                   uint32_t inlineThreshold);
+
+/**
+ * @brief Dispatch QP state changes through the active provider backend.
+ *
+ * BNXT and ERNIC use their DV modify_qp entry points. Other providers use the
+ * common ibverbs modify_qp path.
+ *
+ * @param provider Active RDMA provider.
+ * @param qp Queue pair to modify.
+ * @param attr Attribute values for the transition.
+ * @param attrMask ibverbs attribute mask for the transition.
+ * @return 0 on success, nonzero provider/libibverbs error otherwise.
+ */
+__host__ int modify_qp_dispatch(Provider provider, struct ibv_qp* qp,
+                                struct ibv_qp_attr* attr, int attrMask);
+
+/**
+ * @brief Fill one RDMA verification source buffer and clear its destination.
+ *
+ * @param src Source buffer to fill with the LFSR data pattern.
+ * @param dst Destination buffer to clear before the RDMA operation.
+ * @param transferSize Number of bytes in each buffer.
+ * @param seed Iteration-specific data pattern seed.
+ */
+__device__ void prepare_verify_buffer(uint8_t* src, uint8_t* dst,
+                                      uint32_t transferSize, uint32_t seed);
+
+/**
+ * @brief Verify one RDMA destination buffer and update pass/fail counters.
+ *
+ * @param dst Destination buffer to verify.
+ * @param transferSize Number of bytes in the buffer.
+ * @param seed Iteration-specific data pattern seed.
+ * @param label Failure message label.
+ * @param op Operation or iteration index for diagnostics.
+ * @param verifyPass Optional pass counter in host-mapped memory.
+ * @param verifyFail Optional failure counter in host-mapped memory.
+ */
+__device__ void verify_buffer(uint8_t* dst, uint32_t transferSize,
+                              uint32_t seed, const char* label, unsigned op,
+                              uint32_t* verifyPass, uint32_t* verifyFail);
+
+} // namespace rdma_ep
+} // namespace xio
+
+#endif // RDMA_EP_RDMA_COMMON_H

--- a/src/endpoints/rdma-ep/rdma-common.hip
+++ b/src/endpoints/rdma-ep/rdma-common.hip
@@ -41,8 +41,7 @@ __host__ const char* provider_allowed_names() {
   static char names[64];
   snprintf(names, sizeof(names), "%s, %s, %s, or %s",
            provider_name(Provider::BNXT), provider_name(Provider::MLX5),
-           provider_name(Provider::IONIC),
-           provider_name(Provider::ROCM_ERNIC));
+           provider_name(Provider::IONIC), provider_name(Provider::ROCM_ERNIC));
   return names;
 }
 

--- a/src/endpoints/rdma-ep/rdma-common.hip
+++ b/src/endpoints/rdma-ep/rdma-common.hip
@@ -1,0 +1,152 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+#include <cstdio>
+#include <cstring>
+
+#include <endian.h>
+
+#include "gda-backend.hpp"
+#include "ibv-wrapper.hpp"
+#include "rdma-common.h"
+#include "rdma-ep.h"
+#include "xio-data-pattern.hpp"
+#include "xio.h"
+
+#if defined(GDA_BNXT)
+namespace xio {
+namespace rdma_ep {
+int bnxt_dv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr,
+                      int attr_mask);
+} // namespace rdma_ep
+} // namespace xio
+#endif
+
+#if defined(GDA_ERNIC)
+namespace xio {
+namespace rdma_ep {
+int ernic_dv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr,
+                       int attr_mask);
+} // namespace rdma_ep
+} // namespace xio
+#endif
+
+namespace xio {
+namespace rdma_ep {
+
+__host__ const char* provider_allowed_names() {
+  return "bnxt, mlx5, ionic, or ernic";
+}
+
+__host__ BackendConfig make_backend_config(const XioEndpointConfig& config,
+                                           const RdmaEpConfig& rdmaConfig,
+                                           bool loopback) {
+  bool sq_on_device = (config.memoryMode & XIO_MEM_MODE_SQ_DEVICE) != 0;
+
+  BackendConfig backendConfig;
+  backendConfig.provider = rdmaConfig.provider;
+  backendConfig.gpu_device_id = rdmaConfig.gpuDeviceId;
+  backendConfig.sq_depth = rdmaConfig.sqDepth;
+  backendConfig.cq_depth = rdmaConfig.cqDepth;
+  backendConfig.inline_threshold = rdmaConfig.inlineThreshold;
+  backendConfig.pcie_relaxed_ordering = rdmaConfig.pcieRelaxedOrdering;
+  backendConfig.traffic_class = rdmaConfig.trafficClass;
+  backendConfig.loopback = loopback;
+  backendConfig.queue_mem = sq_on_device ? QueueMemMode::DEVICE_VRAM
+                                         : QueueMemMode::HOST_COHERENT;
+  backendConfig.pci_mmio_bridge = config.pciMmioBridge;
+  if (!rdmaConfig.deviceName.empty())
+    backendConfig.hca_list = rdmaConfig.deviceName.c_str();
+  return backendConfig;
+}
+
+__host__ uint32_t normalize_qp_key(Provider provider, uint32_t key) {
+  return provider == Provider::MLX5 ? htobe32(key) : key;
+}
+
+__host__ void normalize_mr_keys(Provider provider, uint32_t lkey, uint32_t rkey,
+                                uint32_t* normalizedLkey,
+                                uint32_t* normalizedRkey) {
+  if (normalizedLkey)
+    *normalizedLkey = normalize_qp_key(provider, lkey);
+  if (normalizedRkey)
+    *normalizedRkey = normalize_qp_key(provider, rkey);
+}
+
+__host__ uint8_t rd_atomic_cap(Provider provider,
+                               const struct ibv_device_attr& deviceAttr) {
+  if (provider == Provider::IONIC)
+    return 15;
+  if (deviceAttr.max_qp_rd_atom == 0)
+    return 1;
+  uint32_t cap = deviceAttr.max_qp_rd_atom;
+  if (cap > 255)
+    cap = 255;
+  return static_cast<uint8_t>(cap);
+}
+
+__host__ void fill_rc_qp_init_attr(struct ibv_qp_init_attr_ex* attr,
+                                   struct ibv_pd* pd, struct ibv_cq* cq,
+                                   int sqDepth, int recvWr, int recvSge,
+                                   uint32_t inlineThreshold) {
+  memset(attr, 0, sizeof(*attr));
+  attr->send_cq = cq;
+  attr->recv_cq = cq;
+  attr->srq = nullptr;
+  attr->cap.max_send_wr = sqDepth;
+  attr->cap.max_recv_wr = recvWr;
+  attr->cap.max_send_sge = 1;
+  attr->cap.max_recv_sge = recvSge;
+  attr->cap.max_inline_data = inlineThreshold;
+  attr->qp_type = IBV_QPT_RC;
+  attr->sq_sig_all = 0;
+  attr->comp_mask = IBV_QP_INIT_ATTR_PD;
+  attr->pd = pd;
+}
+
+__host__ int modify_qp_dispatch(Provider provider, struct ibv_qp* qp,
+                                struct ibv_qp_attr* attr, int attrMask) {
+#if defined(GDA_BNXT)
+  if (provider == Provider::BNXT)
+    return bnxt_dv_modify_qp(qp, attr, attrMask);
+#endif
+
+#if defined(GDA_ERNIC)
+  if (provider == Provider::ROCM_ERNIC)
+    return ernic_dv_modify_qp(qp, attr, attrMask);
+#endif
+
+  return ibv.modify_qp(qp, attr, attrMask);
+}
+
+__device__ void prepare_verify_buffer(uint8_t* src, uint8_t* dst,
+                                      uint32_t transferSize, uint32_t seed) {
+  xio::DataPatternParams fp{src, transferSize, 0, transferSize, seed, nullptr};
+  xio::dataPattern(false, fp);
+  for (uint32_t b = 0; b < transferSize; b++)
+    dst[b] = 0;
+  __threadfence_system();
+}
+
+__device__ void verify_buffer(uint8_t* dst, uint32_t transferSize,
+                              uint32_t seed, const char* label, unsigned op,
+                              uint32_t* verifyPass, uint32_t* verifyFail) {
+  size_t errOff = 0;
+  xio::DataPatternParams vp{dst, transferSize, 0, transferSize, seed, &errOff};
+  bool ok = xio::dataPattern(true, vp);
+  if (ok) {
+    if (verifyPass)
+      atomicAdd(verifyPass, 1u);
+  } else {
+    if (verifyFail)
+      atomicAdd(verifyFail, 1u);
+    printf("rdma-ep: %s VERIFY FAILED op=%u seed=%u offset=%zu\n", label, op,
+           seed, errOff);
+  }
+}
+
+} // namespace rdma_ep
+} // namespace xio

--- a/src/endpoints/rdma-ep/rdma-common.hip
+++ b/src/endpoints/rdma-ep/rdma-common.hip
@@ -38,7 +38,12 @@ namespace xio {
 namespace rdma_ep {
 
 __host__ const char* provider_allowed_names() {
-  return "bnxt, mlx5, ionic, or ernic";
+  static char names[64];
+  snprintf(names, sizeof(names), "%s, %s, %s, or %s",
+           provider_name(Provider::BNXT), provider_name(Provider::MLX5),
+           provider_name(Provider::IONIC),
+           provider_name(Provider::ROCM_ERNIC));
+  return names;
 }
 
 __host__ BackendConfig make_backend_config(const XioEndpointConfig& config,

--- a/src/endpoints/rdma-ep/rdma-ep.h
+++ b/src/endpoints/rdma-ep/rdma-ep.h
@@ -8,7 +8,9 @@
  * @file rdma-ep.h
  * @brief RDMA Endpoint -- GPU-Direct Access (GDA) for RDMA NICs.
  *
- * Derived from ROCm/rocSHMEM GDA backend, adapted for rocm-xio.
+ * Derived from ROCm/rocSHMEM GDA backend, adapted for rocm-xio. Shared
+ * vendor-independent helpers live in rdma-common.h; provider-specific hardware
+ * operations remain in the vendor subdirectories.
  * Supports four RDMA vendors:
  *   - BNXT   (Broadcom Thor 2)
  *   - MLX5   (Mellanox/NVIDIA ConnectX)
@@ -29,7 +31,7 @@
 
 #include <hip/hip_runtime.h>
 
-#include "vendor-ops.hpp"
+#include "rdma-common.h"
 
 #define RDMA_EP_SQE_SIZE 0
 #define RDMA_EP_CQE_SIZE 0

--- a/src/endpoints/rdma-ep/rdma-ep.h
+++ b/src/endpoints/rdma-ep/rdma-ep.h
@@ -8,9 +8,8 @@
  * @file rdma-ep.h
  * @brief RDMA Endpoint -- GPU-Direct Access (GDA) for RDMA NICs.
  *
- * Derived from ROCm/rocSHMEM GDA backend, adapted for rocm-xio. Shared
- * vendor-independent helpers live in rdma-common.h; provider-specific hardware
- * operations remain in the vendor subdirectories.
+ * Derived from ROCm/rocSHMEM GDA backend, adapted for rocm-xio.
+ * Provider-specific hardware operations remain in the vendor subdirectories.
  * Supports four RDMA vendors:
  *   - BNXT   (Broadcom Thor 2)
  *   - MLX5   (Mellanox/NVIDIA ConnectX)
@@ -27,11 +26,10 @@
 #define RDMA_EP_H
 
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 #include <hip/hip_runtime.h>
-
-#include "rdma-common.h"
 
 #define RDMA_EP_SQE_SIZE 0
 #define RDMA_EP_CQE_SIZE 0
@@ -41,6 +39,61 @@ namespace xio {
 struct XioEndpointConfig;
 
 namespace rdma_ep {
+
+/**
+ * @brief Queue buffer placement for RDMA send/completion queues.
+ */
+enum class QueueMemMode : uint8_t {
+  HOST_COHERENT = 0,
+  DEVICE_VRAM = 1,
+};
+
+/**
+ * @brief RDMA provider backends supported by rdma-ep.
+ */
+enum class Provider : uint8_t {
+  BNXT = 0,
+  MLX5 = 1,
+  IONIC = 2,
+  ROCM_ERNIC = 3,
+  UNKNOWN = 0xFF,
+};
+
+/**
+ * @brief Return the canonical provider name.
+ */
+__host__ inline const char* provider_name(Provider p) {
+  switch (p) {
+    case Provider::BNXT:
+      return "bnxt";
+    case Provider::MLX5:
+      return "mlx5";
+    case Provider::IONIC:
+      return "ionic";
+    case Provider::ROCM_ERNIC:
+      return "rocm-ernic";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * @brief Convert a provider string to a Provider value.
+ */
+__host__ inline Provider provider_from_string(const char* s) {
+  if (!s)
+    return Provider::UNKNOWN;
+  if (strcmp(s, "bnxt") == 0 || strcmp(s, "bnxt_re") == 0)
+    return Provider::BNXT;
+  if (strcmp(s, "mlx5") == 0)
+    return Provider::MLX5;
+  if (strcmp(s, "ionic") == 0 || strcmp(s, "pensando") == 0)
+    return Provider::IONIC;
+  if (strcmp(s, "rocm_ernic") == 0 || strcmp(s, "ernic") == 0 ||
+      strcmp(s, "rocm-ernic") == 0)
+    return Provider::ROCM_ERNIC;
+  return Provider::UNKNOWN;
+}
 
 /**
  * @brief Configuration for the RDMA endpoint.

--- a/src/endpoints/rdma-ep/rdma-ep.hip
+++ b/src/endpoints/rdma-ep/rdma-ep.hip
@@ -5,7 +5,8 @@
  *
  * RDMA Endpoint -- GPU-Direct Access (GDA).
  * Derived from ROCm/rocSHMEM GDA backend,
- * adapted for rocm-xio.
+ * adapted for rocm-xio. Shared RDMA orchestration helpers live in
+ * rdma-common.h and rdma-common.hip.
  *
  * GPU kernels post WQEs directly to NIC send queues
  * and ring hardware doorbells with zero CPU
@@ -20,6 +21,7 @@
 
 #include "gda-backend.hpp"
 #include "queue-pair.hpp"
+#include "rdma-common.h"
 #include "rdma-ep.h"
 #include "xio-data-pattern.hpp"
 #include "xio-timing.h"
@@ -50,14 +52,8 @@ __global__ void rdma_ep_kernel(QueuePair* qp, void* src_ptr, void* dst_ptr,
   while ((infinite || i < iterations) && (!stopRequested || !*stopRequested)) {
     uint32_t iterSeed = baseSeed + i;
 
-    if (doVerify) {
-      xio::DataPatternParams fp{src,          transferSize, 0,
-                                transferSize, iterSeed,     nullptr};
-      xio::dataPattern(false, fp);
-      for (uint32_t b = 0; b < transferSize; b++)
-        dst[b] = 0;
-      __threadfence_system();
-    }
+    if (doVerify)
+      prepare_verify_buffer(src, dst, transferSize, iterSeed);
 
     unsigned long long int t0 = wall_clock64();
 
@@ -93,22 +89,9 @@ __global__ void rdma_ep_kernel(QueuePair* qp, void* src_ptr, void* dst_ptr,
     if (timingStats && t1 > t0)
       updateTimingStats(timingStats, t1 - t0);
 
-    if (doVerify) {
-      size_t errOff = 0;
-      xio::DataPatternParams vp{dst,          transferSize, 0,
-                                transferSize, iterSeed,     &errOff};
-      bool ok = xio::dataPattern(true, vp);
-      if (ok) {
-        if (verifyPass)
-          atomicAdd(verifyPass, 1u);
-      } else {
-        if (verifyFail)
-          atomicAdd(verifyFail, 1u);
-        printf("rdma-ep: VERIFY FAILED iter=%u"
-               " seed=%u offset=%zu\n",
-               i, iterSeed, errOff);
-      }
-    }
+    if (doVerify)
+      verify_buffer(dst, transferSize, iterSeed, "single", i, verifyPass,
+                    verifyFail);
 
     i++;
   }
@@ -159,13 +142,7 @@ __global__ void rdma_ep_batch_kernel(
         unsigned op = infinite ? b : sh_ops_done + b;
         uint8_t* src = buf + (size_t)b * 2 * transferSize;
         uint8_t* dst = src + transferSize;
-        uint32_t seed = baseSeed + op;
-        xio::DataPatternParams fp{src,          transferSize, 0,
-                                  transferSize, seed,         nullptr};
-        xio::dataPattern(false, fp);
-        for (uint32_t x = 0; x < transferSize; x++)
-          dst[x] = 0;
-        __threadfence_system();
+        prepare_verify_buffer(src, dst, transferSize, baseSeed + op);
       }
     }
     __syncthreads();
@@ -193,21 +170,8 @@ __global__ void rdma_ep_batch_kernel(
         for (unsigned b = 0; b < batch_count; b++) {
           unsigned op = infinite ? b : sh_ops_done + b;
           uint8_t* dst = buf + (size_t)b * 2 * transferSize + transferSize;
-          uint32_t seed = baseSeed + op;
-          size_t errOff = 0;
-          xio::DataPatternParams vp{dst,          transferSize, 0,
-                                    transferSize, seed,         &errOff};
-          bool ok = xio::dataPattern(true, vp);
-          if (ok) {
-            if (verifyPass)
-              atomicAdd(verifyPass, 1u);
-          } else {
-            if (verifyFail)
-              atomicAdd(verifyFail, 1u);
-            printf("rdma-ep: batch VERIFY FAILED"
-                   " op=%u seed=%u off=%zu\n",
-                   op, seed, errOff);
-          }
+          verify_buffer(dst, transferSize, baseSeed + op, "batch", op,
+                        verifyPass, verifyFail);
         }
       }
 
@@ -327,8 +291,8 @@ __host__ std::string validateConfig(RdmaEpConfig* config) {
 
   config->provider = provider_from_string(config->providerStr.c_str());
   if (config->provider == Provider::UNKNOWN)
-    return "Invalid provider."
-           " Must be: bnxt, mlx5, ionic, or ernic";
+    return std::string("Invalid provider. Must be: ") +
+           provider_allowed_names();
 
   if (config->infiniteMode)
     config->iterations = 0;
@@ -388,7 +352,6 @@ __host__ unsigned getIterations(void* endpointConfig) {
 
 static hipError_t rdma_ep_loopback(xio::XioEndpointConfig* config,
                                    rdma_ep::RdmaEpConfig* cfg) {
-  bool sq_on_device = (config->memoryMode & XIO_MEM_MODE_SQ_DEVICE) != 0;
   bool data_on_device = (config->memoryMode & XIO_MEM_MODE_DATA_DEVICE) != 0;
 
   uint16_t numQueues = cfg->numQueues;
@@ -444,20 +407,8 @@ static hipError_t rdma_ep_loopback(xio::XioEndpointConfig* config,
 
   // Initialize all backends and buffers
   for (uint16_t q = 0; q < numQueues; q++) {
-    rdma_ep::BackendConfig bcfg;
-    bcfg.provider = cfg->provider;
-    bcfg.gpu_device_id = cfg->gpuDeviceId;
-    bcfg.sq_depth = cfg->sqDepth;
-    bcfg.cq_depth = cfg->cqDepth;
-    bcfg.inline_threshold = cfg->inlineThreshold;
-    bcfg.pcie_relaxed_ordering = cfg->pcieRelaxedOrdering;
-    bcfg.traffic_class = cfg->trafficClass;
-    bcfg.loopback = true;
-    bcfg.queue_mem = sq_on_device ? rdma_ep::QueueMemMode::DEVICE_VRAM
-                                  : rdma_ep::QueueMemMode::HOST_COHERENT;
-    bcfg.pci_mmio_bridge = config->pciMmioBridge;
-    if (!cfg->deviceName.empty())
-      bcfg.hca_list = cfg->deviceName.c_str();
+    rdma_ep::BackendConfig bcfg = rdma_ep::make_backend_config(*config, *cfg,
+                                                               true);
 
     queues[q].backend = new rdma_ep::Backend(bcfg);
     int ret = queues[q].backend->init();
@@ -730,22 +681,7 @@ hipError_t run(XioEndpointConfig* config) {
     // ==========================================================
     // 2-node path -- TCP QP exchange, RDMA WRITE + ping-pong
     // ==========================================================
-    bool sq_on_device = (config->memoryMode & XIO_MEM_MODE_SQ_DEVICE) != 0;
-
-    BackendConfig bcfg;
-    bcfg.provider = cfg->provider;
-    bcfg.gpu_device_id = cfg->gpuDeviceId;
-    bcfg.sq_depth = cfg->sqDepth;
-    bcfg.cq_depth = cfg->cqDepth;
-    bcfg.inline_threshold = cfg->inlineThreshold;
-    bcfg.pcie_relaxed_ordering = cfg->pcieRelaxedOrdering;
-    bcfg.traffic_class = cfg->trafficClass;
-    bcfg.loopback = false;
-    bcfg.queue_mem = sq_on_device ? QueueMemMode::DEVICE_VRAM
-                                  : QueueMemMode::HOST_COHERENT;
-    bcfg.pci_mmio_bridge = config->pciMmioBridge;
-    if (!cfg->deviceName.empty())
-      bcfg.hca_list = cfg->deviceName.c_str();
+    BackendConfig bcfg = make_backend_config(*config, *cfg, false);
 
     Backend backend(bcfg);
     int ret = backend.init();

--- a/src/endpoints/rdma-ep/vendor-ops.hpp
+++ b/src/endpoints/rdma-ep/vendor-ops.hpp
@@ -2,11 +2,10 @@
  *
  * SPDX-License-Identifier: MIT
  *
- * Vendor abstraction layer for rdma-ep. Consolidates shared patterns
- * identified across MLX5, BNXT, and IONIC vendor queue_pair implementations
- * from rocSHMEM GDA. Each vendor still implements its own WQE builder,
- * doorbell, and CQE parser; this layer provides the shared control flow,
- * locking, and logical descriptors.
+ * Vendor abstraction layer for rdma-ep. Common host orchestration helpers live
+ * in rdma-common.h; this layer keeps shared device descriptors, wave helpers,
+ * locking, provider IDs, and provider string conversion close to the
+ * vendor-specific QueuePair code that consumes them.
  */
 
 #ifndef RDMA_EP_VENDOR_OPS_HPP

--- a/src/endpoints/rdma-ep/vendor-ops.hpp
+++ b/src/endpoints/rdma-ep/vendor-ops.hpp
@@ -12,7 +12,6 @@
 #define RDMA_EP_VENDOR_OPS_HPP
 
 #include <cstdint>
-#include <cstring>
 
 #include <hip/hip_runtime.h>
 
@@ -66,49 +65,6 @@ struct AmoDescriptor {
   uintptr_t fetch_addr;
   uint32_t fetch_lkey;
 };
-
-enum class QueueMemMode : uint8_t {
-  HOST_COHERENT = 0,
-  DEVICE_VRAM = 1,
-};
-
-enum class Provider : uint8_t {
-  BNXT = 0,
-  MLX5 = 1,
-  IONIC = 2,
-  ROCM_ERNIC = 3,
-  UNKNOWN = 0xFF,
-};
-
-__host__ inline const char* provider_name(Provider p) {
-  switch (p) {
-    case Provider::BNXT:
-      return "bnxt";
-    case Provider::MLX5:
-      return "mlx5";
-    case Provider::IONIC:
-      return "ionic";
-    case Provider::ROCM_ERNIC:
-      return "rocm-ernic";
-    default:
-      return "unknown";
-  }
-}
-
-__host__ inline Provider provider_from_string(const char* s) {
-  if (!s)
-    return Provider::UNKNOWN;
-  if (strcmp(s, "bnxt") == 0 || strcmp(s, "bnxt_re") == 0)
-    return Provider::BNXT;
-  if (strcmp(s, "mlx5") == 0)
-    return Provider::MLX5;
-  if (strcmp(s, "ionic") == 0 || strcmp(s, "pensando") == 0)
-    return Provider::IONIC;
-  if (strcmp(s, "rocm_ernic") == 0 || strcmp(s, "ernic") == 0 ||
-      strcmp(s, "rocm-ernic") == 0)
-    return Provider::ROCM_ERNIC;
-  return Provider::UNKNOWN;
-}
 
 // Vendor ID constants for NIC detection
 constexpr uint32_t VENDOR_ID_BROADCOM = 0x14E4;

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -317,6 +317,30 @@ hsa_status_t closeDmabuf(int fd);
 __host__ std::string extractEndpointName(int argc, char** argv);
 
 /**
+ * @brief Resolved NVMe controller and namespace paths.
+ */
+struct NvmeDevicePath {
+  std::string namespacePath;
+  std::string controllerPath;
+  std::string controllerName;
+};
+
+/**
+ * @brief Resolve an NVMe controller or namespace path.
+ *
+ * Accepts controller nodes such as /dev/nvme0 and namespace paths such as
+ * /dev/disk/by-id/... links. Namespace inputs preserve the original namespace
+ * path while deriving the controller path required by NVMe admin ioctls.
+ *
+ * @param device_path Controller or namespace device path.
+ * @param nsid Namespace ID to use when deriving a namespace from a controller.
+ * @param resolved Output resolved path information.
+ * @return 0 on success, negative error code on failure.
+ */
+__host__ int resolveNvmeDevicePath(const char* device_path, uint32_t nsid,
+                                   NvmeDevicePath* resolved);
+
+/**
  * @brief Detect PCI MMIO bridge BDF by scanning PCI sysfs.
  *
  * Looks for Vendor ID 0x1b36 and Device ID 0x0015. Errors

--- a/src/tester/xio-cli-options.cpp
+++ b/src/tester/xio-cli-options.cpp
@@ -88,7 +88,7 @@ void registerNvmeEpCliOptions(CLI::App& app, xio::nvme_ep::nvmeEpConfig* cfg) {
     ->group(nvme_group);
   app
     .add_option("--controller", cfg->controller,
-                "NVMe controller device path (required).")
+                "NVMe controller or namespace device path (required).")
     ->required()
     ->group(nvme_group);
   app

--- a/tests/system/nvme-ep/run-nvme-smoke-test.sh
+++ b/tests/system/nvme-ep/run-nvme-smoke-test.sh
@@ -21,6 +21,23 @@ set -e
 XIO_TESTER="${XIO_TESTER:-./build/xio-tester}"
 CONTROLLER="${ROCXIO_NVME_DEVICE:-$NVME_DEVICE}"
 
+resolve_controller() {
+    local device="$1"
+    local real
+    real="$(readlink -f "$device")" || return 1
+    local node
+    node="$(basename "$real")"
+
+    if [[ "$node" =~ ^nvme[0-9]+n[0-9]+$ ]]; then
+        local controller
+        controller="$(basename "$(readlink -f \
+            "/sys/class/block/$node/device")")" || return 1
+        echo "/dev/$controller"
+    else
+        echo "$real"
+    fi
+}
+
 if [ -z "$CONTROLLER" ]; then
     echo "SKIP: ROCXIO_NVME_DEVICE not set"
     exit 77
@@ -30,6 +47,12 @@ if [ ! -e "$CONTROLLER" ]; then
     echo "SKIP: NVMe device $CONTROLLER not found"
     exit 77
 fi
+
+CONTROLLER_INPUT="$CONTROLLER"
+CONTROLLER="$(resolve_controller "$CONTROLLER_INPUT")" || {
+    echo "SKIP: failed to resolve NVMe controller from $CONTROLLER_INPUT"
+    exit 77
+}
 
 if [ "$EUID" -ne 0 ]; then
     echo "SKIP: requires root (run with sudo)"
@@ -41,9 +64,14 @@ if [ ! -f "$XIO_TESTER" ]; then
     exit 77
 fi
 
+EXTRA_ARGS=("$@")
+if [ -n "${ROCXIO_NVME_QUEUE_ID:-}" ]; then
+    EXTRA_ARGS+=(--queue-id "$ROCXIO_NVME_QUEUE_ID")
+fi
+
 if [ "${EXPECT_FAIL:-0}" = "1" ]; then
     if "$XIO_TESTER" nvme-ep \
-         --controller "$CONTROLLER" "$@" \
+         --controller "$CONTROLLER" "${EXTRA_ARGS[@]}" \
          >/dev/null 2>&1; then
         echo "FAIL: expected failure but command succeeded"
         exit 1
@@ -54,4 +82,4 @@ if [ "${EXPECT_FAIL:-0}" = "1" ]; then
 fi
 
 exec "$XIO_TESTER" nvme-ep \
-  --controller "$CONTROLLER" "$@"
+  --controller "$CONTROLLER" "${EXTRA_ARGS[@]}"

--- a/tests/unit/rdma-ep/CMakeLists.txt
+++ b/tests/unit/rdma-ep/CMakeLists.txt
@@ -30,6 +30,14 @@ xio_add_test(
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
 )
 
+xio_add_test(
+  NAME test-rdma-common
+  SOURCE test-rdma-common.hip
+  LABELS unit rdma
+  TIMEOUT 30
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
+)
+
 # BNXT queue sizing math (CPU-only, no GPU or NIC)
 xio_add_test(
   NAME test-bnxt-sizing

--- a/tests/unit/rdma-ep/test-rdma-common.hip
+++ b/tests/unit/rdma-ep/test-rdma-common.hip
@@ -1,0 +1,102 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for shared RDMA endpoint helper logic.
+ */
+
+#include <cstdint>
+#include <cstdio>
+
+#include <endian.h>
+
+#include "ibv-core.hpp"
+#include "rdma-common.h"
+#include "xio-test-assert.h"
+
+int test_provider_allowed_names() {
+  ASSERT_STREQ(xio::rdma_ep::provider_allowed_names(),
+               "bnxt, mlx5, ionic, or rocm-ernic");
+  return 0;
+}
+
+int test_normalize_qp_key_mlx5() {
+  uint32_t key = 0x11223344u;
+  ASSERT_EQ(xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::MLX5, key),
+            htobe32(key));
+  return 0;
+}
+
+int test_normalize_qp_key_native_providers() {
+  uint32_t key = 0x11223344u;
+  ASSERT_EQ(xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::BNXT, key),
+            key);
+  ASSERT_EQ(xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::IONIC, key),
+            key);
+  ASSERT_EQ(
+    xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::ROCM_ERNIC, key),
+    key);
+  ASSERT_EQ(
+    xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::UNKNOWN, key), key);
+  return 0;
+}
+
+int test_normalize_mr_keys() {
+  uint32_t lkey = 0x01020304u;
+  uint32_t rkey = 0xa1b2c3d4u;
+  uint32_t normalized_lkey = 0;
+  uint32_t normalized_rkey = 0;
+
+  xio::rdma_ep::normalize_mr_keys(xio::rdma_ep::Provider::MLX5, lkey, rkey,
+                                  &normalized_lkey, &normalized_rkey);
+  ASSERT_EQ(normalized_lkey, htobe32(lkey));
+  ASSERT_EQ(normalized_rkey, htobe32(rkey));
+
+  normalized_lkey = 0;
+  normalized_rkey = 0;
+  xio::rdma_ep::normalize_mr_keys(xio::rdma_ep::Provider::BNXT, lkey, rkey,
+                                  &normalized_lkey, &normalized_rkey);
+  ASSERT_EQ(normalized_lkey, lkey);
+  ASSERT_EQ(normalized_rkey, rkey);
+
+  xio::rdma_ep::normalize_mr_keys(xio::rdma_ep::Provider::MLX5, lkey, rkey,
+                                  nullptr, nullptr);
+  return 0;
+}
+
+int test_rd_atomic_cap() {
+  struct ibv_device_attr attr = {};
+
+  attr.max_qp_rd_atom = 0;
+  ASSERT_EQ(xio::rdma_ep::rd_atomic_cap(xio::rdma_ep::Provider::BNXT, attr),
+            static_cast<uint8_t>(1));
+
+  attr.max_qp_rd_atom = 7;
+  ASSERT_EQ(xio::rdma_ep::rd_atomic_cap(xio::rdma_ep::Provider::BNXT, attr),
+            static_cast<uint8_t>(7));
+
+  attr.max_qp_rd_atom = 512;
+  ASSERT_EQ(xio::rdma_ep::rd_atomic_cap(xio::rdma_ep::Provider::BNXT, attr),
+            static_cast<uint8_t>(255));
+
+  attr.max_qp_rd_atom = 1;
+  ASSERT_EQ(xio::rdma_ep::rd_atomic_cap(xio::rdma_ep::Provider::IONIC, attr),
+            static_cast<uint8_t>(15));
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_provider_allowed_names();
+  failures += test_normalize_qp_key_mlx5();
+  failures += test_normalize_qp_key_native_providers();
+  failures += test_normalize_mr_keys();
+  failures += test_rd_atomic_cap();
+
+  if (failures == 0) {
+    printf("All rdma-common tests passed.\n");
+    return 0;
+  }
+  printf("%d rdma-common test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/rdma-ep/test-rdma-common.hip
+++ b/tests/unit/rdma-ep/test-rdma-common.hip
@@ -33,11 +33,12 @@ int test_normalize_qp_key_native_providers() {
             key);
   ASSERT_EQ(xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::IONIC, key),
             key);
-  ASSERT_EQ(
-    xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::ROCM_ERNIC, key),
-    key);
-  ASSERT_EQ(
-    xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::UNKNOWN, key), key);
+  ASSERT_EQ(xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::ROCM_ERNIC,
+                                           key),
+            key);
+  ASSERT_EQ(xio::rdma_ep::normalize_qp_key(xio::rdma_ep::Provider::UNKNOWN,
+                                           key),
+            key);
   return 0;
 }
 

--- a/tests/unit/rdma-ep/test-rdma-loopback.hip
+++ b/tests/unit/rdma-ep/test-rdma-loopback.hip
@@ -246,6 +246,12 @@ int main(int argc, char** argv) {
   unsigned iterations = DEFAULT_ITERATIONS;
   const char* provider_str = "auto";
   const char* device_name = nullptr;
+  const char* env_provider = getenv("PROVIDER");
+  const char* env_device = getenv("ROCXIO_RDMA_DEVICE");
+  if (env_provider && env_provider[0] != '\0')
+    provider_str = env_provider;
+  if (env_device && env_device[0] != '\0')
+    device_name = env_device;
   bool diag_mode = false;
   bool write_imm = false;
   bool cpu_poll = false;


### PR DESCRIPTION
Move vendor-independent RDMA setup and verification paths into shared common helpers so provider-specific code only owns hardware-specific WQE, doorbell, CQE, and DV behavior. This centralizes backend config mapping, provider diagnostics, MLX5 key normalization, QP setup defaults, QP modify dispatch, RD atomic caps, and kernel verification logic.

Validation:
- cmake --build build --target all
- ctest --test-dir build -L unit --output-on-failure
- clang-format --dry-run --Werror --style=file on changed RDMA files
- cmake --build build-docs --target doxygen

