### PR TITLE
Improve Doxygen coverage for public API and owned headers

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1012,6 +1012,7 @@ waitCounter
 waitSignal
 XioEndpoint
 XioEndpointConfig
+XioSubstepStats
 xioBufferInfo
 xioQueueSetup
 XioTimingStats

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -21,10 +21,30 @@ EXTRACT_ALL            = YES
 EXTRACT_PRIVATE        = NO
 EXTRACT_STATIC         = YES
 
-# Exclude generated headers and external vendored headers
+# Exclude generated headers, imported ABI mirrors, and low-level protocol
+# layouts that are implementation inputs rather than ROCm XIO API.
 EXCLUDE_PATTERNS       = */external/* \
                          *-generated.h \
-                         *-gen.h
+                         *-gen.h \
+                         */src/common/ibv-core.hpp \
+                         */src/endpoints/rdma-ep/bnxt/bnxt-provider.hpp \
+                         */src/endpoints/rdma-ep/bnxt/bnxt-rdma.h \
+                         */src/endpoints/rdma-ep/bnxt/bnxt-re-dv.h \
+                         */src/endpoints/rdma-ep/bnxt/bnxt-re-hsi.h \
+                         */src/endpoints/rdma-ep/ionic/ionic-provider.hpp \
+                         */src/endpoints/rdma-ep/ionic/ionic-dv.h \
+                         */src/endpoints/rdma-ep/ionic/ionic-fw.h \
+                         */src/endpoints/rdma-ep/ionic/ionic-rdma.h \
+                         */src/endpoints/rdma-ep/mlx/mlx5-rdma.h \
+                         */src/endpoints/rdma-ep/mlx5/mlx5-provider.hpp \
+                         */src/endpoints/rdma-ep/rocm-ernic/ernic-provider.hpp \
+                         */src/endpoints/rdma-ep/rocm-ernic/rocm-ernic-dv.h \
+                         */src/endpoints/sdma-ep/anvil.hpp \
+                         */src/endpoints/sdma-ep/anvil_device.hpp \
+                         */src/endpoints/sdma-ep/sdma-packet.h \
+                         */src/endpoints/sdma-ep/sdma_opcodes.h \
+                         */src/endpoints/sdma-ep/sdma_pkt_struct.h \
+                         */src/endpoints/sdma-ep/sdma_pkt_struct_mi4.h
 
 # XML output for Breathe (via rocm_docs.doxygen)
 GENERATE_HTML          = NO

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -28,6 +28,10 @@ Base Classes
    :members:
    :undoc-members:
 
+.. doxygenstruct:: xio::XioSubstepStats
+   :members:
+   :undoc-members:
+
 Endpoint Registry
 ^^^^^^^^^^^^^^^^^
 

