### PR TITLE
ci: rolling packages use rocm-xio-latest and shared release notes

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -31,6 +31,7 @@ jobs:
       options: --user root
     env:
       LD_LIBRARY_PATH: /opt/rocm/lib:/usr/lib/x86_64-linux-gnu
+      GEN_CHANGELOG_ROLLING: '1'
 
     steps:
     - name: Check out code
@@ -63,6 +64,9 @@ jobs:
     - name: Show generated changelog
       run: cat debian/changelog
 
+    - name: Show generated release notes
+      run: cat debian/generated-release-notes.md
+
     - name: Build .deb packages
       run: dpkg-buildpackage -us -uc -b
 
@@ -89,21 +93,13 @@ jobs:
         name: rocm-xio-debs-${{ github.sha }}
         path: built-debs/
 
-    - name: Update rolling latest pre-release
+    - name: Update rolling package pre-release
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: latest
-        name: Latest development build
-        body: |
-          Rolling pre-release built from the latest commit on `main`.
-
-          **Commit:** ${{ github.sha }}
-          **Built:** ${{ github.event.head_commit.timestamp }}
-
-          These packages are rebuilt on every push to `main` and may not
-          be as stable as tagged releases. For production use, prefer a
-          tagged `vX.Y.Z` release.
+        tag_name: rocm-xio-latest
+        name: Latest package build (main)
+        body_path: debian/generated-release-notes.md
         prerelease: true
         make_latest: false
         files: built-debs/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
     - name: Show generated changelog
       run: cat debian/changelog
 
+    - name: Show generated release notes
+      run: cat debian/generated-release-notes.md
+
     - name: Build .deb packages
       run: dpkg-buildpackage -us -uc -b
 