--- a/src/common/endian.hpp
+++ b/src/common/endian.hpp
@@ -16,6 +16,12 @@
 namespace xio {
 namespace rdma_ep {
 
+/**
+ * @brief Reverse byte order for an integral value.
+ * @tparam T Integral value type.
+ * @param val Value to byte-swap.
+ * @return Value with bytes in reverse order.
+ */
 template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
 constexpr inline __host__ __device__ T byteswap(T val) {
   if constexpr (sizeof(T) == 1) {
@@ -33,12 +39,21 @@ constexpr inline __host__ __device__ T byteswap(T val) {
 
 namespace endian {
 
+/** @brief Endian order used by conversion helpers. */
 enum class Order {
-  Big = __ORDER_BIG_ENDIAN__,
-  Little = __ORDER_LITTLE_ENDIAN__,
-  Native = __BYTE_ORDER__
+  Big = __ORDER_BIG_ENDIAN__,       /**< Big-endian byte order. */
+  Little = __ORDER_LITTLE_ENDIAN__, /**< Little-endian byte order. */
+  Native = __BYTE_ORDER__           /**< Compile-target native order. */
 };
 
+/**
+ * @brief Convert an integral value between endian orders.
+ * @tparam To Destination byte order.
+ * @tparam From Source byte order.
+ * @tparam T Integral value type.
+ * @param val Value to convert.
+ * @return Converted value, or @p val when orders match.
+ */
 template <Order To, Order From, typename T,
           std::enable_if_t<std::is_integral_v<T>, bool> = true>
 __host__ __device__ constexpr inline T convert(T val) {
@@ -49,31 +64,69 @@ __host__ __device__ constexpr inline T convert(T val) {
   }
 }
 
+/**
+ * @brief Convert from a specified endian order to native order.
+ * @tparam From Source byte order.
+ * @tparam T Integral value type.
+ * @param val Value to convert.
+ * @return Native-order value.
+ */
 template <Order From, typename T>
 __host__ __device__ constexpr inline T to_native(T val) {
   return convert<Order::Native, From, T>(val);
 }
 
+/**
+ * @brief Convert from native order to a specified endian order.
+ * @tparam To Destination byte order.
+ * @tparam T Integral value type.
+ * @param val Value to convert.
+ * @return Value in destination order.
+ */
 template <Order To, typename T>
 __host__ __device__ constexpr inline T from_native(T val) {
   return convert<To, Order::Native, T>(val);
 }
 
+/**
+ * @brief Convert a native-order value to big-endian order.
+ * @tparam T Integral value type.
+ * @param val Native-order value.
+ * @return Big-endian value.
+ */
 template <typename T>
 __host__ __device__ constexpr inline T to_be(T val) {
   return convert<Order::Big, Order::Native, T>(val);
 }
 
+/**
+ * @brief Convert a big-endian value to native order.
+ * @tparam T Integral value type.
+ * @param val Big-endian value.
+ * @return Native-order value.
+ */
 template <typename T>
 __host__ __device__ constexpr inline T from_be(T val) {
   return convert<Order::Native, Order::Big, T>(val);
 }
 
+/**
+ * @brief Convert a native-order value to little-endian order.
+ * @tparam T Integral value type.
+ * @param val Native-order value.
+ * @return Little-endian value.
+ */
 template <typename T>
 __host__ __device__ constexpr inline T to_le(T val) {
   return convert<Order::Little, Order::Native, T>(val);
 }
 
+/**
+ * @brief Convert a little-endian value to native order.
+ * @tparam T Integral value type.
+ * @param val Little-endian value.
+ * @return Native-order value.
+ */
 template <typename T>
 __host__ __device__ constexpr inline T from_le(T val) {
   return convert<Order::Native, Order::Little, T>(val);

--- a/src/common/ibv-wrapper.hpp
+++ b/src/common/ibv-wrapper.hpp
@@ -20,57 +20,199 @@
 namespace xio {
 namespace rdma_ep {
 
+/** @brief Runtime-loaded libibverbs facade used by rdma-ep. */
 class IBVWrapper {
 public:
+  /** @brief Load libibverbs and resolve required symbols. */
   explicit IBVWrapper();
+
+  /** @brief Close the libibverbs handle. */
   virtual ~IBVWrapper();
 
-  bool is_initialized{false};
+  bool is_initialized{false}; /**< true when required symbols are resolved. */
 
+  /**
+   * @brief Check whether DMA-BUF memory registration is available.
+   * @return 1 if supported and enabled, 0 if unavailable, -1 on error.
+   */
   int is_dmabuf_supported();
 
+  /**
+   * @brief Forward to ibv_get_device_list().
+   * @param num_devices Output number of returned devices.
+   * @return Null-terminated device list, or nullptr on failure.
+   */
   struct ibv_device** get_device_list(int* num_devices);
+  /**
+   * @brief Forward to ibv_free_device_list().
+   * @param list Device list returned by get_device_list().
+   */
   void free_device_list(struct ibv_device** list);
 
+  /**
+   * @brief Forward to ibv_open_device().
+   * @param device Device handle to open.
+   * @return Opened verbs context, or nullptr on failure.
+   */
   struct ibv_context* open_device(struct ibv_device* device);
+  /**
+   * @brief Forward to ibv_close_device().
+   * @param context Verbs context to close.
+   * @return 0 on success, nonzero on failure.
+   */
   int close_device(struct ibv_context* context);
 
+  /**
+   * @brief Forward to ibv_get_device_name().
+   * @param device Device handle to query.
+   * @return Provider device name string.
+   */
   const char* get_device_name(struct ibv_device* device);
+  /**
+   * @brief Forward to ibv_query_device().
+   * @param context Verbs context to query.
+   * @param device_attr Output device attributes.
+   * @return 0 on success, nonzero on failure.
+   */
   int query_device(struct ibv_context* context,
                    struct ibv_device_attr* device_attr);
+  /**
+   * @brief Forward to ibv_query_port().
+   * @param context Verbs context to query.
+   * @param port_num One-based port number.
+   * @param port_attr Output port attributes.
+   * @return 0 on success, nonzero on failure.
+   */
   int query_port(struct ibv_context* context, uint8_t port_num,
                  struct ibv_port_attr* port_attr);
+  /**
+   * @brief Forward to ibv_query_gid_table().
+   * @param context Verbs context to query.
+   * @param entries Output GID table entries.
+   * @param max_entries Maximum entries in @p entries.
+   * @param flags Query flags.
+   * @return Number of entries written, or negative errno on failure.
+   */
   ssize_t query_gid_table(struct ibv_context* context,
                           struct ibv_gid_entry* entries, size_t max_entries,
                           uint32_t flags);
+  /**
+   * @brief Forward to ibv_query_gid().
+   * @param context Verbs context to query.
+   * @param port_num One-based port number.
+   * @param index GID table index.
+   * @param gid Output GID value.
+   * @return 0 on success, nonzero on failure.
+   */
   int query_gid(struct ibv_context* context, uint8_t port_num, int index,
                 union ibv_gid* gid);
 
+  /**
+   * @brief Forward to ibv_alloc_pd().
+   * @param context Verbs context owning the PD.
+   * @return Allocated protection domain, or nullptr on failure.
+   */
   struct ibv_pd* alloc_pd(struct ibv_context* context);
+  /**
+   * @brief Forward to ibv_alloc_parent_domain().
+   * @param context Verbs context owning the parent domain.
+   * @param attr Parent-domain initialization attributes.
+   * @return Allocated parent domain, or nullptr on failure.
+   */
   struct ibv_pd* alloc_parent_domain(struct ibv_context* context,
                                      struct ibv_parent_domain_init_attr* attr);
+  /**
+   * @brief Forward to ibv_dealloc_pd().
+   * @param pd Protection domain to deallocate.
+   * @return 0 on success, nonzero on failure.
+   */
   int dealloc_pd(struct ibv_pd* pd);
 
+  /**
+   * @brief Register memory using the best available verbs path.
+   * @param pd Protection domain for the MR.
+   * @param addr Buffer base address.
+   * @param length Buffer size in bytes.
+   * @param access Verbs access flags.
+   * @return Registered memory region, or nullptr on failure.
+   */
   struct ibv_mr* reg_mr(struct ibv_pd* pd, void* addr, size_t length,
                         int access);
+  /**
+   * @brief Register host memory with stable IOVA semantics.
+   * @param pd Protection domain for the MR.
+   * @param addr Buffer base address.
+   * @param length Buffer size in bytes.
+   * @param access Verbs access flags.
+   * @return Registered memory region, or nullptr on failure.
+   */
   struct ibv_mr* reg_mr_host(struct ibv_pd* pd, void* addr, size_t length,
                              int access);
+  /**
+   * @brief Forward to ibv_dereg_mr().
+   * @param mr Memory region to deregister.
+   * @return 0 on success, nonzero on failure.
+   */
   int dereg_mr(struct ibv_mr* mr);
 
+  /**
+   * @brief Forward to ibv_create_cq().
+   * @param context Verbs context owning the CQ.
+   * @param cqe Requested completion depth.
+   * @param cq_context User context pointer.
+   * @param channel Optional completion channel.
+   * @param comp_vector Completion vector index.
+   * @return Created CQ, or nullptr on failure.
+   */
   struct ibv_cq* create_cq(struct ibv_context* context, int cqe,
                            void* cq_context, struct ibv_comp_channel* channel,
                            int comp_vector);
+  /**
+   * @brief Forward to ibv_create_cq_ex().
+   * @param context Verbs context owning the CQ.
+   * @param cq_attr Extended CQ initialization attributes.
+   * @return Created extended CQ, or nullptr on failure.
+   */
   struct ibv_cq_ex* create_cq_ex(struct ibv_context* context,
                                  struct ibv_cq_init_attr_ex* cq_attr);
+  /**
+   * @brief Convert an extended CQ handle to a base CQ handle.
+   * @param cq Extended CQ handle.
+   * @return Base CQ handle, or nullptr when @p cq is nullptr.
+   */
   struct ibv_cq* cq_ex_to_cq(struct ibv_cq_ex* cq);
+  /**
+   * @brief Forward to ibv_destroy_cq().
+   * @param cq CQ to destroy.
+   * @return 0 on success, nonzero on failure.
+   */
   int destroy_cq(struct ibv_cq* cq);
 
+  /**
+   * @brief Forward to ibv_create_qp_ex().
+   * @param context Verbs context owning the QP.
+   * @param qp_init_attr Extended QP initialization attributes.
+   * @return Created QP, or nullptr on failure.
+   */
   struct ibv_qp* create_qp_ex(struct ibv_context* context,
                               struct ibv_qp_init_attr_ex* qp_init_attr);
+  /**
+   * @brief Forward to ibv_modify_qp().
+   * @param qp QP to modify.
+   * @param attr Attribute values to apply.
+   * @param attr_mask Bit mask selecting attributes in @p attr.
+   * @return 0 on success, nonzero on failure.
+   */
   int modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask);
+  /**
+   * @brief Forward to ibv_destroy_qp().
+   * @param qp QP to destroy.
+   * @return 0 on success, nonzero on failure.
+   */
   int destroy_qp(struct ibv_qp* qp);
 
 private:
+  /** @cond INTERNAL */
   struct ibv_funcs_t {
     struct ibv_device** (*get_device_list)(int* num_devices);
     void (*free_device_list)(struct ibv_device** list);
@@ -129,6 +271,7 @@ private:
   bool dmabuf_enabled_{true};
 
   std::map<uintptr_t, int> dmabuf_fd_map_;
+  /** @endcond */
 };
 
 extern IBVWrapper ibv;

--- a/src/common/rdma-numa-wrapper.hpp
+++ b/src/common/rdma-numa-wrapper.hpp
@@ -16,25 +16,77 @@ struct bitmask;
 namespace xio {
 namespace rdma_ep {
 
+/** @brief Runtime-loaded libnuma facade used by topology helpers. */
 class NUMAWrapper {
 public:
+  /** @brief Load libnuma and resolve required symbols. */
   explicit NUMAWrapper();
+
+  /** @brief Close the libnuma handle. */
   virtual ~NUMAWrapper();
 
-  bool is_initialized{false};
+  bool is_initialized{false}; /**< true when required symbols are resolved. */
 
+  /**
+   * @brief Forward to numa_bitmask_isbitset().
+   * @param bmp NUMA bitmask to inspect.
+   * @param n Bit index to test.
+   * @return Nonzero if the bit is set.
+   */
   int bitmask_isbitset(const struct bitmask* bmp, unsigned int n);
+  /**
+   * @brief Forward to numa_get_mems_allowed().
+   * @return Current memory-node allowance mask, or nullptr on failure.
+   */
   struct bitmask* get_mems_allowed();
+  /**
+   * @brief Forward to numa_set_preferred().
+   * @param node Preferred NUMA node ID.
+   */
   void set_preferred(int node);
+  /**
+   * @brief Forward to numa_num_configured_nodes().
+   * @return Number of configured NUMA nodes.
+   */
   int num_configured_nodes();
+  /**
+   * @brief Forward to numa_num_configured_cpus().
+   * @return Number of configured CPUs.
+   */
   int num_configured_cpus();
+  /**
+   * @brief Forward to numa_node_of_cpu().
+   * @param cpu CPU index to query.
+   * @return NUMA node ID, or negative value on failure.
+   */
   int node_of_cpu(int cpu);
+  /**
+   * @brief Forward to numa_max_node().
+   * @return Maximum configured NUMA node ID.
+   */
   int max_node();
+  /**
+   * @brief Forward to numa_move_pages().
+   * @param pid Process ID, or 0 for the current process.
+   * @param count Number of pages in @p pages.
+   * @param pages Page-aligned addresses to query or move.
+   * @param nodes Desired nodes, or nullptr for query.
+   * @param status Output page status array.
+   * @param flags NUMA move_pages flags.
+   * @return 0 on success, negative value on failure.
+   */
   long move_pages(int pid, unsigned long count, void** pages, const int* nodes,
                   int* status, int flags);
+  /**
+   * @brief Forward to numa_distance().
+   * @param node1 First NUMA node ID.
+   * @param node2 Second NUMA node ID.
+   * @return Relative NUMA distance.
+   */
   int distance(int node1, int node2);
 
 private:
+  /** @cond INTERNAL */
   struct numa_funcs_t {
     int (*bitmask_isbitset)(const struct bitmask* bmp, unsigned int n);
     struct bitmask* (*get_mems_allowed)();
@@ -52,6 +104,7 @@ private:
   void* numa_handle_{nullptr};
 
   int init_function_table();
+  /** @endcond */
 };
 
 extern NUMAWrapper numa;

--- a/src/common/rdma-topology.hpp
+++ b/src/common/rdma-topology.hpp
@@ -20,62 +20,139 @@
 namespace xio {
 namespace rdma_ep {
 
+/** @brief GID type preference order for RoCE address selection. */
 enum GidPriority {
-  GID_UNKNOWN = -1,
-  ROCEV1_LINK_LOCAL = 0,
-  ROCEV2_LINK_LOCAL = 1,
-  ROCEV1_IPV6 = 2,
-  ROCEV2_IPV6 = 3,
-  ROCEV1_IPV4 = 4,
-  ROCEV2_IPV4 = 5,
+  GID_UNKNOWN = -1,      /**< Unknown or unsupported GID type. */
+  ROCEV1_LINK_LOCAL = 0, /**< RoCEv1 link-local IPv6 GID. */
+  ROCEV2_LINK_LOCAL = 1, /**< RoCEv2 link-local IPv6 GID. */
+  ROCEV1_IPV6 = 2,       /**< RoCEv1 routable IPv6 GID. */
+  ROCEV2_IPV6 = 3,       /**< RoCEv2 routable IPv6 GID. */
+  ROCEV1_IPV4 = 4,       /**< RoCEv1 IPv4-mapped GID. */
+  ROCEV2_IPV4 = 5,       /**< RoCEv2 IPv4-mapped GID. */
 };
 
+/** @brief Device classes used by topology enumeration helpers. */
 enum DeviceType {
-  DEV_CPU = 0,
-  DEV_GPU = 1,
-  DEV_NIC = 2,
+  DEV_CPU = 0, /**< CPU NUMA node. */
+  DEV_GPU = 1, /**< HIP GPU device. */
+  DEV_NIC = 2, /**< RDMA NIC device. */
 };
 
+/** @brief Node in the PCIe topology tree used for proximity scoring. */
 struct PCIeNode {
-  std::string address;
-  mutable std::string description;
-  std::set<PCIeNode> children;
+  std::string address;             /**< PCI address component for this node. */
+  mutable std::string description; /**< Human-readable sysfs description. */
+  std::set<PCIeNode> children;     /**< Child PCIe devices or bridges. */
 
+  /** @brief Construct an empty topology node. */
   PCIeNode() = default;
+
+  /**
+   * @brief Construct a node with only a PCI address.
+   * @param addr PCI address string.
+   */
   PCIeNode(std::string const& addr) : address(addr) {
   }
+
+  /**
+   * @brief Construct a node with a PCI address and description.
+   * @param addr PCI address string.
+   * @param desc Human-readable device description.
+   */
   PCIeNode(std::string const& addr, std::string const& desc)
     : address(addr), description(desc) {
   }
 
+  /**
+   * @brief Order nodes by PCI address for set storage.
+   * @param other Node to compare against.
+   * @return true when this address sorts before @p other.
+   */
   bool operator<(PCIeNode const& other) const {
     return address < other.address;
   }
 };
 
+/**
+ * @brief Extract the bus number from a PCI address string.
+ * @param pcieAddress PCI address such as 0000:03:00.0.
+ * @return Bus number, or -1 if parsing fails.
+ */
 int ExtractBusNumber(std::string const& pcieAddress);
+
+/**
+ * @brief Compute absolute bus-number distance between two PCI addresses.
+ * @param pcieAddress1 First PCI address.
+ * @param pcieAddress2 Second PCI address.
+ * @return Absolute bus distance, or -1 if either address is invalid.
+ */
 int GetBusIdDistance(std::string const& pcieAddress1,
                      std::string const& pcieAddress2);
 
+/**
+ * @brief Find the least common ancestor for two PCIe nodes.
+ * @param root Root of the topology tree.
+ * @param node1Address First target PCI address.
+ * @param node2Address Second target PCI address.
+ * @return Pointer to the LCA node, or nullptr when not found.
+ */
 PCIeNode const* GetLcaBetweenNodes(PCIeNode const* root,
                                    std::string const& node1Address,
                                    std::string const& node2Address);
 
+/**
+ * @brief Find the depth of a PCI address under a topology node.
+ * @param targetBusID PCI address to locate.
+ * @param node Current search node.
+ * @param depth Current tree depth.
+ * @return Node depth, or -1 if the address is absent.
+ */
 int GetLcaDepth(std::string const& targetBusID, PCIeNode const* const& node,
                 int depth = 0);
 
+/**
+ * @brief Insert one sysfs PCIe path into the topology tree.
+ * @param pcieAddress PCI address path component.
+ * @param description Human-readable device description.
+ * @param root Tree root to update.
+ * @return 0 on success, negative value on parse failure.
+ */
 int InsertPCIePathToTree(std::string const& pcieAddress,
                          std::string const& description, PCIeNode& root);
 
+/**
+ * @brief Return nearest candidate devices using the discovered PCIe tree.
+ * @param targetBusId PCI address of the target device.
+ * @param candidateBusIdList Candidate PCI addresses to score.
+ * @return Candidate indices with minimum topology distance.
+ */
 std::set<int> GetNearestDevicesInTree(
   std::string const& targetBusId,
   std::vector<std::string> const& candidateBusIdList);
 
+/**
+ * @brief Return nearest candidate devices using an explicit PCIe tree.
+ * @param targetBusId PCI address of the target device.
+ * @param candidateBusIdList Candidate PCI addresses to score.
+ * @param root Root of the topology tree to use.
+ * @return Candidate indices with minimum topology distance.
+ */
 std::set<int> GetNearestDevicesInTree(
   std::string const& targetBusId,
   std::vector<std::string> const& candidateBusIdList, PCIeNode const* root);
 
+/**
+ * @brief Find the CPU NUMA node closest to a HIP GPU.
+ * @param gpuIndex HIP GPU device index.
+ * @return NUMA node ID, or -1 on failure.
+ */
 int GetClosestCpuNumaToGpu(int gpuIndex);
+
+/**
+ * @brief Find the CPU NUMA node closest to an RDMA NIC.
+ * @param nicIndex Index in the IBV device list.
+ * @return NUMA node ID, or -1 on failure.
+ */
 int GetClosestCpuNumaToNic(int nicIndex);
 
 /**
@@ -90,6 +167,11 @@ int GetClosestCpuNumaToNic(int nicIndex);
 int GetClosestNicToGpu(int gpuIndex, const char* hca_list,
                        const char** dev_name);
 
+/**
+ * @brief Count devices of a topology class.
+ * @param type Device class to count.
+ * @return Number of devices detected, or negative value on failure.
+ */
 int GetNumDevices(DeviceType type);
 
 /**

--- a/src/common/xio-data-pattern.hpp
+++ b/src/common/xio-data-pattern.hpp
@@ -20,13 +20,14 @@
 
 namespace xio {
 
+/** @brief Parameters for deterministic LFSR data generation or checking. */
 struct DataPatternParams {
-  uint8_t* buffer;
-  size_t size;
-  uint64_t offset;
-  uint32_t blockSize;
-  uint32_t seed;
-  size_t* errorOffset;
+  uint8_t* buffer;     /**< Buffer to fill or verify. */
+  size_t size;         /**< Number of bytes to process. */
+  uint64_t offset;     /**< Logical byte offset of the transfer. */
+  uint32_t blockSize;  /**< Block size used to derive the pattern seed. */
+  uint32_t seed;       /**< Caller-supplied seed mixed into the pattern. */
+  size_t* errorOffset; /**< Optional output byte offset for first mismatch. */
 };
 
 /**

--- a/src/common/xio-env.h
+++ b/src/common/xio-env.h
@@ -10,47 +10,75 @@
 
 namespace xio {
 
+/** @brief Logging thresholds controlled by ROCXIO_LOG_LEVEL. */
 enum LogLevel : int {
-  LOG_NONE = 0,
-  LOG_ERROR = 1,
-  LOG_WARN = 2,
-  LOG_INFO = 3,
-  LOG_DEBUG = 4,
-  LOG_TRACE = 5
+  LOG_NONE = 0,  /**< Disable rocm-xio logging. */
+  LOG_ERROR = 1, /**< Print only error messages. */
+  LOG_WARN = 2,  /**< Print warnings and errors. */
+  LOG_INFO = 3,  /**< Print informational messages and above. */
+  LOG_DEBUG = 4, /**< Print debug messages and above. */
+  LOG_TRACE = 5  /**< Print trace-level messages and above. */
 };
 
+/**
+ * @brief Read an integer environment variable.
+ * @param name Environment variable name.
+ * @param defaultVal Value returned when unset or invalid.
+ * @return Parsed integer value, or @p defaultVal.
+ */
 int getEnvInt(const char* name, int defaultVal);
+
+/**
+ * @brief Read a string environment variable.
+ * @param name Environment variable name.
+ * @param defaultVal Value returned when unset.
+ * @return Environment value pointer, or @p defaultVal.
+ */
 const char* getEnvStr(const char* name, const char* defaultVal);
 
+/**
+ * @brief Return the active rocm-xio log threshold.
+ * @return One of LogLevel, parsed from ROCXIO_LOG_LEVEL.
+ */
 int rocxioLogLevel();
+
+/**
+ * @brief Check whether verbose mode is enabled.
+ * @return true when ROCXIO_VERBOSE is set to a nonzero value.
+ */
 bool rocxioVerbose();
 
 } // namespace xio
 
+/** @brief Print an error log message when error logging is enabled. */
 #define ROCXIO_LOG_ERROR(fmt, ...)                                             \
   do {                                                                         \
     if (xio::rocxioLogLevel() >= xio::LOG_ERROR)                               \
       fprintf(stderr, "rocm-xio ERROR: " fmt, ##__VA_ARGS__);                  \
   } while (0)
 
+/** @brief Print a warning log message when warning logging is enabled. */
 #define ROCXIO_LOG_WARN(fmt, ...)                                              \
   do {                                                                         \
     if (xio::rocxioLogLevel() >= xio::LOG_WARN)                                \
       fprintf(stderr, "rocm-xio WARN: " fmt, ##__VA_ARGS__);                   \
   } while (0)
 
+/** @brief Print an info log message when info logging is enabled. */
 #define ROCXIO_LOG_INFO(fmt, ...)                                              \
   do {                                                                         \
     if (xio::rocxioLogLevel() >= xio::LOG_INFO)                                \
       fprintf(stdout, "rocm-xio INFO: " fmt, ##__VA_ARGS__);                   \
   } while (0)
 
+/** @brief Print a debug log message when debug logging is enabled. */
 #define ROCXIO_LOG_DEBUG(fmt, ...)                                             \
   do {                                                                         \
     if (xio::rocxioLogLevel() >= xio::LOG_DEBUG)                               \
       fprintf(stderr, "rocm-xio DEBUG: " fmt, ##__VA_ARGS__);                  \
   } while (0)
 
+/** @brief Print a trace log message when trace logging is enabled. */
 #define ROCXIO_LOG_TRACE(fmt, ...)                                             \
   do {                                                                         \
     if (xio::rocxioLogLevel() >= xio::LOG_TRACE)                               \

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -24,8 +24,10 @@ namespace xio::nvme_ep {
 /**
  * Polling limits for completion queue operations
  */
-#define NVME_EP_MAX_POLLS 10000000U            // Maximum polls before timeout
-#define NVME_EP_MAX_POLLS_BEFORE_BACKOFF 1000U // Polls before backoff reset
+/** @brief Maximum completion-queue polls before an NVMe timeout. */
+#define NVME_EP_MAX_POLLS 10000000U
+/** @brief Completion polls before issuing a GPU sleep backoff. */
+#define NVME_EP_MAX_POLLS_BEFORE_BACKOFF 1000U
 
 /**
  * Doorbell register constants
@@ -59,19 +61,19 @@ typedef struct nvme_cqe cqeType;
  * device code.
  */
 struct nvmeIoParams {
-  uint32_t lbaSize;       // Logical block size in bytes
-  uint64_t baseLba;       // Starting LBA for I/O operations
-  uint64_t lbaRangeLbas;  // LBA range limit (0 = no limit)
-  bool useRandomAccess;   // true for random access, false for sequential
-  int readIo;             // Number of read operations
-  int writeIo;            // Number of write operations
-  uint32_t lfsrSeed;      // Seed for LFSR test pattern (0 = derive from LBA)
-  uint16_t queueSize;     // Queue size in entries
-  uint32_t nsid;          // Namespace ID (must be > 0)
-  uint32_t lbasPerIo;     // Number of LBAs per I/O operation (default: 1)
-  bool infiniteMode;      // Infinite mode: run forever
-  uint32_t batchSize;     // SQEs per doorbell (1=sequential, 0=all)
-  uint32_t wavefrontSize; // Hardware wavefront size (threads per wave)
+  uint32_t lbaSize;       /**< Logical block size in bytes. */
+  uint64_t baseLba;       /**< Starting LBA for I/O operations. */
+  uint64_t lbaRangeLbas;  /**< LBA range limit; 0 means no limit. */
+  bool useRandomAccess;   /**< true for random, false for sequential. */
+  int readIo;             /**< Number of read operations. */
+  int writeIo;            /**< Number of write operations. */
+  uint32_t lfsrSeed;      /**< LFSR seed; 0 derives seed from LBA. */
+  uint16_t queueSize;     /**< Queue depth in entries. */
+  uint32_t nsid;          /**< NVMe namespace ID; must be nonzero. */
+  uint32_t lbasPerIo;     /**< Number of LBAs per I/O operation. */
+  bool infiniteMode;      /**< Run until stopRequested is set. */
+  uint32_t batchSize;     /**< SQEs per doorbell; 1=serial, 0=all. */
+  uint32_t wavefrontSize; /**< Hardware wavefront size in threads. */
 };
 
 /**
@@ -81,11 +83,11 @@ struct nvmeIoParams {
  * and direct BAR0 access. At least one mode must be configured.
  */
 struct nvmeDoorbellParams {
-  uint32_t doorbellOffset; // Offset within BAR0 for doorbell register
-  uint16_t nvmeTargetBdf;  // NVMe target device BDF (0xBBDD format)
-  void* shadowBufferVirt;  // Shadow buffer pointer (MMIO bridge mode)
-  void* nvmeBar0Gpu;       // GPU-accessible BAR0 pointer (direct mode)
-  bool usePciMmioBridge;   // Use PCI MMIO bridge mode (vs direct BAR0)
+  uint32_t doorbellOffset; /**< Doorbell register offset within BAR0. */
+  uint16_t nvmeTargetBdf;  /**< NVMe target device in 0xBBDD form. */
+  void* shadowBufferVirt;  /**< PCI MMIO bridge shadow buffer pointer. */
+  void* nvmeBar0Gpu;       /**< GPU-accessible BAR0 pointer. */
+  bool usePciMmioBridge;   /**< Use bridge mode instead of direct BAR0. */
 };
 
 /**
@@ -95,18 +97,18 @@ struct nvmeDoorbellParams {
  * Buffers must be GPU-accessible. DMA addresses are used for PRP entries.
  */
 struct nvmeBufferParams {
-  uint8_t* readBuffer;     // Read buffer pointer (can be nullptr)
-  uint8_t* writeBuffer;    // Write buffer pointer (can be nullptr)
-  size_t bufferSize;       // Size of buffers in bytes
-  uint64_t readBufferDma;  // DMA address for read buffer
-  uint64_t writeBufferDma; // DMA address for write buffer
-  uint64_t* readPagePhysAddrs;
-  uint64_t* writePagePhysAddrs;
-  uint32_t readNumPages;
-  uint32_t writeNumPages;
-  uint64_t* prpListPool;
-  uint64_t prpListPoolDma;
-  uint32_t prpEntriesPerCmd;
+  uint8_t* readBuffer;          /**< Read destination buffer, or nullptr. */
+  uint8_t* writeBuffer;         /**< Write source buffer, or nullptr. */
+  size_t bufferSize;            /**< Size of each data buffer in bytes. */
+  uint64_t readBufferDma;       /**< DMA address for readBuffer. */
+  uint64_t writeBufferDma;      /**< DMA address for writeBuffer. */
+  uint64_t* readPagePhysAddrs;  /**< Physical address per read page. */
+  uint64_t* writePagePhysAddrs; /**< Physical address per write page. */
+  uint32_t readNumPages;        /**< Entries in readPagePhysAddrs. */
+  uint32_t writeNumPages;       /**< Entries in writePagePhysAddrs. */
+  uint64_t* prpListPool;        /**< PRP list backing storage for commands. */
+  uint64_t prpListPoolDma;      /**< DMA address of prpListPool. */
+  uint32_t prpEntriesPerCmd;    /**< PRP entries reserved per command. */
 };
 
 /**
@@ -635,6 +637,10 @@ __host__ __device__ static inline void calculatePrps(
  * Backward-compatible calculatePrps for transfers that
  * fit within at most 2 NVMe pages (up to 8KB at 4KB
  * page size). Does not support PRP lists.
+ *
+ * @param bufferAddr DMA address of the transfer buffer.
+ * @param bufferSize Transfer size in bytes.
+ * @param sqe SQE to update with PRP1 and PRP2 values.
  */
 __host__ __device__ static inline void calculatePrps(uint64_t bufferAddr,
                                                      uint32_t bufferSize,
@@ -693,65 +699,60 @@ __global__ void gpuKernel(XioEndpointConfig config, nvmeIoParams ioParams,
  * used in device code.
  */
 struct nvmeEpConfig {
-  // Device and queue configuration (host-side only)
-  std::string controller; // NVMe controller device path
-  uint16_t queueId;       // Highest queue ID (0=auto-detect, 1+=IO)
-  uint16_t queueLength;   // Queue length in entries (power of 2)
-  uint16_t numQueues;     // Number of queues to use (default 1)
-  bool queuesCreated;     // Flag: queues have been created
-  uint32_t wavefrontSize; // Hardware wavefront size
+  std::string controller; /**< NVMe controller or namespace device path. */
+  uint16_t queueId;       /**< Highest queue ID; 0 means auto-detect. */
+  uint16_t queueLength;   /**< Queue depth in entries; must be power of 2. */
+  uint16_t numQueues;     /**< Number of independent I/O queues to use. */
+  bool queuesCreated;     /**< true after host-side queues are created. */
+  uint32_t wavefrontSize; /**< Hardware wavefront size in threads. */
 
-  // Per-queue state (populated by run() for multi-queue)
-  struct nvme_queue_info queueInfo;
-  std::vector<uint16_t> queueIds;
-  std::vector<struct nvme_queue_info> queueInfos;
+  struct nvme_queue_info queueInfo; /**< Single-queue state for legacy paths. */
+  std::vector<uint16_t> queueIds;   /**< Queue IDs allocated for multi-queue. */
+  std::vector<struct nvme_queue_info> queueInfos; /**< Per-queue host state. */
 
-  // Physical addresses (host-side only)
-  uint64_t doorbellAddr; // Physical address of doorbell register
-  uint64_t sqBaseAddr;   // Physical base address of submission queue
-  uint64_t cqBaseAddr;   // Physical base address of completion queue
-  size_t sqSize;         // Size of submission queue in bytes
-  size_t cqSize;         // Size of completion queue in bytes
+  uint64_t doorbellAddr; /**< Physical address of the SQ doorbell register. */
+  uint64_t sqBaseAddr;   /**< Physical base address of submission queue. */
+  uint64_t cqBaseAddr;   /**< Physical base address of completion queue. */
+  size_t sqSize;         /**< Submission queue allocation size in bytes. */
+  size_t cqSize;         /**< Completion queue allocation size in bytes. */
 
-  // I/O operation parameters (mirrors nvmeIoParams POD struct)
+  /** @brief Host-side I/O options mirrored into nvmeIoParams. */
   struct {
-    std::string accessPattern; // "sequential" or "random" (default: "random")
-    unsigned lbaSize;      // LBA size in bytes (default: 512, auto-detected)
-    uint64_t baseLba;      // Starting LBA for I/O operations (default: 0)
-    uint64_t lbaRangeLbas; // LBA range limit (0 = no limit, default: 0)
-    uint32_t lfsrSeed;     // Seed for LFSR pattern (0 = derive from LBA)
-    int readIo;            // Number of read I/O operations
-    int writeIo;           // Number of write I/O operations
-    uint32_t nsid;         // Namespace ID (default: 1, must be > 0)
-    uint32_t lbasPerIo;    // Number of LBAs per I/O (default: 1)
-    bool infiniteMode;     // Infinite mode: run forever
-    uint32_t batchSize;    // SQEs per doorbell (1=seq, 0=all)
-  } ioParams;
+    std::string accessPattern; /**< "sequential" or "random". */
+    unsigned lbaSize;          /**< LBA size in bytes; auto-detected. */
+    uint64_t baseLba;          /**< Starting LBA for I/O operations. */
+    uint64_t lbaRangeLbas;     /**< LBA range limit; 0 means no limit. */
+    uint32_t lfsrSeed;         /**< LFSR seed; 0 derives seed from LBA. */
+    int readIo;                /**< Number of read I/O operations. */
+    int writeIo;               /**< Number of write I/O operations. */
+    uint32_t nsid;             /**< NVMe namespace ID; must be nonzero. */
+    uint32_t lbasPerIo;        /**< Number of LBAs per I/O. */
+    bool infiniteMode;         /**< Run until stopRequested is set. */
+    uint32_t batchSize;        /**< SQEs per doorbell; 1=serial, 0=all. */
+  } ioParams;                  /**< I/O operation parameters. */
 
-  // Verification
-  bool verify = false; // Verify LFSR data pattern after read-back
+  bool verify = false; /**< Verify LFSR data pattern after read-back. */
 
-  // Data buffer configuration (mirrors nvmeBufferParams POD struct)
+  /** @brief Host-side data buffer options mirrored into nvmeBufferParams. */
   struct {
-    size_t bufferSize; // Size of data buffers in bytes
-  } bufferParams;
+    size_t bufferSize; /**< Size of data buffers in bytes. */
+  } bufferParams;      /**< Data buffer configuration. */
 
-  // Doorbell configuration (mirrors nvmeDoorbellParams POD struct)
+  /** @brief Host-side doorbell options mirrored into nvmeDoorbellParams. */
   struct {
-    bool usePciMmioBridge;  // Use PCI MMIO bridge for doorbell routing
-    uint16_t mmioBridgeBdf; // PCI MMIO bridge BDF (0xBBDD format, e.g., 0x0400
-                            // for 00:04.0)
-    uint16_t nvmeTargetBdf; // NVMe target device BDF (0xBBDD format, e.g.,
-                            // 0x0600 for 00:06.0)
-    void* shadowBufferVirt; // Virtual address of PCI MMIO bridge shadow buffer
-                            // (mapped from GPA)
-    void* nvmeBar0Gpu;      // GPU-accessible pointer to NVMe BAR0 (for direct
-                            // doorbell)
-  } doorbellParams;
+    bool usePciMmioBridge;  /**< Route doorbells through PCI MMIO bridge. */
+    uint16_t mmioBridgeBdf; /**< Bridge BDF in 0xBBDD form. */
+    uint16_t nvmeTargetBdf; /**< NVMe target BDF in 0xBBDD form. */
+    void* shadowBufferVirt; /**< Mapped MMIO bridge shadow buffer. */
+    void* nvmeBar0Gpu;      /**< GPU-accessible pointer to NVMe BAR0. */
+  } doorbellParams;         /**< Doorbell routing configuration. */
 
-  // Default constructor
-  // Note: queueId defaults to 0 (invalid) - will be auto-detected in
-  // validateConfig
+  /**
+   * @brief Construct NVMe endpoint config with CLI defaults.
+   *
+   * queueId defaults to 0 so validateConfig() can auto-detect the highest
+   * usable I/O queue ID from the controller.
+   */
   nvmeEpConfig()
     : controller(""), queueId(0), queueLength(64), numQueues(1),
       queuesCreated(false), wavefrontSize(0), queueInfo{}, doorbellAddr(0),

--- a/src/endpoints/rdma-ep/gda-backend.hpp
+++ b/src/endpoints/rdma-ep/gda-backend.hpp
@@ -28,11 +28,12 @@ namespace rdma_ep {
 
 class QueuePair;
 
+/** @brief Queue-pair connection parameters exchanged between RDMA peers. */
 struct DestInfo {
-  int lid;
-  int qpn;
-  int psn;
-  union ibv_gid gid;
+  int lid;           /**< Local identifier for InfiniBand transports. */
+  int qpn;           /**< Queue-pair number. */
+  int psn;           /**< Packet sequence number used for RTR transition. */
+  union ibv_gid gid; /**< RoCE global identifier. */
 };
 
 /**
@@ -43,92 +44,144 @@ struct DestInfo {
  * create QPs/CQs, allocate queue memory, and connect the local or remote peer.
  */
 struct BackendConfig {
-  Provider provider{Provider::BNXT};
-  int gpu_device_id{0};
-  int sq_depth{256};
-  int cq_depth{256};
-  uint32_t inline_threshold{28};
-  bool pcie_relaxed_ordering{false};
-  int traffic_class{0};
-  bool loopback{true};
-  DestInfo remote{};
-  const char* hca_list{nullptr};
-  bool pci_mmio_bridge{false};
-  QueueMemMode queue_mem{QueueMemMode::HOST_COHERENT};
+  Provider provider{Provider::BNXT}; /**< Provider backend to open. */
+  int gpu_device_id{0};              /**< HIP GPU device index. */
+  int sq_depth{256};                 /**< Send queue depth in WQEs. */
+  int cq_depth{256};                 /**< Completion queue depth in CQEs. */
+  uint32_t inline_threshold{28};     /**< Max bytes posted inline. */
+  bool pcie_relaxed_ordering{false}; /**< Enable PCIe relaxed ordering. */
+  int traffic_class{0};              /**< RoCE traffic class for AH attrs. */
+  bool loopback{true};               /**< Connect the QP to itself. */
+  DestInfo remote{};                 /**< Remote peer for non-loopback. */
+  const char* hca_list{nullptr};     /**< Optional HCA include/exclude list. */
+  bool pci_mmio_bridge{false};       /**< Route doorbells through bridge. */
+  QueueMemMode queue_mem{QueueMemMode::HOST_COHERENT}; /**< Queue memory. */
 };
 
+/** @brief Host-side owner for one provider-specific RDMA QP/CQ pair. */
 class Backend {
 public:
+  /**
+   * @brief Store backend configuration.
+   * @param config Runtime RDMA backend configuration.
+   */
   explicit Backend(const BackendConfig& config);
+
+  /** @brief Release RDMA and provider resources. */
   ~Backend();
 
+  /**
+   * @brief Open the device, create queues, and initialize GPU state.
+   * @return 0 on success, -1 on failure.
+   */
   int init();
+
+  /** @brief Tear down resources allocated by init(). */
   void shutdown();
 
+  /**
+   * @brief Return the GPU-resident QueuePair object.
+   * @return Pointer to the GPU QueuePair state.
+   */
   QueuePair* get_gpu_qp() {
     return gpu_qp_;
   }
+  /**
+   * @brief Return the resolved provider backend.
+   * @return Provider selected during initialization.
+   */
   Provider get_provider() const {
     return provider_;
   }
+  /**
+   * @brief Return the opened verbs context.
+   * @return Active verbs context, or nullptr before init().
+   */
   struct ibv_context* get_context() const {
     return context_;
   }
+  /**
+   * @brief Return the protection domain used by the QP.
+   * @return Active protection domain, or nullptr before init().
+   */
   struct ibv_pd* get_pd() const {
     return pd_;
   }
+  /**
+   * @brief Return the host verbs QP.
+   * @return Active verbs QP, or nullptr before init().
+   */
   struct ibv_qp* get_ibv_qp() const {
     return qp_;
   }
+  /**
+   * @brief Return the host verbs CQ.
+   * @return Active verbs CQ, or nullptr before init().
+   */
   struct ibv_cq* get_ibv_cq() const {
     return cq_;
   }
+  /**
+   * @brief Return the host mirror of the QueuePair state.
+   * @return Host QueuePair object, or nullptr before init().
+   */
   QueuePair* get_host_qp() const {
     return host_qp_;
   }
 #if defined(GDA_IONIC)
+  /**
+   * @brief Return the Ionic GPU doorbell page.
+   * @return GPU-visible doorbell page pointer.
+   */
   void* get_db_page() const {
     return gpu_db_page_;
   }
 #endif
+  /**
+   * @brief Return the current remote key used by WQEs.
+   * @return Remote memory-region key.
+   */
   uint32_t get_rkey() const {
     return rkey_;
   }
+  /**
+   * @brief Return the local key for registered data buffers.
+   * @return Local memory-region key.
+   */
   uint32_t get_lkey() const {
     return lkey_;
   }
 
   /**
-   * Register a data buffer as an MR and update the QueuePair's lkey/rkey.
-   * Must be called after init(). Re-syncs QueuePair to GPU.
-   * Returns 0 on success, -1 on failure.
+   * @brief Register a data buffer as an MR and update QueuePair keys.
+   * @param buf Buffer base pointer.
+   * @param size Buffer size in bytes.
+   * @return 0 on success, -1 on failure.
    */
   int register_data_buffer(void* buf, size_t size);
 
   /**
-   * Connect QP to a remote peer (non-loopback).
-   * Transitions QP through RESET -> INIT -> RTR -> RTS using the
-   * remote peer's connection info. Must be called after init() on
-   * a Backend created with loopback=false.
-   * Returns 0 on success, -1 on failure.
+   * @brief Connect the QP to a remote peer in non-loopback mode.
+   * @param remote Remote peer connection information.
+   * @return 0 on success, -1 on failure.
    */
   int connect_to_peer(const DestInfo& remote);
 
   /**
-   * Get local connection info for TCP exchange with remote peer.
-   * Valid after init().
+   * @brief Get local connection info for TCP exchange with a peer.
+   * @return Local LID, QPN, PSN, and GID values valid after init().
    */
   DestInfo get_local_dest_info() const;
 
   /**
-   * Set the remote peer's rkey on the QueuePair.
-   * For RDMA WRITE to a remote node, the WQE needs the remote MR's rkey,
-   * not the local MR's rkey. Call after TCP exchange.
-   * Re-syncs QueuePair to GPU.
+   * @brief Set the remote peer's memory-region key on the QueuePair.
+   * @param remote_rkey Remote MR key received during TCP exchange.
+   * @return 0 on success, -1 on failure.
    */
   int set_remote_rkey(uint32_t remote_rkey);
 
 private:
+  /** @cond INTERNAL */
   BackendConfig config_;
   Provider provider_{Provider::UNKNOWN};
 
@@ -231,6 +284,7 @@ private:
   int ernic_dv_dl_init();
   static void* ernic_dv_dlopen();
 #endif
+  /** @endcond */
 };
 
 } // namespace rdma_ep

--- a/src/endpoints/rdma-ep/queue-pair.hpp
+++ b/src/endpoints/rdma-ep/queue-pair.hpp
@@ -58,38 +58,126 @@ class Ops;
 
 class Backend;
 
+/**
+ * @brief GPU-visible queue-pair state and device API for RDMA operations.
+ *
+ * Host code initializes a QueuePair through Backend, then GPU kernels use the
+ * device methods to post non-blocking RMA and atomic operations.
+ */
 class QueuePair {
 public:
+  /** @cond INTERNAL */
   friend Backend;
+  /** @endcond */
   friend class bnxt::Ops;
   friend class mlx5::Ops;
   friend class ionic::Ops;
   friend class ernic::Ops;
 
+  /**
+   * @brief Construct host-side QueuePair state for a provider.
+   * @param pd Verbs protection domain used for queue allocations.
+   * @param provider Provider-specific backend for WQE/CQE formatting.
+   */
   explicit QueuePair(struct ibv_pd* pd, Provider provider);
+
+  /** @brief Release host-side helper allocations owned by the QueuePair. */
   ~QueuePair();
 
-  // --- Public device API ---
+  /**
+   * @brief Post a non-blocking RDMA WRITE.
+   * @param dest Remote destination address.
+   * @param source Local source address.
+   * @param nelems Number of bytes to transfer.
+   */
   __device__ void put_nbi(void* dest, const void* source, size_t nelems);
+
+  /**
+   * @brief Post a non-blocking RDMA READ.
+   * @param dest Local destination address.
+   * @param source Remote source address.
+   * @param nelems Number of bytes to transfer.
+   */
   __device__ void get_nbi(void* dest, const void* source, size_t nelems);
+
+  /** @brief Wait for all outstanding operations on the QP to complete. */
   __device__ void quiet();
 
+  /**
+   * @brief Post a fetching atomic operation.
+   * @param dest Remote atomic target address.
+   * @param value Add or swap operand.
+   * @param cond Compare operand for compare-and-swap providers.
+   * @return Value fetched from the remote target.
+   */
   __device__ int64_t atomic_fetch(void* dest, int64_t value, int64_t cond);
+
+  /**
+   * @brief Post a non-fetching atomic operation.
+   * @param dest Remote atomic target address.
+   * @param value Add or swap operand.
+   * @param cond Compare operand for compare-and-swap providers.
+   */
   __device__ void atomic_nofetch(void* dest, int64_t value, int64_t cond);
+
+  /**
+   * @brief Post a compare-and-swap atomic operation.
+   * @param dest Remote atomic target address.
+   * @param data Replacement value.
+   * @param cmp Expected comparison value.
+   * @return Value fetched from the remote target.
+   */
   __device__ int64_t atomic_cas(void* dest, int64_t data, int64_t cmp);
 
+  /**
+   * @brief Post a non-blocking RDMA WRITE with immediate data.
+   * @param dest Remote destination address.
+   * @param source Local source address.
+   * @param nelems Number of bytes to transfer.
+   * @param imm_data Immediate data value carried by the completion.
+   */
   __device__ void put_nbi_imm(void* dest, const void* source, size_t nelems,
                               uint32_t imm_data);
+
+  /**
+   * @brief Post one RDMA WRITE from a single lane.
+   * @param dest Remote destination address.
+   * @param source Local source address.
+   * @param nelems Number of bytes to transfer.
+   * @param ring_db If true, ring the provider doorbell immediately.
+   */
   __device__ void put_nbi_single(void* dest, const void* source, size_t nelems,
                                  bool ring_db = true);
+
+  /**
+   * @brief Post one RDMA WRITE with immediate data from a single lane.
+   * @param dest Remote destination address.
+   * @param source Local source address.
+   * @param nelems Number of bytes to transfer.
+   * @param imm_data Immediate data value carried by the completion.
+   * @param ring_db If true, ring the provider doorbell immediately.
+   */
   __device__ void put_nbi_imm_single(void* dest, const void* source,
                                      size_t nelems, uint32_t imm_data,
                                      bool ring_db = true);
+
+  /**
+   * @brief Post one RDMA READ from a single lane.
+   * @param dest Local destination address.
+   * @param source Remote source address.
+   * @param nelems Number of bytes to transfer.
+   * @param ring_db If true, ring the provider doorbell immediately.
+   */
   __device__ void get_nbi_single(void* dest, const void* source, size_t nelems,
                                  bool ring_db = true);
+
+  /** @brief Wait for operations posted by the current single-lane path. */
   __device__ void quiet_single();
+
+  /** @brief Ring the provider doorbell for single-lane postings. */
   __device__ void ring_doorbell_single();
 
+  /** @cond INTERNAL */
   // --- Common accessor for vendor code ---
   __device__ uint64_t get_same_qp_lane_mask();
 
@@ -163,8 +251,10 @@ public:
   ernic_device_cq ernic_cq_{};
   ernic_device_sq ernic_sq_{};
 #endif
+  /** @endcond */
 };
 
+/** @cond INTERNAL */
 // ============================================================================
 // Vendor namespace declarations
 // Each vendor provides the same function names for the common operations.
@@ -320,6 +410,7 @@ public:
 };
 } // namespace ernic
 #endif
+/** @endcond */
 
 } // namespace rdma_ep
 } // namespace xio

--- a/src/endpoints/rdma-ep/rdma-ep.h
+++ b/src/endpoints/rdma-ep/rdma-ep.h
@@ -31,7 +31,9 @@
 
 #include <hip/hip_runtime.h>
 
+/** @brief rdma-ep does not expose a fixed public SQE layout. */
 #define RDMA_EP_SQE_SIZE 0
+/** @brief rdma-ep does not expose a fixed public CQE layout. */
 #define RDMA_EP_CQE_SIZE 0
 
 namespace xio {
@@ -44,23 +46,25 @@ namespace rdma_ep {
  * @brief Queue buffer placement for RDMA send/completion queues.
  */
 enum class QueueMemMode : uint8_t {
-  HOST_COHERENT = 0,
-  DEVICE_VRAM = 1,
+  HOST_COHERENT = 0, /**< Allocate queues in coherent host memory. */
+  DEVICE_VRAM = 1,   /**< Allocate queues in GPU VRAM. */
 };
 
 /**
  * @brief RDMA provider backends supported by rdma-ep.
  */
 enum class Provider : uint8_t {
-  BNXT = 0,
-  MLX5 = 1,
-  IONIC = 2,
-  ROCM_ERNIC = 3,
-  UNKNOWN = 0xFF,
+  BNXT = 0,       /**< Broadcom bnxt_re provider. */
+  MLX5 = 1,       /**< Mellanox mlx5 provider. */
+  IONIC = 2,      /**< Pensando Ionic provider. */
+  ROCM_ERNIC = 3, /**< AMD ROCm ERNIC provider. */
+  UNKNOWN = 0xFF, /**< Unknown or unsupported provider. */
 };
 
 /**
  * @brief Return the canonical provider name.
+ * @param p Provider enum value.
+ * @return Canonical provider string, or "unknown" for unsupported values.
  */
 __host__ inline const char* provider_name(Provider p) {
   switch (p) {
@@ -79,6 +83,8 @@ __host__ inline const char* provider_name(Provider p) {
 
 /**
  * @brief Convert a provider string to a Provider value.
+ * @param s Provider name or accepted alias; may be nullptr.
+ * @return Matching Provider, or Provider::UNKNOWN when not recognized.
  */
 __host__ inline Provider provider_from_string(const char* s) {
   if (!s)
@@ -137,16 +143,22 @@ struct RdmaEpConfig {
 
 /**
  * @brief Validate RDMA endpoint configuration.
+ * @param config RDMA endpoint configuration to validate.
+ * @return Empty string when valid, otherwise a diagnostic message.
  */
 __host__ std::string validateConfig(RdmaEpConfig* config);
 
 /**
  * @brief Resolve iteration count from opaque endpoint config.
+ * @param endpointConfig Pointer to an RdmaEpConfig instance.
+ * @return Number of RDMA operations to run; 0 means infinite mode.
  */
 __host__ unsigned getIterations(void* endpointConfig);
 
 /**
  * @brief Run the RDMA endpoint (loopback or 2-node mode).
+ * @param config Base endpoint configuration containing RdmaEpConfig.
+ * @return hipSuccess on success, or a HIP error code on failure.
  */
 __host__ hipError_t run(XioEndpointConfig* config);
 

--- a/src/endpoints/rdma-ep/vendor-ops.hpp
+++ b/src/endpoints/rdma-ep/vendor-ops.hpp
@@ -18,15 +18,16 @@
 namespace xio {
 namespace rdma_ep {
 
+/** @brief Wavefront size assumed by shared RDMA device helpers. */
 constexpr uint32_t WF_SIZE = 64;
+/** @brief Unlocked value for SpinLock::lock. */
 constexpr uint32_t SPIN_LOCK_UNLOCKED = 0;
 
-// GPU spinlock -- replaces 3 different vendor lock implementations.
-// MLX5 used __hip_atomic_exchange; BNXT used __hip_atomic_compare_exchange;
-// IONIC used shared/unique variants. This unifies them.
+/** @brief Agent-scope GPU spin lock shared by provider device code. */
 struct SpinLock {
-  uint32_t lock{SPIN_LOCK_UNLOCKED};
+  uint32_t lock{SPIN_LOCK_UNLOCKED}; /**< Atomic lock word. */
 
+  /** @brief Acquire the lock using an agent-scope atomic exchange. */
   __device__ void acquire() {
     while (__hip_atomic_exchange(&lock, 1u, __ATOMIC_ACQUIRE,
                                  __HIP_MEMORY_SCOPE_AGENT) != 0u) {
@@ -36,63 +37,92 @@ struct SpinLock {
     }
   }
 
+  /** @brief Release the lock with agent-scope release ordering. */
   __device__ void release() {
     __hip_atomic_store(&lock, 0u, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
   }
 };
 
-// Logical RMA descriptor -- filled once by QueuePair dispatch, passed to
-// vendor-specific WQE builder. Avoids each vendor re-extracting the same info.
+/** @brief Provider-neutral RDMA read/write work request descriptor. */
 struct RmaDescriptor {
-  uintptr_t local_addr;
-  uintptr_t remote_addr;
-  uint32_t length;
-  uint32_t lkey;
-  uint32_t rkey;
-  uint8_t opcode;
-  bool send_inline;
-  uint32_t imm_data;
+  uintptr_t local_addr;  /**< Local buffer virtual address. */
+  uintptr_t remote_addr; /**< Remote buffer virtual address. */
+  uint32_t length;       /**< Transfer length in bytes. */
+  uint32_t lkey;         /**< Local memory-region key. */
+  uint32_t rkey;         /**< Remote memory-region key. */
+  uint8_t opcode;        /**< Provider opcode for the RMA operation. */
+  bool send_inline;      /**< true when data should be embedded inline. */
+  uint32_t imm_data;     /**< Immediate data for WRITE_WITH_IMM. */
 };
 
-// Logical AMO descriptor
+/** @brief Provider-neutral atomic work request descriptor. */
 struct AmoDescriptor {
-  uintptr_t remote_addr;
-  uint32_t rkey;
-  uint8_t opcode;
-  int64_t swap_add;
-  int64_t compare;
-  bool fetching;
-  uintptr_t fetch_addr;
-  uint32_t fetch_lkey;
+  uintptr_t remote_addr; /**< Remote atomic target address. */
+  uint32_t rkey;         /**< Remote memory-region key. */
+  uint8_t opcode;        /**< Provider opcode for the atomic operation. */
+  int64_t swap_add;      /**< Add or swap operand. */
+  int64_t compare;       /**< Compare operand for compare-and-swap. */
+  bool fetching;         /**< true when the operation returns old data. */
+  uintptr_t fetch_addr;  /**< Local address for fetched atomic result. */
+  uint32_t fetch_lkey;   /**< Local key for fetch_addr. */
 };
 
-// Vendor ID constants for NIC detection
+/** @brief PCI vendor ID for Broadcom adapters. */
 constexpr uint32_t VENDOR_ID_BROADCOM = 0x14E4;
+/** @brief PCI vendor ID for Mellanox adapters. */
 constexpr uint32_t VENDOR_ID_MELLANOX = 0x02C9;
+/** @brief PCI vendor ID for Pensando adapters. */
 constexpr uint32_t VENDOR_ID_PENSANDO = 0x1DD8;
+/** @brief PCI vendor ID for AMD adapters. */
 constexpr uint32_t VENDOR_ID_AMD = 0x1022;
 
-// Wave/lane helpers -- ported from rocshmem util.hpp
+/**
+ * @brief Return the active-lane mask for the current wavefront.
+ * @return Bit mask of active lanes.
+ */
 __device__ inline uint64_t get_active_lane_mask() {
   return __ballot(1);
 }
 
+/**
+ * @brief Return the lane index within the current wavefront.
+ * @return Lane ID in the range [0, WF_SIZE).
+ */
 __device__ inline int get_lane_id() {
   return __lane_id();
 }
 
+/**
+ * @brief Check whether the current lane is lane zero.
+ * @return true for lane zero in the current wavefront.
+ */
 __device__ inline bool is_thread_zero_in_wave() {
   return get_lane_id() == 0;
 }
 
+/**
+ * @brief Count set bits in a 64-bit mask.
+ * @param mask Mask to count.
+ * @return Number of set bits.
+ */
 __device__ inline int popcount64(uint64_t mask) {
   return __popcll(mask);
 }
 
+/**
+ * @brief Return the lowest set lane in a mask.
+ * @param mask Active-lane mask.
+ * @return First set bit index, or -1 when @p mask is zero.
+ */
 __device__ inline int first_lane(uint64_t mask) {
   return __ffsll(static_cast<long long>(mask)) - 1;
 }
 
+/**
+ * @brief Return the highest set lane in a mask.
+ * @param mask Active-lane mask.
+ * @return Last set bit index; undefined when @p mask is zero.
+ */
 __device__ inline int last_lane(uint64_t mask) {
   return 63 - __clzll(static_cast<long long>(mask));
 }

--- a/src/endpoints/sdma-ep/sdma-ep.h
+++ b/src/endpoints/sdma-ep/sdma-ep.h
@@ -291,7 +291,11 @@ __device__ __forceinline__ void poll_until_ge(uint64_t* addr,
  *       boundary after initialization.
  */
 struct SdmaQueueHandle {
-  /** @brief Wrap a byte index into the ring buffer. */
+  /**
+   * @brief Wrap a byte index into the ring buffer.
+   * @param index Absolute byte index in the SDMA ring.
+   * @return Ring-relative byte offset.
+   */
   __device__ __forceinline__ uint64_t WrapIntoRing(uint64_t index) {
     return index % SDMA_QUEUE_SIZE;
   }
@@ -302,6 +306,9 @@ struct SdmaQueueHandle {
    * Uses a cached HW read index for fast-path; falls
    * back to reading the hardware register if the cached
    * value indicates the queue is full.
+   *
+   * @param uptoIndex Absolute byte index the producer wants to reach.
+   * @return true when the ring has enough free space.
    */
   __device__ __forceinline__ bool CanWriteUpto(uint64_t uptoIndex) {
     if ((uptoIndex - cachedHwReadIndex) < SDMA_QUEUE_SIZE) {
@@ -495,8 +502,10 @@ struct SdmaQueueHandle {
  *       by static_assert).
  */
 struct SdmaQueueSingleProducerHandle : SdmaQueueHandle {
-  /** @brief Pad remaining ring space with NOPs and
-   *         submit. */
+  /**
+   * @brief Pad remaining ring space with NOPs and submit.
+   * @param cur_index Current absolute write pointer before wrap padding.
+   */
   __device__ __forceinline__ void PadRingToEnd(uint64_t cur_index) {
     uint64_t new_index = cur_index +
                          (SDMA_QUEUE_SIZE - WrapIntoRing(cur_index));
@@ -538,6 +547,8 @@ struct SdmaQueueSingleProducerHandle : SdmaQueueHandle {
   /**
    * @brief Submit (single-producer, no committedWptr
    *        serialization).
+   * @param base Base index returned by ReserveQueueSpace().
+   * @param pendingWptr End index after packet placement.
    */
   __device__ __forceinline__ void submitPacket(uint64_t base,
                                                uint64_t pendingWptr) {
@@ -964,6 +975,8 @@ __host__ unsigned getIterations(void* endpointConfig);
 
 /**
  * @brief Run the SDMA endpoint workload.
+ * @param config Base endpoint configuration containing SdmaEpConfig.
+ * @return hipSuccess on success, or a HIP error code on failure.
  */
 __host__ hipError_t run(XioEndpointConfig* config);
 

--- a/src/include/rocm-xio-uapi.h
+++ b/src/include/rocm-xio-uapi.h
@@ -21,120 +21,140 @@ extern "C" {
 #include <linux/ioctl.h>
 #include <linux/types.h>
 
+/** @brief ioctl magic value reserved for the rocm-xio character device. */
 #define ROCM_XIO_IOC_MAGIC 'R'
 
+/** @brief Resolve a VRAM DMA-BUF to a device-usable physical or DMA address. */
 #define ROCM_XIO_GET_VRAM_PHYS_ADDR                                            \
   _IOWR(ROCM_XIO_IOC_MAGIC, 1, struct rocm_xio_vram_req)
+/** @brief Create an NVMe queue using caller-supplied queue memory. */
 #define ROCM_XIO_CREATE_QUEUE                                                  \
   _IOWR(ROCM_XIO_IOC_MAGIC, 2, struct rocm_xio_create_queue_req)
+/** @brief Delete an NVMe queue previously created by the kernel helper. */
 #define ROCM_XIO_DELETE_QUEUE                                                  \
   _IOW(ROCM_XIO_IOC_MAGIC, 3, struct rocm_xio_delete_queue_req)
+/** @brief Query bound-device BAR and queue capability information. */
 #define ROCM_XIO_GET_DEVICE_INFO                                               \
   _IOWR(ROCM_XIO_IOC_MAGIC, 4, struct rocm_xio_device_info)
+/** @brief Bind the character-device session to an NVMe PCI function. */
 #define ROCM_XIO_BIND_DEVICE                                                   \
   _IOW(ROCM_XIO_IOC_MAGIC, 5, struct rocm_xio_bind_device_req)
+/** @brief Register a queue virtual-to-physical mapping for kprobe injection. */
 #define ROCM_XIO_REGISTER_QUEUE_ADDR                                           \
   _IOW(ROCM_XIO_IOC_MAGIC, 6, struct rocm_xio_register_queue_addr_req)
+/** @brief Remove a queue mapping from the kernel helper. */
 #define ROCM_XIO_UNREGISTER_QUEUE_ADDR                                         \
   _IOW(ROCM_XIO_IOC_MAGIC, 7, struct rocm_xio_unregister_queue_addr_req)
+/** @brief Register a data buffer used by NVMe PRP injection. */
 #define ROCM_XIO_REGISTER_BUFFER                                               \
   _IOW(ROCM_XIO_IOC_MAGIC, 8, struct rocm_xio_register_buffer_req)
+/** @brief Remove a registered data-buffer mapping. */
 #define ROCM_XIO_UNREGISTER_BUFFER                                             \
   _IOW(ROCM_XIO_IOC_MAGIC, 9, struct rocm_xio_unregister_buffer_req)
+/** @brief Map the PCI MMIO bridge shadow buffer into userspace. */
 #define ROCM_XIO_GET_MMIO_BRIDGE_SHADOW_BUFFER                                 \
   _IOWR(ROCM_XIO_IOC_MAGIC, 10, struct rocm_xio_mmio_bridge_shadow_req)
+/** @brief Allocate physically contiguous coherent queue memory. */
 #define ROCM_XIO_ALLOC_CONTIG_QUEUE                                            \
   _IOWR(ROCM_XIO_IOC_MAGIC, 11, struct rocm_xio_alloc_contig_req)
+/** @brief Free contiguous queue memory allocated by the kernel helper. */
 #define ROCM_XIO_FREE_CONTIG_QUEUE                                             \
   _IOW(ROCM_XIO_IOC_MAGIC, 12, struct rocm_xio_free_contig_req)
 
-#define ROCM_XIO_FLAG_EMULATED (1 << 0) /* Return BAR GPA for emulated NVMe */
-#define ROCM_XIO_FLAG_PASSTHROUGH                                              \
-  (1 << 1) /* Return P2PDMA IOVA for passthrough */
+/** @brief Return the emulated BAR guest-physical address. */
+#define ROCM_XIO_FLAG_EMULATED (1 << 0)
+/** @brief Return a P2PDMA IOVA for passthrough hardware. */
+#define ROCM_XIO_FLAG_PASSTHROUGH (1 << 1)
 
 /** @brief VRAM physical address resolution request (GET_VRAM_PHYS_ADDR). */
 struct rocm_xio_vram_req {
-  int dmabuf_fd;
-  __u16 nvme_bdf;
-  __u32 flags;
-  __u64 phys_addr;
-  __u64 size;
+  int dmabuf_fd;   /**< DMA-BUF fd exported from a VRAM allocation. */
+  __u16 nvme_bdf;  /**< Target NVMe device in 0xBBDD form. */
+  __u32 flags;     /**< ROCM_XIO_FLAG_* address selection flags. */
+  __u64 phys_addr; /**< Output physical address, IOVA, or emulated GPA. */
+  __u64 size;      /**< Output mapped buffer size in bytes. */
 };
 
+/** @brief NVMe queue creation request (CREATE_QUEUE). */
 struct rocm_xio_create_queue_req {
-  __u16 queue_id;
-  __u16 queue_size;
-  __u32 cq_vector;
-  __u64 sq_phys_addr;
-  __u64 cq_phys_addr;
-  __u64 doorbell_addr;
-  __u32 doorbell_offset;
+  __u16 queue_id;        /**< NVMe queue identifier to create. */
+  __u16 queue_size;      /**< Queue depth in entries. */
+  __u32 cq_vector;       /**< Interrupt vector for completion queues. */
+  __u64 sq_phys_addr;    /**< Submission queue base physical address. */
+  __u64 cq_phys_addr;    /**< Completion queue base physical address. */
+  __u64 doorbell_addr;   /**< Output doorbell register physical address. */
+  __u32 doorbell_offset; /**< Output doorbell offset within BAR0. */
 };
 
+/** @brief NVMe queue deletion request (DELETE_QUEUE). */
 struct rocm_xio_delete_queue_req {
-  __u16 queue_id;
-  __u8 queue_type;
+  __u16 queue_id;  /**< NVMe queue identifier to delete. */
+  __u8 queue_type; /**< Queue type: 0 for SQ, 1 for CQ. */
 };
 
+/** @brief Bound NVMe device information returned by GET_DEVICE_INFO. */
 struct rocm_xio_device_info {
-  __u16 bdf;
-  __u64 bar0_addr;
-  __u64 bar0_size;
-  __u32 doorbell_stride;
-  __u32 max_queues;
+  __u16 bdf;             /**< Bound NVMe device in 0xBBDD form. */
+  __u64 bar0_addr;       /**< BAR0 physical base address. */
+  __u64 bar0_size;       /**< BAR0 mapping size in bytes. */
+  __u32 doorbell_stride; /**< NVMe doorbell stride in bytes. */
+  __u32 max_queues;      /**< Maximum queue count reported by device. */
 };
 
+/** @brief Bind request selecting the NVMe PCI function for later ioctls. */
 struct rocm_xio_bind_device_req {
-  __u16 bdf;
+  __u16 bdf; /**< NVMe device in 0xBBDD form. */
 };
 
 /** @brief Register queue virtual/physical mapping (REGISTER_QUEUE_ADDR). */
 struct rocm_xio_register_queue_addr_req {
-  __u64 virt_addr;
-  __u64 phys_addr;
-  __u64 size;
-  __u64 prp2;
-  __u16 nvme_bdf;
-  __u8 queue_type;
-  __u8 reserved[5];
+  __u64 virt_addr;  /**< Userspace virtual queue base address. */
+  __u64 phys_addr;  /**< Physical or DMA queue base address. */
+  __u64 size;       /**< Queue allocation size in bytes. */
+  __u64 prp2;       /**< PRP2 value for multi-page queue commands. */
+  __u16 nvme_bdf;   /**< Target NVMe device in 0xBBDD form. */
+  __u8 queue_type;  /**< Queue type: 0 for SQ, 1 for CQ. */
+  __u8 reserved[5]; /**< Reserved for ABI alignment; must be zero. */
 };
 
+/** @brief Unregister a queue mapping by userspace virtual address. */
 struct rocm_xio_unregister_queue_addr_req {
-  __u64 virt_addr;
+  __u64 virt_addr; /**< Userspace virtual queue base address. */
 };
 
 /** @brief Register data buffer for PRP injection (REGISTER_BUFFER). */
 struct rocm_xio_register_buffer_req {
-  int dmabuf_fd;
-  __u64 virt_addr;
-  __u64 phys_addr;
-  __u64 size;
-  __u16 nvme_bdf;
-  __u32 flags;
+  int dmabuf_fd;   /**< DMA-BUF fd for VRAM, or -1 for host memory. */
+  __u64 virt_addr; /**< Userspace virtual buffer base address. */
+  __u64 phys_addr; /**< Physical address, IOVA, or emulated GPA. */
+  __u64 size;      /**< Buffer size in bytes. */
+  __u16 nvme_bdf;  /**< Target NVMe device in 0xBBDD form. */
+  __u32 flags;     /**< ROCM_XIO_FLAG_* address selection flags. */
 };
 
+/** @brief Unregister a data buffer by userspace virtual address. */
 struct rocm_xio_unregister_buffer_req {
-  __u64 virt_addr;
+  __u64 virt_addr; /**< Userspace virtual buffer base address. */
 };
 
 /** @brief MMIO bridge shadow buffer mapping (GET_MMIO_BRIDGE_SHADOW_BUFFER). */
 struct rocm_xio_mmio_bridge_shadow_req {
-  __u16 bridge_bdf;
-  __u64 shadow_gpa;
-  __u64 shadow_size;
+  __u16 bridge_bdf;  /**< PCI MMIO bridge device in 0xBBDD form. */
+  __u64 shadow_gpa;  /**< Output guest-physical shadow buffer address. */
+  __u64 shadow_size; /**< Output shadow buffer size in bytes. */
 };
 
 /** @brief Contiguous queue allocation (ALLOC_CONTIG_QUEUE). */
 struct rocm_xio_alloc_contig_req {
-  __u64 size;
-  __u16 nvme_bdf;
-  __u64 phys_addr;
-  __u32 mmap_offset;
+  __u64 size;        /**< Requested queue allocation size in bytes. */
+  __u16 nvme_bdf;    /**< Target NVMe device in 0xBBDD form. */
+  __u64 phys_addr;   /**< Output physical address of allocation. */
+  __u32 mmap_offset; /**< Output mmap offset used as allocation handle. */
 };
 
 /** @brief Free contiguous queue allocation (FREE_CONTIG_QUEUE). */
 struct rocm_xio_free_contig_req {
-  __u32 mmap_offset;
+  __u32 mmap_offset; /**< mmap offset returned by allocation ioctl. */
 };
 
 #ifdef __cplusplus

--- a/src/include/xio-endpoint-core.h
+++ b/src/include/xio-endpoint-core.h
@@ -26,10 +26,10 @@ namespace xio {
  * Tracks min, max, sum, and count of IO completion times.
  */
 struct XioTimingStats {
-  unsigned long long int minDuration = ULLONG_MAX;
-  unsigned long long int maxDuration = 0;
-  unsigned long long int sumDuration = 0;
-  unsigned long long int count = 0;
+  unsigned long long int minDuration = ULLONG_MAX; /**< Shortest duration. */
+  unsigned long long int maxDuration = 0;          /**< Longest duration. */
+  unsigned long long int sumDuration = 0;          /**< Sum of durations. */
+  unsigned long long int count = 0;                /**< Samples recorded. */
 };
 
 /**
@@ -79,27 +79,34 @@ struct XioSubstepStats {
  * configuration structures via the endpointConfig pointer.
  */
 struct XioEndpointConfig {
-  unsigned iterations = 128;
-  unsigned numThreads = 1;
-  long long delayNs = 0;
-  unsigned memoryMode = 0;
-  bool verbose = false;
-  bool pciMmioBridge = false;
+  unsigned iterations = 128;  /**< Operations or loop iterations to run. */
+  unsigned numThreads = 1;    /**< GPU work-items or endpoint queues. */
+  long long delayNs = 0;      /**< Optional inter-operation delay in ns. */
+  unsigned memoryMode = 0;    /**< XIO_MEM_MODE_* queue and data flags. */
+  bool verbose = false;       /**< Enable endpoint-specific verbose logs. */
+  bool pciMmioBridge = false; /**< Route MMIO doorbells through bridge. */
 
-  unsigned long long int* startTimes = nullptr;
-  unsigned long long int* endTimes = nullptr;
-  XioTimingStats* timingStats = nullptr;
-  XioSubstepStats* substepStats = nullptr;
+  unsigned long long int* startTimes = nullptr; /**< Per-op start times. */
+  unsigned long long int* endTimes = nullptr;   /**< Per-op end times. */
+  XioTimingStats* timingStats = nullptr;        /**< Aggregate timing. */
+  XioSubstepStats* substepStats = nullptr;      /**< Hot-path breakdown. */
 
-  void* submissionQueue = nullptr;
-  void* completionQueue = nullptr;
-  volatile bool* stopRequested = nullptr;
-  void* endpointConfig = nullptr;
+  void* submissionQueue = nullptr;        /**< GPU-visible submission queue. */
+  void* completionQueue = nullptr;        /**< GPU-visible completion queue. */
+  volatile bool* stopRequested = nullptr; /**< Shared SIGINT stop flag. */
+  void* endpointConfig = nullptr; /**< Endpoint-specific config object. */
 
-  uint32_t verifyPass = 0;
-  uint32_t verifyFail = 0;
+  uint32_t verifyPass = 0; /**< Successful verification count. */
+  uint32_t verifyFail = 0; /**< Failed verification count. */
 
+  /** @brief Construct a config with default values. */
   XioEndpointConfig() = default;
+
+  /**
+   * @brief Construct a config with explicit iteration and thread counts.
+   * @param iter Operations or loop iterations to run.
+   * @param threads GPU work-items or endpoint queues.
+   */
   XioEndpointConfig(unsigned iter, unsigned threads = 1)
     : iterations(iter), numThreads(threads) {
   }
@@ -113,21 +120,37 @@ struct XioEndpointConfig {
  */
 class XIO_API XioEndpoint {
 public:
+  /** @brief Destroy an endpoint implementation. */
   virtual ~XioEndpoint() = default;
 
-  /** @brief Get the endpoint type identifier. */
+  /**
+   * @brief Get the endpoint type identifier.
+   * @return Generated endpoint type for this implementation.
+   */
   __host__ virtual EndpointType getType() const = 0;
 
-  /** @brief Get the endpoint name string. */
+  /**
+   * @brief Get the endpoint name string.
+   * @return Stable CLI and factory name for this endpoint.
+   */
   __host__ virtual const char* getName() const = 0;
 
-  /** @brief Get a human-readable description. */
+  /**
+   * @brief Get a human-readable description.
+   * @return Static endpoint description string.
+   */
   __host__ virtual const char* getDescription() const = 0;
 
-  /** @brief Get submission queue entry size in bytes. */
+  /**
+   * @brief Get submission queue entry size in bytes.
+   * @return Size of one SQE, or 0 when the endpoint has no SQE type.
+   */
   __host__ virtual size_t getSubmissionQueueEntrySize() const = 0;
 
-  /** @brief Get completion queue entry size in bytes. */
+  /**
+   * @brief Get completion queue entry size in bytes.
+   * @return Size of one CQE, or 0 when the endpoint has no CQE type.
+   */
   __host__ virtual size_t getCompletionQueueEntrySize() const = 0;
 
   /**

--- a/src/include/xio-endpoint-registry.h
+++ b/src/include/xio-endpoint-registry.h
@@ -15,29 +15,52 @@
 #include "xio-endpoint-registry-gen.h"
 #include "xio-export.h"
 
-// Endpoint information structure
+/**
+ * @brief Static metadata for one registered endpoint.
+ */
 struct EndpointInfo {
-  std::string name;
-  std::string description;
-  EndpointType type;
+  std::string name;        /**< CLI and factory name for the endpoint. */
+  std::string description; /**< Human-readable endpoint summary. */
+  EndpointType type;       /**< Generated endpoint type identifier. */
 };
 
-// Get the registry of all available endpoints
+/**
+ * @brief Return the registry of endpoints compiled into the binary.
+ * @return Immutable vector of endpoint metadata entries.
+ */
 XIO_API const std::vector<EndpointInfo>& getEndpointRegistry();
 
-// Convert string name to endpoint type
+/**
+ * @brief Convert an endpoint name to its generated type identifier.
+ * @param name Endpoint name, matched case-insensitively.
+ * @return Matching EndpointType, or EndpointType::UNKNOWN when absent.
+ */
 XIO_API EndpointType getEndpointType(const std::string& name);
 
-// Get endpoint name from type
+/**
+ * @brief Return the canonical endpoint name for a generated type.
+ * @param type Endpoint type identifier.
+ * @return Endpoint name string, or nullptr when @p type is unknown.
+ */
 XIO_API const char* getEndpointName(EndpointType type);
 
-// List all available endpoints
+/**
+ * @brief Print all registered endpoint names and descriptions to stdout.
+ */
 XIO_API void listAvailableEndpoints();
 
-// Validate endpoint name
+/**
+ * @brief Check whether an endpoint name is registered.
+ * @param name Endpoint name to validate, matched case-insensitively.
+ * @return true when @p name resolves to a registered endpoint.
+ */
 XIO_API bool isValidEndpoint(const std::string& name);
 
-// Get EndpointInfo from EndpointType
+/**
+ * @brief Return metadata for an endpoint type.
+ * @param type Endpoint type identifier.
+ * @return Matching EndpointInfo, or an UNKNOWN entry when unsupported.
+ */
 XIO_API EndpointInfo getEndpointInfo(EndpointType type);
 
 #endif // XIO_ENDPOINT_REGISTRY_H

--- a/src/include/xio-timing.h
+++ b/src/include/xio-timing.h
@@ -22,6 +22,11 @@
 #include <atomic>
 #endif
 
+/**
+ * @brief Atomically add one duration sample to aggregate timing stats.
+ * @param stats Timing stats to update; nullptr is ignored.
+ * @param duration Duration sample in the caller's time unit.
+ */
 __host__ __device__ inline void updateTimingStats(
   xio::XioTimingStats* stats, unsigned long long int duration) {
   if (stats == nullptr)

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -24,7 +24,7 @@
 #include "xio-endpoint-registry.h"
 #include "xio-export.h"
 
-// ROCm-XIO kernel module device path (same as kernel uapi header convention)
+/** @brief Default rocm-xio kernel module character-device path. */
 #ifndef ROCM_XIO_DEVICE_PATH
 #define ROCM_XIO_DEVICE_PATH "/dev/rocm-xio"
 #endif
@@ -54,34 +54,49 @@
     _xio_hip_status;                                                           \
   }))
 
-// Memory mode flags (bits in memoryMode field)
+/** @brief Place the submission queue in GPU device memory. */
 #define XIO_MEM_MODE_SQ_DEVICE 0x1
+/** @brief Place the completion queue in GPU device memory. */
 #define XIO_MEM_MODE_CQ_DEVICE 0x2
+/** @brief Place doorbell state in GPU device memory. */
 #define XIO_MEM_MODE_DOORBELL_DEVICE 0x4
+/** @brief Place endpoint data buffers in GPU device memory. */
 #define XIO_MEM_MODE_DATA_DEVICE 0x8
 
-// Device memory allocation flags for allocDeviceMemory()
+/** @brief Allocate fine-grained HSA device memory. */
 #define XIO_DEVICE_MEM_FINE_GRAINED 0x0
+/** @brief Allocate coarse-grained HSA device memory. */
 #define XIO_DEVICE_MEM_COARSE_GRAINED 0x1
+/** @brief Allocate uncached HIP extended device memory. */
 #define XIO_DEVICE_MEM_UNCACHED 0x2
+/** @brief Allocate memory through HIP virtual memory APIs. */
 #define XIO_DEVICE_MEM_VMEM 0x4
+/** @brief Allocate memory through hipMalloc. */
 #define XIO_DEVICE_MEM_HIP 0x8
 
-// Host memory allocation flags for allocHostMemory()
+/** @brief Allocate host memory mapped into the GPU address space. */
 #define XIO_HOST_MEM_MAPPED 0x0
+/** @brief Allocate coherent host memory for PCIe-visible queues. */
 #define XIO_HOST_MEM_COHERENT 0x1
+/** @brief Allocate pinned host memory. */
 #define XIO_HOST_MEM_PINNED 0x2
+/** @brief Allocate ordinary pageable host memory. */
 #define XIO_HOST_MEM_PLAIN 0x4
+/** @brief Use the default host allocation policy. */
 #define XIO_HOST_MEM_DEFAULT 0x8
 
-// PCI MMIO Bridge command types
+/** @brief PCI MMIO bridge no-op command. */
 #define PCI_MMIO_BRIDGE_CMD_NOP 0
+/** @brief PCI MMIO bridge write command. */
 #define PCI_MMIO_BRIDGE_CMD_WRITE 1
+/** @brief PCI MMIO bridge read command. */
 #define PCI_MMIO_BRIDGE_CMD_READ 2
 
-// PCI MMIO Bridge status codes
+/** @brief PCI MMIO bridge command has not completed. */
 #define PCI_MMIO_BRIDGE_STATUS_PENDING 0
+/** @brief PCI MMIO bridge command completed successfully. */
 #define PCI_MMIO_BRIDGE_STATUS_COMPLETE 1
+/** @brief PCI MMIO bridge command completed with an error. */
 #define PCI_MMIO_BRIDGE_STATUS_ERROR 2
 
 #include "xio-endpoint-core.h"
@@ -320,9 +335,9 @@ __host__ std::string extractEndpointName(int argc, char** argv);
  * @brief Resolved NVMe controller and namespace paths.
  */
 struct NvmeDevicePath {
-  std::string namespacePath;
-  std::string controllerPath;
-  std::string controllerName;
+  std::string namespacePath;  /**< Namespace path used for I/O, if any. */
+  std::string controllerPath; /**< Controller path for admin commands. */
+  std::string controllerName; /**< Sysfs controller name, e.g. nvme0. */
 };
 
 /**
@@ -429,12 +444,12 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
  * @brief Buffer allocation result structure.
  */
 struct xioBufferInfo {
-  void* hostPtr;
-  void* gpuPtr;
-  uint64_t dmaAddr;
-  bool isDeviceMemory;
-  uint64_t* pagePhysAddrs;
-  uint32_t numPages;
+  void* hostPtr;           /**< CPU-accessible allocation pointer. */
+  void* gpuPtr;            /**< GPU-accessible pointer to the buffer. */
+  uint64_t dmaAddr;        /**< DMA address for device-backed buffers. */
+  bool isDeviceMemory;     /**< true when allocated in GPU memory. */
+  uint64_t* pagePhysAddrs; /**< Host-buffer physical address per page. */
+  uint32_t numPages;       /**< Number of entries in pagePhysAddrs. */
 };
 
 /**
@@ -543,15 +558,15 @@ int kmodRegQueue(int kmod_fd, void* virt_addr, uint64_t phys_addr, size_t size,
  * @brief Queue setup structure for unified initialization.
  */
 struct xioQueueSetup {
-  void* virt;
-  void* gpu;
-  uint64_t phys;
-  bool uses_coherent;
-  void* prp_list;
-  uint64_t prp_list_phys;
-  uint64_t prp2;
-  bool uses_contig;
-  uint32_t contig_id;
+  void* virt;             /**< CPU-accessible queue base. */
+  void* gpu;              /**< GPU-accessible queue base. */
+  uint64_t phys;          /**< Physical or DMA address for queue base. */
+  bool uses_coherent;     /**< Queue was reallocated as coherent host mem. */
+  void* prp_list;         /**< CPU pointer to queue PRP list, if needed. */
+  uint64_t prp_list_phys; /**< Physical address of prp_list. */
+  uint64_t prp2;          /**< NVMe PRP2 value for multi-page queues. */
+  bool uses_contig;       /**< Queue was allocated by kernel contig path. */
+  uint32_t contig_id;     /**< mmap offset identifying contig allocation. */
 };
 
 /**
@@ -919,10 +934,10 @@ __host__ __device__ static inline void ringDoorbellFenced(void* base_addr,
  *        (matches QEMU device).
  */
 struct pci_mmio_bridge_ring_meta {
-  uint32_t producer_idx;
-  uint32_t consumer_idx;
-  uint32_t queue_depth;
-  uint32_t reserved;
+  uint32_t producer_idx; /**< Next command slot produced by the GPU. */
+  uint32_t consumer_idx; /**< Next command slot consumed by the bridge. */
+  uint32_t queue_depth;  /**< Number of command entries in the ring. */
+  uint32_t reserved;     /**< Reserved for ABI alignment; must be zero. */
 } __attribute__((packed));
 
 /**
@@ -930,16 +945,16 @@ struct pci_mmio_bridge_ring_meta {
  *        (matches QEMU device).
  */
 struct pci_mmio_bridge_command {
-  uint16_t target_bdf;
-  uint8_t target_bar;
-  uint8_t reserved1;
-  uint32_t offset;
-  uint64_t value;
-  uint8_t command;
-  uint8_t size;
-  uint8_t status;
-  uint8_t reserved2;
-  uint32_t sequence;
+  uint16_t target_bdf; /**< Target PCI device in 0xBBDD form. */
+  uint8_t target_bar;  /**< Target BAR number. */
+  uint8_t reserved1;   /**< Reserved padding; must be zero. */
+  uint32_t offset;     /**< Byte offset within the target BAR. */
+  uint64_t value;      /**< Write value or read result. */
+  uint8_t command;     /**< PCI_MMIO_BRIDGE_CMD_* command code. */
+  uint8_t size;        /**< Transfer size in bytes: 1, 2, 4, or 8. */
+  uint8_t status;      /**< PCI_MMIO_BRIDGE_STATUS_* completion code. */
+  uint8_t reserved2;   /**< Reserved padding; must be zero. */
+  uint32_t sequence;   /**< Monotonic command sequence number. */
 } __attribute__((packed));
 
 /**


### PR DESCRIPTION
Expand Doxygen comments across registry/core config, xio.h helpers and macros, rocm-xio-uapi ioctl structs and defines, NVMe/RDMA/SDMA endpoints, timing and data-pattern helpers, RDMA topology and runtime wrappers, backend and QueuePair device API, and vendor-ops descriptors.

Docs: add XioSubstepStats to reference/api.rst; extend EXCLUDE_PATTERNS in Doxyfile.in for imported protocol/vendor layout headers so generated HTML stays focused on the documented surface.