@@ -83,6 +86,7 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        generate_release_notes: true
+        body_path: debian/generated-release-notes.md
+        generate_release_notes: false
         prerelease: ${{ contains(github.ref_name, '-') }}
         files: built-debs/*

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ kernel/*/..module-common.o.cmd
 kernel/*/.*.o.d
 
 # Generated files
+debian/generated-release-notes.md
 cmake/ctest-resources.json
 src/include/xio-endpoint-registry-gen.h
 src/include/xio-endpoint-includes-gen.h

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-rocm-xio (0.1.0) noble; urgency=low
+rocm-xio (0.1.0~git2d9d85a) noble; urgency=low
 
-  * Initial Debian packaging
+  * ci: rolling packages use rocm-xio-latest and shared release notes
 
- -- AMD ROCm Build <rocm-xio@amd.com>  Wed, 02 Apr 2026 00:00:00 +0000
+ -- AMD ROCm Build <rocm-xio@amd.com>  Fri, 08 May 2026 14:25:12 -0400

--- a/debian/gen-changelog.sh
+++ b/debian/gen-changelog.sh
@@ -3,13 +3,20 @@
 #
 # SPDX-License-Identifier: MIT
 #
-# Generate debian/changelog from CMakeLists.txt version
-# and git metadata. Intended for CI use.
+# Generate debian/changelog from CMakeLists.txt version and git metadata.
+# Optionally writes debian/generated-release-notes.md for GitHub Releases.
+# Intended for CI use.
+#
+# Environment:
+#   GEN_CHANGELOG_ROLLING=1  — range from rolling tag (see below) to HEAD.
+#   GEN_CHANGELOG_ROLLING_TAG=name — rolling tag (default: rocm-xio-latest).
 
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RELEASE_NOTES="${SCRIPT_DIR}/generated-release-notes.md"
+ROLLING_TAG="${GEN_CHANGELOG_ROLLING_TAG:-rocm-xio-latest}"
 
 MAJOR=$(sed -n \
   's/^set(ROCM_XIO_LIBRARY_MAJOR \([0-9]*\))/\1/p' \
@@ -33,11 +40,13 @@ fi
 VERSION="${MAJOR}.${MINOR}.${PATCH}"
 
 SHORT_SHA="HEAD"
+FULL_SHA=""
 if command -v git >/dev/null 2>&1 && \
    git -C "${PROJECT_DIR}" rev-parse HEAD \
      >/dev/null 2>&1; then
   SHORT_SHA=$(git -C "${PROJECT_DIR}" \
     rev-parse --short HEAD)
+  FULL_SHA=$(git -C "${PROJECT_DIR}" rev-parse HEAD)
   DEB_VERSION="${VERSION}~git${SHORT_SHA}"
 else
   DEB_VERSION="${VERSION}"
@@ -45,13 +54,123 @@ fi
 
 DIST=$(lsb_release -cs 2>/dev/null || echo "noble")
 DATE=$(date -R)
+DATE_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-cat > "${SCRIPT_DIR}/changelog" <<EOF
-rocm-xio (${DEB_VERSION}) ${DIST}; urgency=low
+# Determine git log range for changelog bullets (git only; same gate as
+# FULL_SHA — avoids invoking git under set -e when unavailable).
+RANGE=""
+RANGE_LABEL=""
+cd "${PROJECT_DIR}"
 
-  * Automated build from git ${SHORT_SHA}
+if [ -n "${FULL_SHA}" ]; then
+  if [ "${GEN_CHANGELOG_ROLLING:-}" = "1" ]; then
+    if git -C "${PROJECT_DIR}" rev-parse -q --verify \
+      "refs/tags/${ROLLING_TAG}" >/dev/null 2>&1; then
+      RANGE="${ROLLING_TAG}..HEAD"
+      RANGE_LABEL="since tag \`${ROLLING_TAG}\`"
+    else
+      PREV_V=$(git -C "${PROJECT_DIR}" describe --tags --abbrev=0 \
+        --match='v[0-9]*.[0-9]*.[0-9]*' HEAD 2>/dev/null \
+        || true)
+      if [ -n "${PREV_V}" ]; then
+        RANGE="${PREV_V}..HEAD"
+        RANGE_LABEL="since latest semver tag \`${PREV_V}\` (rolling tag absent)"
+      else
+        RANGE="HEAD"
+        RANGE_LABEL="single revision (no prior tag)"
+      fi
+    fi
+  else
+    PREV_V=$(git -C "${PROJECT_DIR}" describe --tags --abbrev=0 \
+      --match='v[0-9]*.[0-9]*.[0-9]*' HEAD~1 2>/dev/null \
+      || true)
+    if [ -n "${PREV_V}" ]; then
+      RANGE="${PREV_V}..HEAD"
+      RANGE_LABEL="since \`${PREV_V}\`"
+    else
+      RANGE="HEAD"
+      RANGE_LABEL="initial or first tagged release"
+    fi
+  fi
+else
+  RANGE="HEAD"
+  RANGE_LABEL="git unavailable (no revision range)"
+fi
 
- -- AMD ROCm Build <rocm-xio@amd.com>  ${DATE}
-EOF
+# Collect commit subjects (no merges), newest first, cap for Debian noise.
+TMP_SUBJ=$(mktemp "${TMPDIR:-/tmp}/rocm-xio-changelog-subj.XXXXXX") \
+  || exit 1
+DEB_BULLETS=$(mktemp "${TMPDIR:-/tmp}/rocm-xio-deb-bullets.XXXXXX") \
+  || {
+    rm -f "${TMP_SUBJ}"
+    exit 1
+  }
+trap 'rm -f "${TMP_SUBJ}" "${DEB_BULLETS}"' EXIT INT HUP
+if [ -n "${FULL_SHA}" ]; then
+  if [ "${RANGE}" = "HEAD" ]; then
+    git -C "${PROJECT_DIR}" log --no-merges -n 1 \
+      --pretty='%s' HEAD | head -n 80 > "${TMP_SUBJ}" || true
+  else
+    git -C "${PROJECT_DIR}" log --no-merges --pretty='%s' \
+      "${RANGE}" | head -n 80 > "${TMP_SUBJ}" || true
+  fi
+fi
+
+if [ ! -s "${TMP_SUBJ}" ]; then
+  printf '%s\n' \
+    "  * Automated build from git ${SHORT_SHA}" >> "${DEB_BULLETS}"
+else
+  while IFS= read -r line; do
+    # Debian changelog: indent bullet; skip blank lines
+    case "${line}" in
+      '') continue ;;
+      *) printf '%s\n' "  * ${line}" >> "${DEB_BULLETS}" ;;
+    esac
+  done < "${TMP_SUBJ}"
+fi
+
+{
+  printf '%s\n' "rocm-xio (${DEB_VERSION}) ${DIST}; urgency=low"
+  printf '%s\n' ""
+  cat "${DEB_BULLETS}"
+  printf '%s\n' ""
+  printf '%s\n' \
+    " -- AMD ROCm Build <rocm-xio@amd.com>  ${DATE}"
+} > "${SCRIPT_DIR}/changelog"
+
+# Markdown release notes (GitHub Release body).
+HEAD_LINE="ROCm XIO ${DEB_VERSION}"
+if [ "${GEN_CHANGELOG_ROLLING:-}" = "1" ]; then
+  TITLE="# Rolling package build (\`${ROLLING_TAG}\`)"
+else
+  TITLE="# Release ${VERSION}"
+fi
+
+{
+  printf '%s\n\n' "${TITLE}"
+  printf '%s\n\n' "${HEAD_LINE}"
+  printf '%s\n' "**Package version:** \`${DEB_VERSION}\`  "
+  if [ -n "${FULL_SHA}" ]; then
+    printf '%s\n' "**Commit:** \`${FULL_SHA}\`  "
+  else
+    printf '%s\n' "**Commit:** (git unavailable)  "
+  fi
+  printf '%s\n' "**Built:** ${DATE_ISO}  "
+  printf '%s\n\n' "**Change range:** ${RANGE_LABEL}"
+  if [ "${GEN_CHANGELOG_ROLLING:-}" = "1" ]; then
+    printf '%s\n\n' \
+"This pre-release is updated on each push to \`main\`. It may be less stable than a semver-tagged release; for production, prefer a tagged \`vX.Y.Z\` release."
+  fi
+  printf '%s\n\n' "## Changes"
+  if [ ! -s "${TMP_SUBJ}" ]; then
+    printf '%s\n' "* Automated build from git ${SHORT_SHA}"
+  else
+    while IFS= read -r line; do
+      [ -z "${line}" ] && continue
+      printf '* %s\n' "${line}"
+    done < "${TMP_SUBJ}"
+  fi
+} > "${RELEASE_NOTES}"
 
 echo "Generated debian/changelog: ${DEB_VERSION}"
+echo "Generated ${RELEASE_NOTES}"


### PR DESCRIPTION
Point the deb-build rolling GitHub Release at tag rocm-xio-latest and load the release body from debian/generated-release-notes.md instead of inline text. Teach debian/gen-changelog.sh to emit that markdown alongside debian/changelog from the same git revision range: rolling builds prefer rocm-xio-latest..HEAD with semver fallbacks; semver releases use commits since the previous v* tag. Fix lone-HEAD log ranges to use git log -n 1 so the changelog does not list full history. Align release.yml with body_path and disable GitHub-generated release notes for a single source of truth. Ignore debian/generated-release-notes.md in .gitignore.
