### PR TITLE
Improve endpoint HIP launch diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,15 +23,22 @@ exempt.
 Never use volatile NVMe namespace paths such as `/dev/nvme0n1` in destructive
 or benchmark commands. The root filesystem may live on an NVMe namespace, so an
 incorrect volatile path can corrupt the OS disk. NVMe hardware tests must target
-only the spare MTR SLC SSD by stable identity:
+only a stable `/dev/disk/by-id/` namespace path that the user has explicitly
+confirmed is safe to overwrite or benchmark.
 
-```bash
-/dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC
-```
+Before running any NVMe hardware test, resolve the proposed by-id namespace,
+verify it is not mounted as `/` or any other active filesystem, and ask the user
+to confirm that the resolved device is the intended scratch/test drive. Do not
+infer safety from controller numbering such as `/dev/nvmeX`; use controller
+nodes only when an API explicitly requires a controller path.
 
-For multi-queue NVMe runs, set an explicit queue id. On the current test node,
-the MTR SLC controller has `queue_count=33`, so `ROCXIO_NVME_QUEUE_ID=32` is the
-known-good value.
+For multi-queue NVMe runs, set an explicit queue id after checking the selected
+controller's `queue_count`. Use the last valid I/O queue id, which is normally
+`queue_count - 1`, unless the user asks for a different queue.
+
+Do not use `--pci-mmio-bridge` for bare-metal NVMe tests. PCI MMIO bridge mode
+is intended for VM environments; direct bare-metal NVMe endpoint runs should use
+the default doorbell path.
 
 ## Build Setup
 
@@ -126,13 +133,14 @@ truth for this path.
 Run the sweep in three parts so the results are deterministic and each vendor is
 tested against the intended device.
 
-First run non-RDMA tests, including NVMe on only the MTR SLC by-id namespace:
+First run non-RDMA tests, including NVMe only on a user-confirmed safe by-id
+namespace:
 
 ```bash
 sudo env \
-  ROCXIO_NVME_DEVICE=/dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC \
-  NVME_DEVICE=/dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC \
-  ROCXIO_NVME_QUEUE_ID=32 \
+  ROCXIO_NVME_DEVICE="${SAFE_NVME_BY_ID:?set a confirmed by-id namespace}" \
+  NVME_DEVICE="${SAFE_NVME_BY_ID:?set a confirmed by-id namespace}" \
+  ROCXIO_NVME_QUEUE_ID="${SAFE_NVME_QUEUE_ID:?set after checking queue_count}" \
   LD_LIBRARY_PATH="$LIB:/opt/rocs-ais/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}" \
   HSA_FORCE_FINE_GRAIN_PCIE=1 \
   ctest --test-dir build -LE 'rdma|fixture' \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ site][docs-site].
 
 <!-- References -->
 
-[docs-site]: https://rocm.docs.amd.com/projects/rocm-xio/en/beta-0.1.0/
+[docs-site]: https://rocm.docs.amd.com/projects/rocm-xio/en/beta-0.1.0/A
 [ep-nvme]: https://rocm.docs.amd.com/projects/rocm-xio/en/beta-0.1.0/reference/endpoints.html#nvme-ep-nvme-endpoint
 [ep-rdma]: https://rocm.docs.amd.com/projects/rocm-xio/en/beta-0.1.0/reference/endpoints.html#rdma-ep-rdma-endpoint
 [ep-sdma]: https://rocm.docs.amd.com/projects/rocm-xio/en/beta-0.1.0/reference/endpoints.html#sdma-ep-sdma-endpoint

--- a/cmake/XIOVirtualMachine.cmake
+++ b/cmake/XIOVirtualMachine.cmake
@@ -21,9 +21,11 @@
 # 1. QEMU binary
 # ---------------------------------------------------
 # Cache variable: override with
-#   -DQEMU_PATH=/opt/qemu-10.1.2/bin/
+#   -DQEMU_PATH=/opt/qemu-pci-10.2.0/bin/
+#   or -DQEMU_PATH=/opt/qemu-mmio-bridge-submit/bin/
+#   or -DQEMU_PATH=/opt/qemu-10.1.2/bin/
 set(QEMU_PATH "" CACHE STRING
-  "Path prefix for qemu-system-x86_64 (empty = system)")
+  "Path prefix for qemu-system-x86_64 (empty: search PATH then /opt). Prefer /opt/qemu-mmio-bridge-submit/bin/ or /opt/qemu-pci*/bin/.")
 
 if(QEMU_PATH)
   set(_qemu_bin "${QEMU_PATH}/qemu-system-x86_64")
@@ -39,7 +41,23 @@ if(QEMU_PATH)
     endif()
   endif()
 else()
-  find_program(_qemu_bin qemu-system-x86_64)
+  set(_qemu_bin "")
+  if(EXISTS
+      "/opt/qemu-mmio-bridge-submit/bin/qemu-system-x86_64")
+    set(_qemu_bin
+      "/opt/qemu-mmio-bridge-submit/bin/qemu-system-x86_64")
+  endif()
+  if(NOT _qemu_bin)
+    file(GLOB _xio_qemu_pci_glob
+      "/opt/qemu-pci*/bin/qemu-system-x86_64")
+    if(_xio_qemu_pci_glob)
+      list(SORT _xio_qemu_pci_glob COMPARE NATURAL)
+      list(GET _xio_qemu_pci_glob -1 _qemu_bin)
+    endif()
+  endif()
+  if(NOT _qemu_bin)
+    find_program(_qemu_bin qemu-system-x86_64)
+  endif()
 endif()
 
 set(_qemu_ok FALSE)
@@ -98,7 +116,9 @@ endif()
 # 3. run-vm script
 # ---------------------------------------------------
 find_program(RUN_VM run-vm
-  HINTS "$ENV{HOME}/Projects/qemu-minimal/qemu")
+  HINTS
+    "${CMAKE_SOURCE_DIR}/../qemu-minimal/qemu"
+    "$ENV{HOME}/Projects/qemu-minimal/qemu")
 
 if(NOT RUN_VM)
   message(STATUS
@@ -279,12 +299,11 @@ else()
   if(NOT _qemu_ok)
     list(APPEND _err_cmds
       COMMAND ${CMAKE_COMMAND} -E echo
-        "Error: qemu-system-x86_64 not found or"
-        "version < 10.1.0."
+        "Error: qemu-system-x86_64 not found or QEMU version below 10.1.0."
       COMMAND ${CMAKE_COMMAND} -E echo
         "  sudo apt-get install qemu-system-x86"
       COMMAND ${CMAKE_COMMAND} -E echo
-        "  or: -DQEMU_PATH=/opt/qemu-10.1.2/bin/")
+        "  or: -DQEMU_PATH=/opt/qemu-mmio-bridge-submit/bin/")
   endif()
 
   if(NOT RUN_VM)
@@ -338,7 +357,9 @@ endif()
 # 7. gen-vm script and cloud-localds
 # ---------------------------------------------------
 find_program(GEN_VM gen-vm
-  HINTS "$ENV{HOME}/Projects/qemu-minimal/qemu")
+  HINTS
+    "${CMAKE_SOURCE_DIR}/../qemu-minimal/qemu"
+    "$ENV{HOME}/Projects/qemu-minimal/qemu")
 
 find_program(CLOUD_LOCALDS cloud-localds)
 
@@ -431,9 +452,9 @@ else()
   if(NOT _qemu_ok)
     list(APPEND _gen_err
       COMMAND ${CMAKE_COMMAND} -E echo
-        "Error: QEMU not found or < 10.1.0."
+        "Error: QEMU not found or QEMU version below 10.1.0."
       COMMAND ${CMAKE_COMMAND} -E echo
-        "  -DQEMU_PATH=/opt/qemu-10.1.2/bin/")
+        "  -DQEMU_PATH=/opt/qemu-mmio-bridge-submit/bin/")
   endif()
 
   if(NOT GEN_VM)

--- a/docs/how-to/vm-testing.rst
+++ b/docs/how-to/vm-testing.rst
@@ -23,8 +23,10 @@ Prerequisites
 Tool                Install
 ==================  ===================================
 QEMU >= 10.1        ``apt install qemu-system-x86``
-                    or build from source under
-                    ``/opt/qemu-<version>``
+                    or a PCI/MMIO-capable build (for example
+                    ``/opt/qemu-mmio-bridge-submit/bin/`` or
+                    ``/opt/qemu-pci*/bin/``) preferred for
+                    passthrough and MMIO bridge tests
 ``driverctl``       ``apt install driverctl``
 ``cloud-localds``   ``apt install cloud-image-utils``
 ``qemu-minimal``    Clone
@@ -192,8 +194,14 @@ configure time.
 ======================  ================================
 Variable                Description
 ======================  ================================
-``QEMU_PATH``           QEMU binary prefix (empty =
-                        system ``qemu-system-x86_64``)
+``QEMU_PATH``           QEMU binary directory prefix
+                        (must include a trailing ``/`` when
+                        passed to ``run-vm``; CMake and
+                        ``launch-vm`` normalize this). Prefer a
+                        PCI/MMIO-capable build under
+                        ``/opt/qemu-mmio-bridge-submit/bin/`` or
+                        ``/opt/qemu-pci*/bin/`` (>= 10.1) over the
+                        distro ``qemu-system-x86_64`` alone.
 ``XIO_VM_GPU``          GPU BDF for passthrough
                         (for example, ``10:00.0``); auto-
                         detected if not set
@@ -201,7 +209,9 @@ Variable                Description
 ``XIO_VM_PASS``         VM password (default:
                         ``password``)
 ``RUN_VM``              Path to ``qemu-minimal``
-                        ``run-vm`` script
+                        ``run-vm`` script (CMake searches next
+                        to this checkout:
+                        ``<repo>/../qemu-minimal/qemu``)
 ``GEN_VM``              Path to ``qemu-minimal``
                         ``gen-vm`` script
 ======================  ================================
@@ -221,10 +231,80 @@ Variable                Default   Notes
 ``RDMA_NIC_BDF``        c3:00.1   BNXT NIC (rdma mode)
 ``NVME_DEV_BDF``        85:00.0   NVMe ctrl (nvme mode)
 ``VCPUS``               16        Guest vCPU count
-``VMEM``                32768     Guest RAM (MB)
+``VMEM``                16384     Guest RAM (MB); lower if VFIO
+                                  hits ENOMEM, higher only with
+                                  memlock limits raised
 ``VM_MODE``             rdma      ``rdma``, ``nvme``,
                                   ``ernic``, or ``full``
+``NVME``                1         Emulated qcow2 NVMe count
+                                  for ``run-vm`` (``2`` for
+                                  two devices)
+``NVME_TRACE``          none      ``doorbell``, ``all``, or a
+                                  QEMU event name; see
+                                  ``qemu-minimal`` ``run-vm``
+                                  header
+``NVME_TRACE_FILE``     (empty)   Host path for ``-trace
+                                  file=...`` when tracing
+``NVME_RECREATE``       false     When ``true``, delete and
+                                  recreate emulated NVMe
+                                  qcow2 images before boot
+``DRY_RUN``             none      Any value other than
+                                  ``none`` prints the QEMU
+                                  argv without running QEMU
+``QMP_SOCKET``          false     ``true``, ``false``, or a
+                                  custom Unix socket path; see
+                                  ``run-vm``
 ======================  ========  =====================
+
+The ``launch-test-vm`` target passes ``RUN_VM``, ``GPU_BDF``,
+and ``QEMU_PATH`` via ``cmake -E env``; other variables in the
+table are inherited from the environment of the tool that runs
+the build (for example ``ninja``), so export them in the same
+shell before ``cmake --build`` when you need tracing or a dry
+run.
+
+QEMU path, dual NVMe topology, and tracing
+==========================================
+
+``run-vm`` builds the QEMU command by concatenating
+``QEMU_PATH`` with ``qemu-system-x86_64`` (plus arguments).
+``QEMU_PATH`` must therefore be a directory prefix, normally
+ending in ``bin/``. ``launch-vm`` adds the trailing slash when
+it is missing and, when ``QEMU_PATH`` is unset or empty, picks
+``/opt/qemu-mmio-bridge-submit/bin/`` when that install exists,
+otherwise the newest matching ``/opt/qemu-pci*/bin/`` directory
+that contains a usable ``qemu-system-x86_64`` (or
+``qemu-system-amd64``), so routine VM launches align with the
+PCI/MMIO-capable QEMU builds used for ``gen-test-vm`` when you
+configure with ``-DQEMU_PATH=`` under that tree.
+
+In ``nvme`` and ``full`` modes the guest receives **both** the
+emulated qcow2-backed NVMe device(s) controlled by ``NVME`` and
+a **VFIO**-passthrough NVMe **controller** (``NVME_DEV_BDF``).
+``launch-vm`` also enables ``PCI_MMIO_BRIDGE`` for GPU-direct
+NVMe in those modes. QEMU wires the emulated NVMe first, then
+VFIO devices. Namespace names inside the guest are not the
+same as host ``/dev/disk/by-id/...`` paths; use ``lsblk`` and
+``nvme list`` in the guest to pick the correct device for
+``xio-tester nvme-ep`` (use ``--pci-mmio-bridge`` when the VM
+was started with the MMIO bridge). Passthrough detaches the
+whole PCI function from the host for the VM session; confirm
+the BDF is the intended scratch or test controller before
+binding it to ``vfio-pci``.
+
+QEMU **NVMe trace** events complement rocm-xio logging on the
+emulated path (for example ``ROCXIO_NVME_DUMP_PRP``). Set
+``NVME_TRACE`` to ``doorbell``, ``all``, or a specific event
+name, and optionally ``NVME_TRACE_FILE`` to capture trace lines
+to a host file. Example inspection without booting the guest
+(``DRY_RUN=1`` skips host VFIO checks in ``launch-vm`` and
+``pci_check`` in ``run-vm`` so you can print the argv without
+binding devices; a real boot still needs ``vfio-pci``):
+
+.. code-block:: bash
+
+   DRY_RUN=1 NVME_TRACE=all \
+     ./scripts/test/launch-vm nvme
 
 GPU detection
 =============
@@ -290,3 +370,22 @@ Troubleshooting
       cd ~/Projects/rocm-ernic
       cmake -B build -G Ninja
       cmake --build build
+
+**VFIO ``vfio_container_dma_map ... Cannot allocate memory``**
+   QEMU maps all guest RAM for the GPU VFIO container; with a
+   large ``VMEM`` and a low **locked memory** hard limit, the
+   kernel returns ENOMEM. ``ulimit -l unlimited`` only works
+   after an admin raises the **hard** cap, for example under
+   ``/etc/security/limits.d/`` (``memlock`` soft/hard
+   ``unlimited`` for your user), then a full logout and login.
+   Until then, run with less RAM, for example
+   ``VMEM=8192 ./scripts/test/launch-vm nvme``.
+
+**QEMU ``Can't add chassis slot, error -16`` on a second
+   ``pcie-root-port``**
+   Older ``qemu-minimal`` ``run-vm`` lines gave every
+   ``pcie-root-port`` the default ACPI ``chassis``/``slot``,
+   so the second VFIO passthrough root port collides (EBUSY).
+   Update ``qemu-minimal`` ``run-vm`` so each host root port
+   sets distinct ``chassis=``/``slot=`` (or pull the latest
+   ``run-vm`` from your ``qemu-minimal`` checkout).

--- a/kernel/rocm-xio/rocm-xio.c
+++ b/kernel/rocm-xio/rocm-xio.c
@@ -19,9 +19,12 @@
  *   1. Userspace allocates GPU VRAM buffers (queues, data buffers etc)
  *   2. Get physical addresses via GET_VRAM_PHYS_ADDR ioctl
  *   3. Register queue addresses via REGISTER_QUEUE_ADDR ioctl
- *   4. Register data buffers via REGISTER_BUFFER ioctl (optional, for I/O)
- *   5. Use normal NVMe driver interface - kprobe automatically injects
- *      physical addresses into PRP1/PRP2 fields
+ *   4. Register data buffers via REGISTER_BUFFER ioctl when SQE PRPs carry
+ *      the buffer virtual base (host or GPU); skip when PRPs are already
+ *      IOVAs. Host vs VRAM is selected by REGISTER_BUFFER dmabuf_fd (-1 vs
+ *      DMA-BUF fd).
+ *   5. Use normal NVMe driver interface - kprobe injects device-visible
+ *      addresses for PRPs that fall inside a registered virtual range.
  */
 
 #include "rocm-xio.h"
@@ -88,6 +91,7 @@ struct vram_buffer_entry {
   __u64 virt_addr;
   __u64 phys_addr;
   __u64 size;
+  __u64 dmabuf_linear_off;
   struct list_head list;
   // For passthrough NVMe - keep attachment alive for P2PDMA
   struct dma_buf* dmabuf;
@@ -709,6 +713,27 @@ static __u64 lookup_queue_prp2(__u64 virt_addr) {
  * Look up physical address for data buffer (I/O commands).
  * First checks registered VRAM buffers, then falls back to virt_to_phys.
  */
+static int sgtable_dma_at_byte(struct sg_table* sgt, size_t offset,
+                               dma_addr_t* out) {
+  struct scatterlist* sg;
+  unsigned int i;
+  size_t pos = 0;
+
+  if (!sgt || !sgt->sgl || !out)
+    return -EINVAL;
+
+  for_each_sg(sgt->sgl, sg, sgt->nents, i) {
+    unsigned int len = sg_dma_len(sg);
+
+    if (offset < pos + (size_t)len) {
+      *out = sg_dma_address(sg) + (dma_addr_t)(offset - pos);
+      return 0;
+    }
+    pos += (size_t)len;
+  }
+  return -EINVAL;
+}
+
 static __u64 lookup_buffer_phys_addr(__u64 virt_addr) {
   struct vram_buffer_entry* entry;
   __u64 phys_addr = 0;
@@ -718,7 +743,17 @@ static __u64 lookup_buffer_phys_addr(__u64 virt_addr) {
   list_for_each_entry(entry, &vram_buffers, list) {
     if (virt_addr >= entry->virt_addr &&
         virt_addr < (entry->virt_addr + entry->size)) {
-      phys_addr = entry->phys_addr + (virt_addr - entry->virt_addr);
+      size_t delta = (size_t)(virt_addr - entry->virt_addr);
+      size_t off = (size_t)entry->dmabuf_linear_off + delta;
+
+      if (entry->is_passthrough && entry->sgt) {
+        dma_addr_t d;
+
+        if (sgtable_dma_at_byte(entry->sgt, off, &d) == 0)
+          phys_addr = (__u64)d;
+      } else {
+        phys_addr = entry->phys_addr + (__u64)off;
+      }
       break;
     }
   }
@@ -733,6 +768,179 @@ static __u64 lookup_buffer_phys_addr(__u64 virt_addr) {
   }
 
   return 0;
+}
+
+/*
+ * True if @addr lies in the virtual range of a REGISTER_BUFFER entry.
+ * Host vs device memory is already distinguished at registration time
+ * (struct rocm_xio_register_buffer_req: dmabuf_fd -1 vs VRAM DMA-BUF fd).
+ * The NVMe kprobe only rewrites PRPs when the SQE still carries such a
+ * registered user/GPU virtual address; values that are already IOVAs
+ * (including PRP list pointers) are left unchanged.
+ */
+static bool vram_user_virt_registered(__u64 addr) {
+  struct vram_buffer_entry* entry;
+  bool found = false;
+
+  spin_lock(&vram_buffers_lock);
+  list_for_each_entry(entry, &vram_buffers, list) {
+    if (addr >= entry->virt_addr &&
+        addr < (__u64)(entry->virt_addr + entry->size)) {
+      found = true;
+      break;
+    }
+  }
+  spin_unlock(&vram_buffers_lock);
+  return found;
+}
+
+#define ROCM_XIO_NVME_PAGE_BYTES 4096ULL
+#define ROCM_XIO_MAX_SG_SNAPSHOT 512U
+
+static int snap_dma_byte_offset(const dma_addr_t* sg_addr,
+                                const unsigned int* sg_len,
+                                unsigned int sg_count, size_t offset,
+                                dma_addr_t* out) {
+  size_t pos = 0;
+  unsigned int i;
+
+  for (i = 0; i < sg_count; i++) {
+    if (offset < pos + (size_t)sg_len[i]) {
+      *out = sg_addr[i] + (dma_addr_t)(offset - pos);
+      return 0;
+    }
+    pos += (size_t)sg_len[i];
+  }
+  return -EINVAL;
+}
+
+/*
+ * Copy one NVMe 4K-page DMA/IOVA per buffer page for a REGISTER_BUFFER entry.
+ * Passthrough buffers use the full scatter-gather map; emulated buffers use
+ * a linear GPA from the single registered base.
+ */
+static long rocm_xio_ioctl_get_buffer_dma_pages(void __user* uarg) {
+  struct rocm_xio_buffer_dma_pages_req req;
+  struct vram_buffer_entry* entry;
+  dma_addr_t* sg_addr = NULL;
+  unsigned int* sg_len = NULL;
+  unsigned int sg_count = 0;
+  bool use_sg = false;
+  __u64 linear_phys = 0;
+  size_t buf_size = 0;
+  bool found = false;
+  unsigned long irqflags;
+  __u32 needed;
+  __u64* kbuf = NULL;
+  __u32 p;
+  long ret = 0;
+  __u64 dmabuf_lo = 0;
+
+  if (copy_from_user(&req, uarg, sizeof(req)))
+    return -EFAULT;
+
+  if (!req.user_addrs_ptr || req.max_pages == 0)
+    return -EINVAL;
+  if (req.max_pages > (1U << 20))
+    return -EINVAL;
+
+  sg_addr = kmalloc_array(ROCM_XIO_MAX_SG_SNAPSHOT, sizeof(*sg_addr),
+                          GFP_KERNEL);
+  if (!sg_addr) {
+    ret = -ENOMEM;
+    goto out_free_snap;
+  }
+  sg_len = kmalloc_array(ROCM_XIO_MAX_SG_SNAPSHOT, sizeof(*sg_len),
+                         GFP_KERNEL);
+  if (!sg_len) {
+    ret = -ENOMEM;
+    goto out_free_snap;
+  }
+
+  spin_lock_irqsave(&vram_buffers_lock, irqflags);
+  list_for_each_entry(entry, &vram_buffers, list) {
+    if (entry->virt_addr == req.virt_addr) {
+      buf_size = (size_t)entry->size;
+      dmabuf_lo = entry->dmabuf_linear_off;
+      if (entry->is_passthrough && entry->sgt) {
+        struct scatterlist* sg;
+        unsigned int sg_i;
+
+        if ((unsigned int)entry->sgt->nents > ROCM_XIO_MAX_SG_SNAPSHOT) {
+          spin_unlock_irqrestore(&vram_buffers_lock, irqflags);
+          ret = -E2BIG;
+          goto out_free_snap;
+        }
+        for_each_sg(entry->sgt->sgl, sg, entry->sgt->nents, sg_i) {
+          sg_addr[sg_count] = sg_dma_address(sg);
+          sg_len[sg_count] = sg_dma_len(sg);
+          sg_count++;
+        }
+        use_sg = true;
+      } else {
+        linear_phys = entry->phys_addr;
+        use_sg = false;
+      }
+      found = true;
+      break;
+    }
+  }
+  spin_unlock_irqrestore(&vram_buffers_lock, irqflags);
+
+  if (!found) {
+    ret = -ENOENT;
+    goto out_free_snap;
+  }
+  if (buf_size == 0) {
+    ret = -EINVAL;
+    goto out_free_snap;
+  }
+
+  needed = (__u32)DIV_ROUND_UP(buf_size, ROCM_XIO_NVME_PAGE_BYTES);
+  if (req.max_pages < needed) {
+    ret = -EINVAL;
+    goto out_free_snap;
+  }
+
+  kbuf = kmalloc_array(needed, sizeof(__u64), GFP_KERNEL);
+  if (!kbuf) {
+    ret = -ENOMEM;
+    goto out_free_snap;
+  }
+
+  for (p = 0; p < needed; p++) {
+    size_t off = (size_t)dmabuf_lo +
+                 (size_t)p * (size_t)ROCM_XIO_NVME_PAGE_BYTES;
+
+    if (use_sg) {
+      dma_addr_t d;
+
+      if (snap_dma_byte_offset(sg_addr, sg_len, sg_count, off, &d) != 0) {
+        ret = -EIO;
+        goto out_kfree_kbuf;
+      }
+      kbuf[p] = (__u64)d;
+    } else {
+      kbuf[p] = linear_phys + (__u64)off;
+    }
+  }
+
+  if (copy_to_user((void __user*)(uintptr_t)req.user_addrs_ptr, kbuf,
+                   (size_t)needed * sizeof(__u64))) {
+    ret = -EFAULT;
+    goto out_kfree_kbuf;
+  }
+
+  req.num_pages_out = needed;
+  if (copy_to_user(uarg, &req, sizeof(req)))
+    ret = -EFAULT;
+
+out_kfree_kbuf:
+  kfree(kbuf);
+out_free_snap:
+  kfree(sg_addr);
+  kfree(sg_len);
+  return ret;
 }
 
 /*
@@ -837,9 +1045,7 @@ static int nvme_submit_user_cmd_pre(struct kprobe* p, struct pt_regs* regs) {
     __u64 prp1_val = le64_to_cpu(cmd->common.dptr.prp1);
     __u64 prp2_val = le64_to_cpu(cmd->common.dptr.prp2);
 
-    /* If PRP1 looks like a virtual address (not a high physical address),
-     * try to convert it */
-    if (prp1_val && prp1_val < 0x100000000ULL) {
+    if (prp1_val && vram_user_virt_registered(prp1_val)) {
       phys_addr = lookup_buffer_phys_addr(prp1_val);
       if (phys_addr) {
         pr_debug("rocm-axiio: Injecting PRP1 for I/O: 0x%016llx\n",
@@ -848,8 +1054,7 @@ static int nvme_submit_user_cmd_pre(struct kprobe* p, struct pt_regs* regs) {
       }
     }
 
-    /* Same for PRP2 if present */
-    if (prp2_val && prp2_val < 0x100000000ULL) {
+    if (prp2_val && vram_user_virt_registered(prp2_val)) {
       phys_addr = lookup_buffer_phys_addr(prp2_val);
       if (phys_addr) {
         pr_debug("rocm-axiio: Injecting PRP2 for I/O: 0x%016llx\n",
@@ -1037,6 +1242,7 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
       struct rocm_xio_register_buffer_req req;
       struct vram_buffer_entry* entry;
       __u64 phys_addr;
+      __u64 logical_size;
       bool is_emulated = false;
       struct dma_buf* dmabuf = NULL;
       struct dma_buf_attachment* attach = NULL;
@@ -1045,6 +1251,14 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
 
       if (copy_from_user(&req, (void __user*)arg, sizeof(req)))
         return -EFAULT;
+
+      /*
+       * Userspace passes the logical I/O buffer size. get_dmabuf_* may
+       * overwrite req.size with the full DMA-BUF object size (page-rounded
+       * export), which can be larger. entry->size must stay logical so
+       * GET_BUFFER_DMA_PAGES and PRP range checks match hip allocation.
+       */
+      logical_size = req.size;
 
       /* Determine if this is emulated NVMe based on flags field */
       if (req.flags & ROCM_XIO_FLAG_EMULATED) {
@@ -1106,7 +1320,8 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
       /* Store userspace virtual address */
       entry->virt_addr = (__u64)req.virt_addr;
       entry->phys_addr = phys_addr;
-      entry->size = req.size;
+      entry->size = logical_size;
+      entry->dmabuf_linear_off = req.dmabuf_linear_off;
       entry->is_passthrough = !is_emulated;
 
       /* Store attachment info for passthrough (keep alive) */
@@ -1139,17 +1354,20 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
         format_bdf_as_pci_addr(bdf, pci_addr, sizeof(pci_addr));
         if (pci_addr[0] != '\0') {
           pr_info("rocm-axiio: Registered buffer: virt=0x%016llx "
-                  "phys=0x%016llx size=0x%llx (%s)%s\n",
+                  "phys=0x%016llx size=0x%llx (dmabuf=0x%llx) (%s)%s\n",
                   (unsigned long long)entry->virt_addr,
-                  (unsigned long long)phys_addr, (unsigned long long)req.size,
-                  pci_addr,
+                  (unsigned long long)phys_addr,
+                  (unsigned long long)logical_size,
+                  (unsigned long long)req.size, pci_addr,
                   entry->is_passthrough ? " (P2PDMA attachment kept alive)"
                                         : "");
         } else {
           pr_info("rocm-axiio: Registered buffer: virt=0x%016llx "
-                  "phys=0x%016llx size=0x%llx%s\n",
+                  "phys=0x%016llx size=0x%llx (dmabuf=0x%llx)%s\n",
                   (unsigned long long)entry->virt_addr,
-                  (unsigned long long)phys_addr, (unsigned long long)req.size,
+                  (unsigned long long)phys_addr,
+                  (unsigned long long)logical_size,
+                  (unsigned long long)req.size,
                   entry->is_passthrough ? " (P2PDMA attachment kept alive)"
                                         : "");
         }
@@ -1243,6 +1461,9 @@ static long rocm_xio_ioctl(struct file* file, unsigned int cmd,
       kfree(entry);
       return 0;
     }
+
+    case ROCM_XIO_GET_BUFFER_DMA_PAGES:
+      return rocm_xio_ioctl_get_buffer_dma_pages((void __user*)arg);
 
     case ROCM_XIO_GET_MMIO_BRIDGE_SHADOW_BUFFER: {
       struct rocm_xio_mmio_bridge_shadow_req req;

--- a/run-ctests.sh
+++ b/run-ctests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Run the full CTest sweep (NVMe + RDMA + unit + install examples) with
+# hardware-oriented environment. Requires sudo.
+#
+# Usage:
+#   ./run-ctests.sh [--] [bnxt|ionic|mlx5|all] [--] [ctest-option...]
+#
+# All arguments after the optional vendor keyword are passed through to
+# ctest unchanged (after stripping optional "--" sentinels used only by this
+# wrapper). Examples:
+#   ./run-ctests.sh -R nvme-verify-seq-host-mem -V
+#   ./run-ctests.sh ionic -LE rdma --output-on-failure
+#   ./run-ctests.sh bnxt -- -R '^rdma-xio-loopback' --output-on-failure
+#
+# Optional first argument selects the RDMA vendor passed to
+# setup-rdma-loopback.sh (default: bnxt). You can also set VENDOR in the
+# environment. When vendor is "all", ROCXIO_RDMA_DEVICE is left unset so
+# scripts auto-detect the first InfiniBand device.
+#
+# Override NVMe path when the default MTR by-id is not present:
+#   ROCXIO_NVME_DEVICE=/dev/disk/by-id/... ./run-ctests.sh ionic
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+
+if [[ "${1:-}" == "--" ]]; then
+  shift
+elif [[ "${1:-}" =~ ^(bnxt|ionic|mlx5|all)$ ]]; then
+  export VENDOR="$1"
+  shift
+fi
+
+# Allow ./run-ctests.sh <vendor> -- <ctest-args> so ctest never sees a bare
+# "--" from the wrapper.
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+export VENDOR="${VENDOR:-bnxt}"
+if [[ "${VENDOR}" == all ]]; then
+  export PROVIDER="${PROVIDER:-auto}"
+else
+  export PROVIDER="${PROVIDER:-${VENDOR}}"
+fi
+
+ROCXIO_NVME_DEVICE="${ROCXIO_NVME_DEVICE:-/dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC}"
+
+case "${VENDOR}" in
+bnxt)
+  export ROCXIO_RDMA_DEVICE="${ROCXIO_RDMA_DEVICE:-rocm-rdma-bnxt0}"
+  ;;
+ionic)
+  export ROCXIO_RDMA_DEVICE="${ROCXIO_RDMA_DEVICE:-rocm-rdma-ionic0}"
+  ;;
+mlx5)
+  export ROCXIO_RDMA_DEVICE="${ROCXIO_RDMA_DEVICE:-rocm-rdma-mlx50}"
+  ;;
+all)
+  if [[ -z "${ROCXIO_RDMA_DEVICE:-}" ]]; then
+    unset ROCXIO_RDMA_DEVICE
+  fi
+  ;;
+esac
+
+LIB="${REPO_ROOT}/build/_deps/rdma-core/install/lib"
+RDMA_LDPATH="${LIB}:${LIB}/libibverbs:/opt/rocs-ais/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}"
+
+CTEST_ARGS=(--test-dir "${REPO_ROOT}/build" --output-on-failure)
+if [[ -f "${REPO_ROOT}/build/ctest-resources.json" ]]; then
+  CTEST_ARGS+=(--resource-spec-file "${REPO_ROOT}/build/ctest-resources.json")
+fi
+
+ENV_ARGS=(
+  "ROCXIO_NVME_DEVICE=${ROCXIO_NVME_DEVICE}"
+  "NVME_DEVICE=${NVME_DEVICE:-${ROCXIO_NVME_DEVICE}}"
+  "VENDOR=${VENDOR}"
+  "PROVIDER=${PROVIDER}"
+  "LD_LIBRARY_PATH=${RDMA_LDPATH}"
+  "HSA_FORCE_FINE_GRAIN_PCIE=${HSA_FORCE_FINE_GRAIN_PCIE:-1}"
+)
+if [[ -n "${ROCXIO_RDMA_DEVICE:-}" ]]; then
+  ENV_ARGS+=("ROCXIO_RDMA_DEVICE=${ROCXIO_RDMA_DEVICE}")
+fi
+
+# Remaining "$@" are forwarded to ctest after our default flags.
+sudo env "${ENV_ARGS[@]}" ctest "${CTEST_ARGS[@]}" "$@"

--- a/run-inf.sh
+++ b/run-inf.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+LIB=/home/stebates/Projects/rocm-xio/build/_deps/rdma-core/install/lib
+
+# PRP dump: set ROCXIO_NVME_DUMP_PRP=1 and ROCXIO_LOG_LEVEL=3 (do not put `#`
+# comments inside a backslash-continued sudo env line — it splits the command
+# so xio-tester runs without sudo and hits EACCES on the NVMe node).
+sudo env ROCXIO_NVME_DUMP_VERIFY_MISMATCH=1 \
+  ROCXIO_NVME_DUMP_VERIFY_MISMATCH_HALF=48 \
+  ROCXIO_NVME_DUMP_PRP=1 \
+  ROCXIO_NVME_DUMP_PRP_BATCH=2 \
+  ROCXIO_LOG_LEVEL=3 \
+  LD_LIBRARY_PATH="${LIB}:/opt/rocs-ais/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}" \
+  HSA_FORCE_FINE_GRAIN_PCIE=1 \
+  ./build/xio-tester nvme-ep \
+  --controller /dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC \
+  --access-pattern random \
+  --lfsr-seed 0x4446 \
+  --memory-mode 0 \
+  --write-io 0 \
+  --read-io 1 \
+  --queue-length 1024 \
+  --batch-size 63 \
+  --infinite \
+  --num-queues 4 \
+  --lbas-per-io 4 \
+  --less-timing

--- a/run-this.sh
+++ b/run-this.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+LIB=/home/stebates/Projects/rocm-xio/build/_deps/rdma-core/install/lib
+
+# PRP dump: set ROCXIO_NVME_DUMP_PRP=1 and ROCXIO_LOG_LEVEL=3 (do not put `#`
+# comments inside a backslash-continued sudo env line — it splits the command
+# so xio-tester runs without sudo and hits EACCES on the NVMe node).
+sudo env ROCXIO_NVME_DUMP_VERIFY_MISMATCH=1 \
+  ROCXIO_NVME_DUMP_VERIFY_MISMATCH_HALF=48 \
+  ROCXIO_NVME_DUMP_PRP=1 \
+  ROCXIO_NVME_DUMP_PRP_BATCH=2 \
+  ROCXIO_LOG_LEVEL=3 \
+  LD_LIBRARY_PATH="${LIB}:/opt/rocs-ais/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}" \
+  HSA_FORCE_FINE_GRAIN_PCIE=1 \
+  ./build/xio-tester nvme-ep \
+  --controller /dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC \
+  --access-pattern random \
+  --lfsr-seed 0x4444 \
+  --memory-mode 8 \
+  --write-io 1 \
+  --read-io 1 \
+  --queue-length 1024 \
+  --batch-size 1 \
+  --num-queues 1 \
+  --histogram \
+  --verify \
+  --lbas-per-io 17 \
+  --verbose

--- a/scripts/test/dd-prp-list-write-confirm.sh
+++ b/scripts/test/dd-prp-list-write-confirm.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Snapshot a fixed LBA range with dd, run xio-tester nvme-ep for a single
+# write that uses a PRP list (17 LBAs = 8704 B), then dd again and show
+# whether the namespace content changed. When the snapshot differs, also
+# compares the post-write dd image to the LFSR golden from xio-tester
+# --dump-pattern, then runs nvme-ep once with --write-io 1 --read-io 1
+# --verify so the read DMA buffer is checked against the same golden (host
+# verify; requires a second in-process write before the read, same pattern).
+#
+# Requires: root for dd to the namespace and for xio-tester nvme-ep; a
+# stable /dev/disk/by-id/... namespace path (never use volatile /dev/nvmeXnY
+# for destructive workflows—pick a scratch region the operator confirms).
+#
+# Usage:
+#   sudo ./scripts/test/dd-prp-list-write-confirm.sh [SLBA]
+# Environment (optional):
+#   NVME_NS   Namespace block device (default: MTR by-id path below).
+#   LBAS      LBAs per I/O (default: 17 => 8704 B, PRP list path).
+#   XIO_TESTER  Path to xio-tester (default: ./build/xio-tester from repo root).
+#   MEMORY_MODE  nvme-ep --memory-mode (default: 8).
+#   LFSR_SEED   Passed to --lfsr-seed (default: 0). If the namespace already
+#               holds the same LFSR bytes for this SLBA/length/seed, BEFORE
+#               and AFTER hashes match even when the write succeeded.
+#   DD_PRP_SCRATCH_RANDOMIZE  If set to 1, overwrites the SLBA range with
+#               random bytes (dd from urandom) before step (1). DESTRUCTIVE;
+#               only on a confirmed scratch namespace.
+#   REPO_ROOT If unset, inferred from script location.
+#
+# Exit codes: 0 success (dd changed, disk matches golden, xio verify pass);
+#   1 root/device/binary errors; 2 before/after identical; 3 disk vs golden
+#   mismatch; 4 xio --verify failure.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")"/../.. && pwd)}"
+cd "$REPO_ROOT"
+
+NVME_NS="${NVME_NS:-/dev/disk/by-id/nvme-MTR_SLC_16GB_0400000E3CBC}"
+SLBA="${1:-${SLBA:-20000000}}"
+LBAS="${LBAS:-17}"
+BS=512
+COUNT="$LBAS"
+WORKDIR="${WORKDIR:-/tmp}"
+BEFORE="${WORKDIR}/nvme-prp-dd-before.$$"
+AFTER="${WORKDIR}/nvme-prp-dd-after.$$"
+EXPECTED="${WORKDIR}/nvme-prp-lfsr-expected.$$"
+BYTES=$((COUNT * BS))
+XIO_TESTER="${XIO_TESTER:-$REPO_ROOT/build/xio-tester}"
+LIB="${LIB:-$REPO_ROOT/build/_deps/rdma-core/install/lib}"
+LFSR_SEED="${LFSR_SEED:-0}"
+
+nvme_ep_common=(
+  nvme-ep
+  --controller "$NVME_NS"
+  --access-pattern sequential
+  --base-lba "$SLBA"
+  --lfsr-seed "$LFSR_SEED"
+  --lbas-per-io "$LBAS"
+  --memory-mode "${MEMORY_MODE:-8}"
+  --queue-length 1024
+  --batch-size 1
+  --num-queues 1
+)
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run as root (sudo) so dd and xio-tester can open the NVMe node."
+  exit 1
+fi
+
+if [[ ! -b "$NVME_NS" ]]; then
+  echo "Not a block device: $NVME_NS"
+  exit 1
+fi
+
+if [[ ! -x "$XIO_TESTER" ]]; then
+  echo "Missing xio-tester: $XIO_TESTER (build the project first)."
+  exit 1
+fi
+
+cleanup() {
+  rm -f "$BEFORE" "$AFTER" "$EXPECTED"
+}
+trap cleanup EXIT
+
+echo "Namespace: $NVME_NS"
+echo "SLBA=$SLBA  sectors=$COUNT  bytes=$((COUNT * BS))  (PRP list when LBAS>=17 at 512 B/LBA)"
+echo "LFSR_SEED=$LFSR_SEED (export LFSR_SEED to change pattern; see script header)"
+echo
+
+if [[ "${DD_PRP_SCRATCH_RANDOMIZE:-0}" == 1 ]]; then
+  echo "=== (0) DD_PRP_SCRATCH_RANDOMIZE=1: overwrite SLBA range with urandom (DESTRUCTIVE) ==="
+  dd if=/dev/urandom of="$NVME_NS" bs="$BS" seek="$SLBA" count="$COUNT" status=none conv=fdatasync
+  echo
+fi
+
+echo "=== (1) dd read BEFORE xio-tester ==="
+dd if="$NVME_NS" of="$BEFORE" bs="$BS" skip="$SLBA" count="$COUNT" status=none
+sha256sum "$BEFORE" | awk '{print "sha256(before)=" $1}'
+
+echo
+echo "=== (2) xio-tester: one sequential write at --base-lba $SLBA (--lbas-per-io $LBAS) ==="
+export LD_LIBRARY_PATH="${LIB}:/opt/rocs-ais/lib:/opt/rocm/lib:${LD_LIBRARY_PATH:-}"
+export HSA_FORCE_FINE_GRAIN_PCIE="${HSA_FORCE_FINE_GRAIN_PCIE:-1}"
+"$XIO_TESTER" "${nvme_ep_common[@]}" \
+  --write-io 1 \
+  --read-io 0
+
+echo
+echo "=== (3) dd read AFTER xio-tester ==="
+dd if="$NVME_NS" of="$AFTER" bs="$BS" skip="$SLBA" count="$COUNT" status=none
+sha256sum "$AFTER" | awk '{print "sha256(after)=" $1}'
+
+echo
+if cmp -s "$BEFORE" "$AFTER"; then
+  echo "RESULT: BEFORE and AFTER are byte-identical (same sha256)."
+  echo "This does NOT prove the NVMe write failed. Common case: the namespace"
+  echo "already held the exact LFSR pattern xio-tester would write for this"
+  echo "SLBA, length, and --lfsr-seed (e.g. default 0 after earlier runs)."
+  echo "To force a visible delta: use a new LFSR_SEED, e.g."
+  echo "  sudo LFSR_SEED=\$RANDOM $0 $SLBA"
+  echo "or set DD_PRP_SCRATCH_RANDOMIZE=1 once on a confirmed scratch device"
+  echo "(see script header), then rerun without it."
+  echo "First 64 bytes (snapshot):"
+  xxd -l 64 "$BEFORE"
+  exit 2
+fi
+
+echo "RESULT: Namespace content changed (cmp differs)."
+echo "First differing byte (cmp -l):"
+cmp -l "$BEFORE" "$AFTER" | head -n 5 || true
+echo
+echo "xxd around byte 4096 (second 4 KiB page of this $BYTES B window):"
+dd if="$BEFORE" bs=1 skip=4032 count=128 status=none 2>/dev/null | xxd
+echo "--- after ---"
+dd if="$AFTER" bs=1 skip=4032 count=128 status=none 2>/dev/null | xxd
+
+echo
+echo "=== (4) LFSR golden (${BYTES} B, --dump-pattern-block-size 512) ==="
+"$XIO_TESTER" \
+  --dump-pattern "$EXPECTED" \
+  --dump-pattern-seed "$LFSR_SEED" \
+  --dump-pattern-size "$BYTES" \
+  --dump-pattern-block-size 512 \
+  --dump-pattern-offset 0
+
+echo
+echo "=== (5) dd AFTER vs LFSR golden (same bytes xio --verify expects) ==="
+if cmp -s "$AFTER" "$EXPECTED"; then
+  echo "DISK vs GOLDEN: MATCH (namespace snapshot matches LFSR for this seed / length)."
+else
+  echo "DISK vs GOLDEN: MISMATCH — first differences (cmp -l):"
+  cmp -l "$AFTER" "$EXPECTED" | head -n 8 || true
+  exit 3
+fi
+
+echo
+echo "=== (6) xio-tester: write-io 1 read-io 1 --verify (same LBAs; host checks read buffer) ==="
+echo "Note: nvme-ep requires --write-io with --verify; this re-writes the same"
+echo "pattern then issues one read and compares the read DMA buffer to the golden."
+set +e
+"$XIO_TESTER" "${nvme_ep_common[@]}" \
+  --write-io 1 \
+  --read-io 1 \
+  --verify
+verify_rc=$?
+set -e
+if [[ "$verify_rc" -eq 0 ]]; then
+  echo "XIO_READ_VERIFY: PASS (read buffer matched LFSR golden; same as disk if step (5) matched)."
+  exit 0
+fi
+echo "XIO_READ_VERIFY: FAIL (exit $verify_rc). If step (5) matched, suspect read DMA / PRP path."
+exit 4

--- a/scripts/test/invoke-rdma-loopback-setup.sh
+++ b/scripts/test/invoke-rdma-loopback-setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# CTest entry for rdma-hw-setup: forwards VENDOR into the sudo environment so
+# setup-rdma-loopback.sh sees the same vendor selection as the parent ctest
+# process (default sudo env_reset drops inherited variables).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec sudo env "VENDOR=${VENDOR:-all}" bash "${SCRIPT_DIR}/setup-rdma-loopback.sh"

--- a/scripts/test/launch-vm
+++ b/scripts/test/launch-vm
@@ -33,13 +33,34 @@
 #   ERNIC_INSTANCES Number of ERNIC instances
 #                   (default: 1)
 #   ERNIC_BACKEND   ERNIC backend (default: loopback)
-#   RUN_VM          Path to qemu-minimal run-vm script
-#   QEMU_PATH       Path prefix for QEMU binary
+#   RUN_VM          Path to qemu-minimal run-vm script (default:
+#                   ../qemu-minimal/qemu/run-vm next to this repo,
+#                   else ${HOME}/Projects/qemu-minimal/qemu/run-vm)
+#   QEMU_PATH       Directory prefix for QEMU, trailing slash
+#                   required (run-vm uses ${QEMU_PATH}qemu-system-*).
+#                   If unset, /opt/qemu-mmio-bridge-submit/bin/ is
+#                   used when present, else the newest
+#                   /opt/qemu-pci*/bin/ with qemu-system-x86_64.
+#   NVME            Emulated NVMe count for run-vm (default: 1; use 2
+#                   for two qcow2-backed devices)
+#   NVME_TRACE      QEMU NVMe trace: none | doorbell | all | event name
+#   NVME_TRACE_FILE Optional; redirect -trace file=... host path
+#   NVME_RECREATE   true deletes/recreates emulated NVMe qcow2 (default:
+#                   false)
+#   DRY_RUN         none (default) runs QEMU; any other value prints
+#                   the argv only (run-vm)
+#   QMP_SOCKET      false | true | unix path for QMP (run-vm)
 #   VCPUS           Number of vCPUs (default: 16)
-#   VMEM            VM memory in MB (default: 32768)
+#   VMEM            Guest RAM in MB (default: 16384). VFIO GPU
+#                   passthrough maps guest RAM for DMA; large
+#                   values need memlock unlimited (limits.d). Use
+#                   VMEM=8192 or VMEM=32768 as needed.
 
 set -e
 
+_LVM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_LVM_DIR}/../.." && pwd)"
+_RUN_VM_SIBLING="${_REPO_ROOT}/../qemu-minimal/qemu/run-vm"
 
 MODE="${1:-${VM_MODE:-rdma}}"
 SSH_PORT="${SSH_PORT:-2222}"
@@ -47,13 +68,19 @@ GPU_BDF="${GPU_BDF:-10:00.0}"
 RDMA_NIC_BDF="${RDMA_NIC_BDF:-c3:00.1}"
 NVME_DEV_BDF="${NVME_DEV_BDF:-85:00.0}"
 VCPUS="${VCPUS:-16}"
-VMEM="${VMEM:-32768}"
+VMEM="${VMEM:-16384}"
 
 ERNIC_BIN="${ERNIC_BIN:-}"
 ERNIC_INSTANCES="${ERNIC_INSTANCES:-1}"
 ERNIC_BACKEND="${ERNIC_BACKEND:-loopback}"
 
-RUN_VM="${RUN_VM:-${HOME}/Projects/qemu-minimal/qemu/run-vm}"
+if [ -z "${RUN_VM:-}" ]; then
+    if [ -x "${_RUN_VM_SIBLING}" ]; then
+        RUN_VM="${_RUN_VM_SIBLING}"
+    else
+        RUN_VM="${HOME}/Projects/qemu-minimal/qemu/run-vm"
+    fi
+fi
 
 RUN_VM_DIR="$(dirname "${RUN_VM}")"
 IMAGES="${RUN_VM_DIR}/../images"
@@ -74,6 +101,9 @@ cleanup() {
 }
 
 check_vfio_binding() {
+    if [ "${DRY_RUN:-none}" != "none" ]; then
+        return 0
+    fi
     local bdf="$1"
     local sysfs="/sys/bus/pci/devices/0000:${bdf}"
 
@@ -103,6 +133,9 @@ check_vfio_binding() {
 }
 
 check_ssh_port() {
+    if [ "${DRY_RUN:-none}" != "none" ]; then
+        return 0
+    fi
     if ss -tln 2>/dev/null \
          | grep -q ":${SSH_PORT} "; then
         echo "ERROR: Port ${SSH_PORT} already in use."
@@ -282,7 +315,15 @@ case "${MODE}" in
         echo "  Sockets:      ${VFIO_USERDEV}"
         ;;
 esac
-echo "  Emulated NVMe: 1x 1TB"
+_NVME_SHOW="${NVME:-1}"
+case "${_NVME_SHOW}" in
+    ''|*[!0-9]*)
+        echo "  Emulated NVMe: custom (NVME=${_NVME_SHOW})"
+        ;;
+    *)
+        echo "  Emulated NVMe: ${_NVME_SHOW}x 1TB"
+        ;;
+esac
 echo ""
 echo "Networking:"
 echo "  SSH: ssh -p ${SSH_PORT} user@localhost"
@@ -330,12 +371,55 @@ esac
 echo "${SEP}"
 echo ""
 
+# run-vm concatenates ${QEMU_PATH}qemu-system-${QARCH}; QEMU_PATH must end
+# with /. Prefer /opt/qemu-mmio-bridge-submit/bin/, then newest
+# /opt/qemu-pci*/bin/, when unset (PCI/MMIO-capable QEMU for nvme/full).
+if [ -n "${QEMU_PATH:-}" ]; then
+    case "${QEMU_PATH}" in
+        */) ;;
+        *)
+            QEMU_PATH="${QEMU_PATH}/"
+            ;;
+    esac
+else
+    _qpicked=""
+    _mmio_bin="/opt/qemu-mmio-bridge-submit/bin"
+    if [ -x "${_mmio_bin}/qemu-system-x86_64" ] \
+        || [ -x "${_mmio_bin}/qemu-system-amd64" ]; then
+        _qpicked="${_mmio_bin}"
+    else
+        shopt -s nullglob
+        _qpci_dirs=(/opt/qemu-pci*/bin)
+        shopt -u nullglob
+        _qpci_valid=""
+        for _d in "${_qpci_dirs[@]}"; do
+            if [ -x "${_d}/qemu-system-x86_64" ] \
+                || [ -x "${_d}/qemu-system-amd64" ]; then
+                _qpci_valid="${_qpci_valid}${_d}"$'\n'
+            fi
+        done
+        if [ -n "${_qpci_valid}" ]; then
+            _qpicked="$(printf '%s' "${_qpci_valid}" | sort -V | tail -n1)"
+        fi
+    fi
+    if [ -n "${_qpicked}" ]; then
+        QEMU_PATH="${_qpicked}/"
+    fi
+fi
+
+export NVME_TRACE="${NVME_TRACE:-none}"
+export NVME_TRACE_FILE="${NVME_TRACE_FILE:-}"
+export NVME_RECREATE="${NVME_RECREATE:-false}"
+export DRY_RUN="${DRY_RUN:-none}"
+export QMP_SOCKET="${QMP_SOCKET:-false}"
+export NVME="${NVME:-1}"
+
 export VM_NAME=rocm-xio-vm
 export VCPUS
 export VMEM
 export FILESYSTEM=/home/stebates/Projects
 export SSH_PORT
 export IMAGES
-export NVME=1
+[ -n "${QEMU_PATH:-}" ] && export QEMU_PATH
 
 exec "${RUN_VM}"

--- a/scripts/test/test-nvme-ep-data-verification.sh
+++ b/scripts/test/test-nvme-ep-data-verification.sh
@@ -230,13 +230,25 @@ test_device() {
 
     local read_file="$TEMP_DIR/${device_name}_read.bin"
     local expected_file="$TEMP_DIR/${device_name}_expected.bin"
+    local nvme_read_log="$TEMP_DIR/${device_name}_nvme_read.log"
 
-    if ! $NVME_CMD read "$ns" \
+    set +e
+    $NVME_CMD read "$ns" \
         --start-block=$BASE_LBA \
         --block-count=$total_blocks \
         --data-size=$total_bytes \
-        --data="$read_file" > /dev/null 2>&1; then
-        echo "✗ Read failed"
+        --data="$read_file" >"$nvme_read_log" 2>&1
+    local nvme_read_rc=$?
+    set -e
+    if [ "$nvme_read_rc" -ne 0 ]; then
+        echo "✗ Read failed (nvme exit $nvme_read_rc)"
+        echo "  Command: $NVME_CMD read $ns" \
+            "--start-block=$BASE_LBA" \
+            "--block-count=$total_blocks" \
+            "--data-size=$total_bytes" \
+            "--data=$read_file"
+        echo "  nvme-cli output ($nvme_read_log):"
+        sed 's/^/    /' "$nvme_read_log" || true
         return 1
     fi
 

--- a/scripts/test/test-rdma-ep-xio-loopback.sh
+++ b/scripts/test/test-rdma-ep-xio-loopback.sh
@@ -40,7 +40,7 @@ if [ -z "${PROVIDER:-}" ] && [ -n "$RDMA_DEV" ]; then
     case "$RDMA_DEV" in
         *bnxt*)  PROVIDER=bnxt  ;;
         *ionic*) PROVIDER=ionic ;;
-        *mlx5*)  PROVIDER=mlx5  ;;
+        *mlx5*|*roce*|*mlx*) PROVIDER=mlx5  ;;
         *ernic*) PROVIDER=ernic ;;
         *)
             echo "ERROR: cannot derive provider" \

--- a/scripts/test/test-xio-tester-rdma-ep.sh
+++ b/scripts/test/test-xio-tester-rdma-ep.sh
@@ -31,7 +31,7 @@ if [ -z "${VENDOR:-}" ]; then
     case "$_dev" in
       *bnxt*)  VENDOR=bnxt  ;;
       *ionic*) VENDOR=ionic ;;
-      *mlx5*)  VENDOR=mlx5  ;;
+      *mlx5*|*roce*|*mlx*) VENDOR=mlx5  ;;
       *ernic*) VENDOR=ernic ;;
       *)
         echo "ERROR: cannot derive vendor" \

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -133,11 +133,54 @@ void printGpuDeviceDetails(int deviceId) {
   }
 }
 
+__host__ hipError_t clearHipLaunchError(const char* endpoint,
+                                        const char* kernel,
+                                        uint32_t queue_id) {
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    ROCXIO_LOG_WARN("%s: cleared stale HIP error before %s "
+                    "launch for queue %u: %s (code: %d)\n",
+                    endpoint ? endpoint : "xio", kernel ? kernel : "kernel",
+                    queue_id, hipGetErrorString(err), err);
+  }
+  return err;
+}
+
+__host__ hipError_t checkHipLaunchError(const char* endpoint,
+                                        const char* kernel,
+                                        uint32_t queue_id, unsigned blocks,
+                                        unsigned threads, size_t shmem_bytes,
+                                        hipStream_t stream) {
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    ROCXIO_LOG_ERROR("%s: %s launch failed for queue %u "
+                     "(blocks=%u, threads=%u, shmem=%zu, stream=%p): "
+                     "%s (code: %d)\n",
+                     endpoint ? endpoint : "xio", kernel ? kernel : "kernel",
+                     queue_id, blocks, threads, shmem_bytes, (void*)stream,
+                     hipGetErrorString(err), err);
+  }
+  return err;
+}
+
+__host__ hipError_t syncHipKernel(const char* endpoint, const char* kernel,
+                                  uint32_t queue_id, hipStream_t stream) {
+  hipError_t err = stream ? hipStreamSynchronize(stream)
+                          : hipDeviceSynchronize();
+  if (err != hipSuccess) {
+    ROCXIO_LOG_ERROR("%s: %s sync failed for queue %u "
+                     "(stream=%p): %s (code: %d)\n",
+                     endpoint ? endpoint : "xio", kernel ? kernel : "kernel",
+                     queue_id, (void*)stream, hipGetErrorString(err), err);
+  }
+  return err;
+}
+
 void printStatistics(const std::vector<double>& durations,
                      unsigned totalIterations, unsigned numThreads,
                      unsigned readIterations, unsigned writeIterations,
                      unsigned verifiedReadsCount, unsigned verifyPass,
-                     unsigned verifyFail) {
+                     unsigned verifyFail, bool firstIoIgnored) {
   if (durations.empty()) {
     return;
   }
@@ -185,7 +228,10 @@ void printStatistics(const std::vector<double>& durations,
     time_unit = " ns";
   }
 
-  std::cout << "\nStatistics:" << std::endl;
+  if (firstIoIgnored)
+    std::cout << "\nStatistics (first I/O ignored):" << std::endl;
+  else
+    std::cout << "\nStatistics:" << std::endl;
 
   // Print iterations - endpoint-specific (at the top)
   if (readIterations > 0 || writeIterations > 0) {
@@ -231,7 +277,8 @@ void printStatistics(const std::vector<double>& durations,
 void printHistogram(const std::vector<double>& durations, unsigned nIterations,
                     unsigned numThreads, unsigned readIterations,
                     unsigned writeIterations, unsigned verifiedReadsCount,
-                    unsigned verifyPass, unsigned verifyFail) {
+                    unsigned verifyPass, unsigned verifyFail,
+                    bool firstIoIgnored) {
   if (durations.empty() || nIterations == 0) {
     return;
   }
@@ -339,7 +386,8 @@ void printHistogram(const std::vector<double>& durations, unsigned nIterations,
 
   // Print statistics after histogram
   printStatistics(durations, nIterations, numThreads, readIterations,
-                  writeIterations, verifiedReadsCount, verifyPass, verifyFail);
+                  writeIterations, verifiedReadsCount, verifyPass, verifyFail,
+                  firstIoIgnored);
 }
 
 static hsa_status_t allocDeviceMemoryHsa(size_t size, void** ptr,
@@ -2401,7 +2449,8 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
   hsa_status_t status;
   hipDeviceptr_t aligned_ptr;
   const size_t host_page_size = sysconf(_SC_PAGESIZE);
-  uint64_t dmabuf_offset = 0;
+  uint64_t hsa_dmabuf_off = 0;
+  uint64_t virt_skew = 0;
   size_t aligned_size;
   int dmabuf_fd = -1;
   int kmod_fd = -1;
@@ -2413,17 +2462,18 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
 
   // Round down to host page size for dmabuf alignment
   aligned_ptr = (hipDeviceptr_t)((uintptr_t)vram_ptr & ~(host_page_size - 1));
-  dmabuf_offset = (uintptr_t)vram_ptr - (uintptr_t)aligned_ptr;
-  aligned_size = (size + dmabuf_offset + host_page_size - 1) &
+  virt_skew =
+    static_cast<uint64_t>((uintptr_t)vram_ptr - (uintptr_t)aligned_ptr);
+  aligned_size = (size + virt_skew + host_page_size - 1) &
                  ~(host_page_size - 1);
 
   ROCXIO_LOG_INFO("  Aligning VRAM buffer: ptr=%p -> aligned=%p, "
                   "size=%zu -> %zu, offset=%llu\n",
                   vram_ptr, (void*)aligned_ptr, size, aligned_size,
-                  (unsigned long long)dmabuf_offset);
+                  (unsigned long long)virt_skew);
 
   status = exportDmabuf((void*)aligned_ptr, aligned_size, &dmabuf_fd,
-                        &dmabuf_offset);
+                        &hsa_dmabuf_off);
   if (status != HSA_STATUS_SUCCESS) {
     ROCXIO_LOG_ERROR("exportDmabuf failed (status=%d)\n", status);
     ROCXIO_LOG_ERROR("  This requires:\n");
@@ -2433,8 +2483,11 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
     return -ENOTSUP;
   }
 
-  ROCXIO_LOG_INFO("  ✅ Exported dmabuf: fd=%d, offset=0x%llx\n", dmabuf_fd,
-                  (unsigned long long)dmabuf_offset);
+  ROCXIO_LOG_INFO("  ✅ Exported dmabuf: fd=%d, hsa_offset=0x%llx "
+                  "virt_skew=0x%llx linear_off=0x%llx\n",
+                  dmabuf_fd, (unsigned long long)hsa_dmabuf_off,
+                  (unsigned long long)virt_skew,
+                  (unsigned long long)(virt_skew + hsa_dmabuf_off));
 
   // Open kernel module device
   kmod_fd = open(kernel_module_device, O_RDWR);
@@ -2450,6 +2503,7 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
   req.dmabuf_fd = dmabuf_fd;
   req.virt_addr = reinterpret_cast<uint64_t>(vram_ptr);
   req.size = size;
+  req.dmabuf_linear_off = virt_skew + hsa_dmabuf_off;
   req.nvme_bdf = nvme_bdf;
   req.flags = is_emulated ? ROCM_XIO_FLAG_EMULATED : ROCM_XIO_FLAG_PASSTHROUGH;
 
@@ -2462,8 +2516,8 @@ __host__ int exportRegVramBuf(void* vram_ptr, size_t size, uint16_t nvme_bdf,
     return -errno;
   }
 
-  // Physical address includes the offset within the dmabuf
-  *phys_addr_out = req.phys_addr + dmabuf_offset;
+  // Physical address includes skew from page alignment and HSA export offset.
+  *phys_addr_out = req.phys_addr + virt_skew + hsa_dmabuf_off;
 
   ROCXIO_LOG_INFO("  ✅ Registered buffer: virt=0x%016llx, phys=0x%016llx, "
                   "size=%zu\n",
@@ -2505,6 +2559,18 @@ __host__ __device__ void genPciMmioBridgeCmd(void* shadowBufferVirt,
 #ifdef __HIP_DEVICE_COMPILE__
   __threadfence_system();
 #endif
+}
+
+__host__ static void unregisterRocmXioVramBuffer(void* gpu_virt) {
+  if (!gpu_virt)
+    return;
+  int fd = open(ROCM_XIO_DEVICE_PATH, O_RDWR);
+  if (fd < 0)
+    return;
+  struct rocm_xio_unregister_buffer_req ur = {};
+  ur.virt_addr = reinterpret_cast<uint64_t>(gpu_virt);
+  (void)ioctl(fd, ROCM_XIO_UNREGISTER_BUFFER, &ur);
+  close(fd);
 }
 
 // Allocate GPU-accessible buffer for DMA operations
@@ -2559,6 +2625,69 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
 
     ROCXIO_LOG_INFO("  Data buffer physical: 0x%016llx (VRAM)\n",
                     (unsigned long long)bufferInfo->dmaAddr);
+
+    {
+      constexpr size_t nvme_page = 4096;
+      uint32_t nvme_np = (uint32_t)((size + nvme_page - 1) / nvme_page);
+      size_t pa_bytes = (size_t)nvme_np * sizeof(uint64_t);
+      uint64_t* pa = nullptr;
+      hipError_t pa_err =
+        hipHostMalloc((void**)&pa, pa_bytes, hipHostMallocMapped);
+      if (pa_err != hipSuccess || !pa) {
+        ROCXIO_LOG_ERROR(
+          "hipHostMalloc for VRAM per-page DMA table failed (%zu bytes): %s\n",
+          pa_bytes, hipGetErrorString(pa_err));
+        unregisterRocmXioVramBuffer(bufferInfo->hostPtr);
+        freeDeviceMemory(bufferInfo->hostPtr, XIO_DEVICE_MEM_HIP);
+        bufferInfo->hostPtr = nullptr;
+        return hipErrorMemoryAllocation;
+      }
+      memset(pa, 0, pa_bytes);
+
+      int fetch_fd = open(ROCM_XIO_DEVICE_PATH, O_RDWR);
+      if (fetch_fd < 0) {
+        ROCXIO_LOG_ERROR("open %s for GET_BUFFER_DMA_PAGES: %s\n",
+                         ROCM_XIO_DEVICE_PATH, strerror(errno));
+        (void)hipHostFree(pa);
+        unregisterRocmXioVramBuffer(bufferInfo->hostPtr);
+        freeDeviceMemory(bufferInfo->hostPtr, XIO_DEVICE_MEM_HIP);
+        bufferInfo->hostPtr = nullptr;
+        return hipErrorInvalidValue;
+      }
+
+      struct rocm_xio_buffer_dma_pages_req dma_req = {};
+      dma_req.virt_addr = reinterpret_cast<uint64_t>(bufferInfo->hostPtr);
+      dma_req.user_addrs_ptr =
+        reinterpret_cast<uint64_t>(static_cast<void*>(pa));
+      dma_req.max_pages = nvme_np;
+      dma_req.num_pages_out = 0;
+
+      int ioctl_ret = ioctl(fetch_fd, ROCM_XIO_GET_BUFFER_DMA_PAGES, &dma_req);
+      int ioctl_errno = errno;
+      close(fetch_fd);
+
+      if (ioctl_ret != 0 || dma_req.num_pages_out != nvme_np) {
+        ROCXIO_LOG_ERROR(
+          "GET_BUFFER_DMA_PAGES failed (ioctl ret=%d errno=%d %s, "
+          "num_pages_out=%u expected %u). Rebuild and install kernel/"
+          "rocm-xio (sudo make -C kernel/rocm-xio install && "
+          "sudo modprobe -r rocm-xio && sudo modprobe rocm-xio).\n",
+          ioctl_ret, ioctl_errno, strerror(ioctl_errno),
+          dma_req.num_pages_out, nvme_np);
+        (void)hipHostFree(pa);
+        unregisterRocmXioVramBuffer(bufferInfo->hostPtr);
+        freeDeviceMemory(bufferInfo->hostPtr, XIO_DEVICE_MEM_HIP);
+        bufferInfo->hostPtr = nullptr;
+        return hipErrorInvalidValue;
+      }
+
+      bufferInfo->pagePhysAddrs = pa;
+      bufferInfo->numPages = nvme_np;
+      ROCXIO_LOG_INFO("  Resolved %u NVMe-page P2P DMA addrs for VRAM "
+                      "buffer\n",
+                      nvme_np);
+    }
+
     ROCXIO_LOG_INFO("  GPU writes directly to VRAM\n");
     ROCXIO_LOG_INFO("  NVMe DMAs from VRAM (P2P)\n");
 
@@ -2586,37 +2715,71 @@ __host__ hipError_t allocateGpuAccessibleBuffer(
       size_t sys_page = (ps > 0) ? (size_t)ps : 4096;
       uint32_t sys_np = (uint32_t)((size + sys_page - 1) / sys_page);
       uint32_t nvme_np = (uint32_t)((size + nvme_page - 1) / nvme_page);
-      size_t pa_bytes = nvme_np * sizeof(uint64_t);
-      uint64_t* pa = nullptr;
-      hipError_t pa_err = hipHostMalloc((void**)&pa, pa_bytes,
-                                        hipHostMallocMapped);
-      if (pa_err == hipSuccess && pa) {
-        memset(pa, 0, pa_bytes);
-        uint64_t sys_addrs[1024];
-        uint32_t max_sys = (sys_np <= 1024) ? sys_np : 1024;
-        int ret = getPagePhysAddrs(bufferInfo->hostPtr, size, sys_addrs,
-                                   max_sys);
-        if (ret < 0) {
-          ROCXIO_LOG_WARN("Failed to resolve per-page "
-                          "phys addrs: %s\n",
-                          strerror(-ret));
-          (void)hipHostFree(pa);
-        } else {
-          uint32_t ratio = (uint32_t)(sys_page / nvme_page);
-          for (uint32_t s = 0; s < sys_np; s++) {
-            for (uint32_t sub = 0; sub < ratio; sub++) {
-              uint32_t idx = s * ratio + sub;
-              if (idx >= nvme_np)
-                break;
-              pa[idx] = sys_addrs[s] + sub * nvme_page;
-            }
-          }
-          bufferInfo->pagePhysAddrs = pa;
-          bufferInfo->numPages = nvme_np;
-          ROCXIO_LOG_INFO("  Resolved %u NVMe-page phys "
-                          "addrs for host buffer\n",
-                          nvme_np);
+
+      if (nvme_np > 1) {
+        if (sys_np > 1024) {
+          ROCXIO_LOG_ERROR(
+            "Host buffer needs per-page phys for %u system pages; "
+            "only 1024 are supported. Reduce buffer size or increase "
+            "page size.\n",
+            sys_np);
+          (void)hipHostFree(bufferInfo->hostPtr);
+          bufferInfo->hostPtr = nullptr;
+          return hipErrorInvalidValue;
         }
+        if (sys_page < nvme_page || (sys_page % nvme_page) != 0) {
+          ROCXIO_LOG_ERROR(
+            "System page size %zu is incompatible with NVMe 4K PRP "
+            "page mapping.\n",
+            sys_page);
+          (void)hipHostFree(bufferInfo->hostPtr);
+          bufferInfo->hostPtr = nullptr;
+          return hipErrorInvalidValue;
+        }
+
+        size_t pa_bytes = (size_t)nvme_np * sizeof(uint64_t);
+        uint64_t* pa = nullptr;
+        hipError_t pa_err = hipHostMalloc((void**)&pa, pa_bytes,
+                                          hipHostMallocMapped);
+        if (pa_err != hipSuccess || !pa) {
+          ROCXIO_LOG_ERROR(
+            "hipHostMalloc for NVMe per-page phys table failed "
+            "(%zu bytes): %s\n",
+            pa_bytes, hipGetErrorString(pa_err));
+          (void)hipHostFree(bufferInfo->hostPtr);
+          bufferInfo->hostPtr = nullptr;
+          return hipErrorMemoryAllocation;
+        }
+        memset(pa, 0, pa_bytes);
+
+        uint64_t sys_addrs[1024];
+        int ret = getPagePhysAddrs(bufferInfo->hostPtr, size, sys_addrs,
+                                   sys_np);
+        if (ret < 0) {
+          ROCXIO_LOG_ERROR(
+            "Failed to resolve per-page phys addrs (required for "
+            "multi-page host buffers): %s\n",
+            strerror(-ret));
+          (void)hipHostFree(pa);
+          (void)hipHostFree(bufferInfo->hostPtr);
+          bufferInfo->hostPtr = nullptr;
+          return hipErrorInvalidValue;
+        }
+
+        uint32_t ratio = (uint32_t)(sys_page / nvme_page);
+        for (uint32_t s = 0; s < sys_np; s++) {
+          for (uint32_t sub = 0; sub < ratio; sub++) {
+            uint32_t idx = s * ratio + sub;
+            if (idx >= nvme_np)
+              break;
+            pa[idx] = sys_addrs[s] + sub * nvme_page;
+          }
+        }
+        bufferInfo->pagePhysAddrs = pa;
+        bufferInfo->numPages = nvme_np;
+        ROCXIO_LOG_INFO("  Resolved %u NVMe-page phys addrs for host "
+                        "buffer\n",
+                        nvme_np);
       }
     }
 
@@ -2664,21 +2827,22 @@ __host__ void freeGpuAccessibleBuffer(struct xioBufferInfo* bufferInfo) {
     return;
   }
 
+  if (bufferInfo->pagePhysAddrs) {
+    (void)hipHostFree(bufferInfo->pagePhysAddrs);
+    bufferInfo->pagePhysAddrs = nullptr;
+  }
+
   if (bufferInfo->isDeviceMemory) {
+    unregisterRocmXioVramBuffer(bufferInfo->hostPtr);
     freeDeviceMemory(bufferInfo->hostPtr, XIO_DEVICE_MEM_HIP);
   } else {
     freeHostMemory(bufferInfo->hostPtr, XIO_HOST_MEM_MAPPED);
-  }
-
-  if (bufferInfo->pagePhysAddrs) {
-    (void)hipHostFree(bufferInfo->pagePhysAddrs);
   }
 
   bufferInfo->hostPtr = nullptr;
   bufferInfo->gpuPtr = nullptr;
   bufferInfo->dmaAddr = 0;
   bufferInfo->isDeviceMemory = false;
-  bufferInfo->pagePhysAddrs = nullptr;
   bufferInfo->numPages = 0;
 }
 

--- a/src/common/xio-data-pattern.hpp
+++ b/src/common/xio-data-pattern.hpp
@@ -31,6 +31,24 @@ struct DataPatternParams {
 };
 
 /**
+ * Expected pattern byte at buffer index @p index for the same rules as
+ * dataPattern() with base @p baseOffset, @p blockSize, and @p seed.
+ */
+__host__ __device__ static inline uint8_t dataPatternExpectedByte(
+    uint64_t baseOffset, uint32_t blockSize, uint32_t seed, size_t index) {
+  const uint64_t block = baseOffset / blockSize;
+  const uint32_t base_seed = (uint32_t)(block * 0x12345678);
+  const uint32_t mixed = base_seed ^ seed;
+  uint32_t rng = (uint32_t)(block * 0x9e3779b9 + mixed + index);
+  rng ^= rng >> 16;
+  rng *= 0x85ebca6b;
+  rng ^= rng >> 13;
+  rng *= 0xc2b2ae35;
+  rng ^= rng >> 16;
+  return (uint8_t)(rng & 0xFF);
+}
+
+/**
  * Generate or verify LFSR-based test data pattern.
  *
  * Generates or verifies a deterministic pseudo-random data pattern using
@@ -45,18 +63,9 @@ struct DataPatternParams {
  */
 __host__ __device__ static inline bool dataPattern(bool isVerify,
                                                    DataPatternParams& params) {
-  uint64_t block = params.offset / params.blockSize;
-  uint32_t base_seed = (uint32_t)(block * 0x12345678);
-  uint32_t seed = base_seed ^ params.seed;
-
   for (size_t i = 0; i < params.size; i++) {
-    uint32_t rng = (uint32_t)(block * 0x9e3779b9 + seed + i);
-    rng ^= rng >> 16;
-    rng *= 0x85ebca6b;
-    rng ^= rng >> 13;
-    rng *= 0xc2b2ae35;
-    rng ^= rng >> 16;
-    uint8_t expected = (uint8_t)(rng & 0xFF);
+    const uint8_t expected = dataPatternExpectedByte(
+        params.offset, params.blockSize, params.seed, i);
 
     if (isVerify) {
       if (params.buffer[i] != expected) {

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -242,6 +242,22 @@ __host__ int queryLbaSize(const char* nvme_device, uint32_t nsid,
                           unsigned* lba_size);
 
 /**
+ * Query controller MDTS maximum single-command transfer size (bytes).
+ *
+ * Reads Identify Controller (CNS=1) and derives the NVMe maximum data
+ * transfer size from the MDTS field: (2^MDTS) * 4096 when MDTS is non-zero.
+ * Uses the conventional minimum memory page size (4 KiB). When MDTS is 0,
+ * the controller reports no limit and @p max_xfer_bytes is set to 0.
+ *
+ * @param nvme_device Controller or namespace path (resolved like queryLbaSize).
+ * @param nsid Namespace id for path resolution (controller identify is global).
+ * @param max_xfer_bytes Out: 0 if unlimited or on failure to query.
+ * @return 0 on success, negative errno-style code on failure.
+ */
+__host__ int queryMdtsMaxXferBytes(const char* nvme_device, uint32_t nsid,
+                                   uint64_t* max_xfer_bytes);
+
+/**
  * Query namespace capacity in LBAs from NVMe controller
  *
  * This function queries the NVMe controller to determine the namespace
@@ -817,6 +833,21 @@ struct nvmeEpConfig {
   } ioParams;                  /**< I/O operation parameters. */
 
   bool verify = false; /**< Verify LFSR data pattern after read-back. */
+  /**
+   * When true with --verify, force a verification failure after successful
+   * I/O so automated tests can assert a non-zero process exit. For testing
+   * only; requires --verify, --write-io, and --read-io.
+   */
+  bool injectVerifyFail = false;
+
+  /**
+   * Identify Controller MDTS-derived maximum NVM read/write data size
+   * (bytes) for one command. Filled by validateConfig when Identify succeeds;
+   * when mdtsIdentified is true and mdtsMaxXferBytes is 0, the controller
+   * reports no MDTS limit (MDTS field 0).
+   */
+  bool mdtsIdentified = false;
+  uint64_t mdtsMaxXferBytes = 0;
 
   /** @brief Host-side data buffer options mirrored into nvmeBufferParams. */
   struct {

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -188,7 +188,8 @@ __host__ __device__ void ringDoorbell(uint16_t value,
  *                 is mixed into the hash so that different
  *                 seed values produce different LBA
  *                 sequences across runs.
- * @return Calculated LBA address
+ * @return Calculated LBA address (sequential mode keeps each transfer inside
+ *         lbaRangeLbas when that bound is set).
  */
 static __host__ __device__ uint64_t getRandomLba(unsigned op_index,
                                                  uint16_t cmd_id,
@@ -208,12 +209,26 @@ static __host__ __device__ uint64_t getRandomLba(unsigned op_index,
                          : 1;
     return ioParams.baseLba + (seed % max_lba);
   } else {
-    // Sequential access mode
+    // Sequential access mode: each I/O covers `blocks` consecutive LBAs.
+    // The starting LBA offset must satisfy start + blocks - 1 < base + range,
+    // i.e. offset <= lbaRangeLbas - blocks (when lbaRangeLbas >= blocks).
+    // Using % lbaRangeLbas on (op_index * blocks) alone can pick a start whose
+    // tail extends past the end of the namespace (e.g. range 100 LBAs,
+    // blocks 64, offset 64 -> LBAs 64..127), which breaks verify and data
+    // integrity. Mirror the random path by wrapping in the number of valid
+    // starting offsets (lbaRangeLbas - blocks + 1).
+    const uint64_t span = static_cast<uint64_t>(blocks);
     if (ioParams.lbaRangeLbas > 0) {
-      return ioParams.baseLba + ((op_index * blocks) % ioParams.lbaRangeLbas);
-    } else {
-      return ioParams.baseLba + (op_index * blocks);
+      const uint64_t R = ioParams.lbaRangeLbas;
+      if (R < span) {
+        return ioParams.baseLba;
+      }
+      const uint64_t nStarts = R - span + 1;
+      const uint64_t stride = static_cast<uint64_t>(op_index) * span;
+      const uint64_t off = stride % nStarts;
+      return ioParams.baseLba + off;
     }
+    return ioParams.baseLba + (static_cast<uint64_t>(op_index) * span);
   }
 }
 
@@ -271,6 +286,7 @@ __device__ static void driveEndpointSingle(
   constexpr unsigned kMaxTimedBatch = 256;
   unsigned long long int batchStartTimes[kMaxTimedBatch];
   const bool useBatchTiming = (config.timingStats != nullptr);
+  bool skippedFirstTiming = false;
   if (useBatchTiming && batch_size > kMaxTimedBatch) {
     batch_size = kMaxTimedBatch;
   }
@@ -434,6 +450,14 @@ __device__ static void driveEndpointSingle(
 
       if (!ioParams.infiniteMode && config.startTimes != nullptr) {
         config.startTimes[op_idx] = wall_clock64();
+        if (config.verboseLbas != nullptr) {
+          config.verboseLbas[op_idx] = lba;
+          config.verboseXferBytes[op_idx] =
+            (uint32_t)((transfer_size > 0xFFFFFFFFULL)
+                         ? 0xFFFFFFFFU
+                         : (uint32_t)transfer_size);
+          config.verboseRwFlags[op_idx] = is_read_op ? 1U : 0U;
+        }
       } else if (useBatchTiming && b < kMaxTimedBatch) {
         batchStartTimes[b] = wall_clock64();
       }
@@ -510,7 +534,11 @@ __device__ static void driveEndpointSingle(
       } else if (useBatchTiming && b < kMaxTimedBatch) {
         unsigned long long int endTime = wall_clock64();
         if (endTime > batchStartTimes[b]) {
-          updateTimingStats(config.timingStats, endTime - batchStartTimes[b]);
+          if (config.skipFirstIoTiming && !skippedFirstTiming) {
+            skippedFirstTiming = true;
+          } else {
+            updateTimingStats(config.timingStats, endTime - batchStartTimes[b]);
+          }
         }
       }
 
@@ -593,6 +621,7 @@ __device__ static void driveEndpointWavefront(
   __shared__ unsigned sh_batch_count;
   __shared__ bool sh_stop;
   __shared__ bool sh_error;
+  __shared__ bool sh_skipped_first_timing;
   extern __shared__ unsigned long long int sh_startTimes[];
 
   if (tid == 0) {
@@ -602,6 +631,7 @@ __device__ static void driveEndpointWavefront(
     sh_ops_done = 0;
     sh_stop = false;
     sh_error = false;
+    sh_skipped_first_timing = false;
 
     if (has_write_buffer) {
       xio::DataPatternParams pp{
@@ -784,7 +814,11 @@ __device__ static void driveEndpointWavefront(
         } else if (useBatchTiming) {
           unsigned long long int endTime = wall_clock64();
           if (endTime > sh_startTimes[b]) {
-            updateTimingStats(config.timingStats, endTime - sh_startTimes[b]);
+            if (config.skipFirstIoTiming && !sh_skipped_first_timing) {
+              sh_skipped_first_timing = true;
+            } else {
+              updateTimingStats(config.timingStats, endTime - sh_startTimes[b]);
+            }
           }
         }
 
@@ -900,18 +934,28 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
     config->controller = nvme_path.controllerPath;
   }
 
+  // Query the controller queue count before accepting an explicit queue ID.
+  // Linux exposes queue_count as admin queue + I/O queues, so the last valid
+  // I/O queue ID is queue_count - 1.
+  uint16_t max_queue_id = 0;
+  int queue_ret = queryMaxQueueId(config->controller.c_str(), &max_queue_id);
+  if (queue_ret != 0) {
+    return "Failed to detect maximum queue ID. "
+           "Please specify --queue-id manually.";
+  }
+
   // Auto-detect maximum queue ID if queueId is 0 (default)
   if (config->queueId == 0) {
-    uint16_t max_queue_id = 0;
-    int ret = queryMaxQueueId(config->controller.c_str(), &max_queue_id);
-    if (ret != 0) {
-      return "Failed to detect maximum queue ID. "
-             "Please specify --queue-id manually.";
-    }
     config->queueId = max_queue_id;
     ROCXIO_LOG_INFO("Auto-detected last available queue "
                     "ID: %u\n",
                     config->queueId);
+  } else if (config->queueId > max_queue_id) {
+    char buf[256];
+    snprintf(buf, sizeof(buf),
+             "--queue-id %u exceeds last available I/O queue ID %u",
+             config->queueId, max_queue_id);
+    return std::string(buf);
   }
 
   // Multi-queue validation: ensure enough I/O queues
@@ -989,6 +1033,8 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
              "batching intermixes write and read ops, "
              "preventing correct read-back verification)";
   }
+  if (config->injectVerifyFail && !config->verify)
+    return "--inject-verify-fail requires --verify";
 
   // Detect LBA size from controller/namespace
   unsigned detected_lba_size = 0;
@@ -999,6 +1045,42 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
            std::string(strerror(-ret));
   }
   config->ioParams.lbaSize = detected_lba_size;
+
+  // Single-command transfer must fit controller MDTS (Identify Controller).
+  // Common failure: 4 KiB LBAs x 64 blocks = 256 KiB exceeds MDTS on drives
+  // that report 128 KiB max even though random LBA selection is valid.
+  {
+    config->mdtsIdentified = false;
+    config->mdtsMaxXferBytes = 0;
+    const uint64_t xfer_req = (uint64_t)config->ioParams.lbasPerIo *
+                              (uint64_t)config->ioParams.lbaSize;
+    uint64_t mdts_max = 0;
+    const int mdret = queryMdtsMaxXferBytes(config->controller.c_str(),
+                                            config->ioParams.nsid, &mdts_max);
+    if (mdret != 0) {
+      ROCXIO_LOG_WARN("Could not query MDTS (%s); skipping MDTS vs "
+                      "transfer-size check.\n",
+                      strerror(-mdret));
+    } else {
+      config->mdtsIdentified = true;
+      config->mdtsMaxXferBytes = mdts_max;
+      if (mdts_max > 0 && xfer_req > mdts_max) {
+        const uint64_t lba_b = (uint64_t)config->ioParams.lbaSize;
+        const uint64_t max_lbas = lba_b ? (mdts_max / lba_b) : 0;
+        char buf[512];
+        snprintf(
+          buf, sizeof(buf),
+          "Single-command transfer is %llu bytes (%u LBAs x %u bytes/LBA) "
+          "but Identify Controller MDTS limits each NVM read/write to "
+          "%llu bytes (at most %llu LBAs at this LBA size). "
+          "Set --lbas-per-io to at most %llu.",
+          (unsigned long long)xfer_req, (unsigned)config->ioParams.lbasPerIo,
+          (unsigned)config->ioParams.lbaSize, (unsigned long long)mdts_max,
+          (unsigned long long)max_lbas, (unsigned long long)max_lbas);
+        return std::string(buf);
+      }
+    }
+  }
 
   // Detect PCI MMIO bridge BDF if --pci-mmio-bridge is set
   if (config->doorbellParams.usePciMmioBridge) {
@@ -1062,6 +1144,80 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
   }
 
   return std::string();
+}
+
+/**
+ * When ROCXIO_NVME_DUMP_VERIFY_MISMATCH is set, log actual vs expected bytes
+ * around the first verify failure (half-window from
+ * ROCXIO_NVME_DUMP_VERIFY_MISMATCH_HALF, default 32).
+ */
+static __host__ void dumpNvmeVerifyMismatchIfRequested(
+  unsigned queue_idx, size_t err_off, size_t verify_bytes,
+  const uint8_t* host_read_buf, uint64_t pattern_base_offset,
+  uint32_t block_size, uint32_t seed) {
+  const char* flag = getenv("ROCXIO_NVME_DUMP_VERIFY_MISMATCH");
+  if (!flag || !flag[0] || !host_read_buf || verify_bytes == 0)
+    return;
+  if (block_size == 0) {
+    ROCXIO_LOG_WARN("ROCXIO_NVME_DUMP_VERIFY_MISMATCH: block_size 0; "
+                    "skip dump\n");
+    return;
+  }
+  if (err_off >= verify_bytes) {
+    ROCXIO_LOG_WARN("ROCXIO_NVME_DUMP_VERIFY_MISMATCH: err_off %zu "
+                    "out of range (verify_bytes %zu)\n",
+                    err_off, verify_bytes);
+    return;
+  }
+
+  int half = xio::getEnvInt("ROCXIO_NVME_DUMP_VERIFY_MISMATCH_HALF", 32);
+  if (half < 1)
+    half = 1;
+  if (half > 2048)
+    half = 2048;
+
+  const size_t start = err_off > (size_t)half ? err_off - (size_t)half
+                                              : (size_t)0;
+  size_t end = err_off + (size_t)half + 1;
+  if (end > verify_bytes)
+    end = verify_bytes;
+
+  const uint8_t exp_at = xio::dataPatternExpectedByte(pattern_base_offset,
+                                                      block_size, seed,
+                                                      err_off);
+  ROCXIO_LOG_WARN("ROCXIO_NVME_DUMP_VERIFY_MISMATCH queue=%u err_off=%zu "
+                  "verify_bytes=%zu pattern_base_offset=%llu: "
+                  "actual=0x%02x expected=0x%02x\n",
+                  queue_idx, err_off, verify_bytes,
+                  (unsigned long long)pattern_base_offset,
+                  (unsigned)host_read_buf[err_off], (unsigned)exp_at);
+
+  ROCXIO_LOG_WARN("ROCXIO_NVME_DUMP_VERIFY_MISMATCH hex [%zu,%zu) "
+                  "(ROCXIO_NVME_DUMP_VERIFY_MISMATCH_HALF=%d)\n",
+                  start, end, half);
+
+  for (size_t row = start; row < end; row += 16) {
+    char line[400];
+    size_t n = 0;
+    n += snprintf(line + n, sizeof(line) - n, "  %06zu act ", row);
+    for (size_t c = row; c < row + 16 && c < end; c++)
+      n += snprintf(line + n, sizeof(line) - n, "%02x ",
+                    (unsigned)host_read_buf[c]);
+    n += snprintf(line + n, sizeof(line) - n, "| exp ");
+    for (size_t c = row; c < row + 16 && c < end; c++) {
+      const uint8_t e = xio::dataPatternExpectedByte(pattern_base_offset,
+                                                     block_size, seed, c);
+      n += snprintf(line + n, sizeof(line) - n, "%02x ", (unsigned)e);
+    }
+    n += snprintf(line + n, sizeof(line) - n, "| xor ");
+    for (size_t c = row; c < row + 16 && c < end; c++) {
+      const uint8_t e = xio::dataPatternExpectedByte(pattern_base_offset,
+                                                     block_size, seed, c);
+      n += snprintf(line + n, sizeof(line) - n, "%02x ",
+                    (unsigned)(host_read_buf[c] ^ e));
+    }
+    ROCXIO_LOG_WARN("%s\n", line);
+  }
 }
 
 /**
@@ -1644,9 +1800,14 @@ __host__ hipError_t run(XioEndpointConfig* config) {
       }
 
       void* gpu_pool = nullptr;
-      (void)hipHostGetDevicePointer(&gpu_pool, pool, 0);
-      if (!gpu_pool) {
-        gpu_pool = pool;
+      hipError_t gpu_ptr_err = hipHostGetDevicePointer(&gpu_pool, pool, 0);
+      if (gpu_ptr_err != hipSuccess || !gpu_pool) {
+        ROCXIO_LOG_ERROR("Failed to get PRP list pool GPU pointer "
+                         "for queue %u: %s\n",
+                         qid, hipGetErrorString(gpu_ptr_err));
+        (void)hipHostFree(pool);
+        result = gpu_ptr_err != hipSuccess ? gpu_ptr_err : hipErrorInvalidValue;
+        goto cleanup;
       }
 
       uint64_t* page_dmas = nullptr;
@@ -1837,20 +1998,35 @@ __host__ hipError_t run(XioEndpointConfig* config) {
                     "(stream %p)\n",
                     qid, (void*)streams[q]);
 
+    (void)xio::clearHipLaunchError("nvme-ep", "gpuKernel", qid);
+
     hipLaunchKernelGGL(nvme_ep::gpuKernel, dim3(1), dim3(kernelThreads),
                        dynShmemBytes, streams[q], kernelConfig, ioParams,
                        qDoorbellParams, qBufParams);
+
+    hipError_t launchErr = xio::checkHipLaunchError("nvme-ep", "gpuKernel", qid,
+                                                    1, kernelThreads,
+                                                    dynShmemBytes, streams[q]);
+    if (launchErr != hipSuccess) {
+      result = launchErr;
+      goto cleanup;
+    }
   }
 
   ROCXIO_LOG_INFO("%u kernel%s launched.\n", numQueues,
                   numQueues > 1 ? "s" : "");
 
-  // Wait for all GPU kernels to complete
-  result = hipDeviceSynchronize();
-  if (result != hipSuccess) {
-    ROCXIO_LOG_INFO("Device synchronization error: "
-                    "%s (code: %d).\n",
-                    hipGetErrorString(result), result);
+  // Wait for all GPU kernels to complete.  Stream-specific sync gives a
+  // precise queue id in multi-queue mode while preserving default-stream
+  // behavior for the single-queue path.
+  for (uint16_t q = 0; q < numQueues; q++) {
+    uint16_t qid = q < nvmeConfig->queueIds.size()
+                     ? nvmeConfig->queueIds[q]
+                     : (uint16_t)(baseQueueId + q);
+    result = xio::syncHipKernel("nvme-ep", "gpuKernel", qid, streams[q]);
+    if (result != hipSuccess) {
+      goto cleanup;
+    }
   }
 
   // ---- Verify read buffers ----
@@ -1884,17 +2060,52 @@ __host__ hipError_t run(XioEndpointConfig* config) {
         rbuf = host_rb;
       }
       if (rbuf) {
+        size_t err_off = 0;
         xio::DataPatternParams vp{
-          rbuf, verifyBytes, 0, ioParams.lbaSize, ioParams.lfsrSeed, nullptr};
+          rbuf, verifyBytes, 0, ioParams.lbaSize, ioParams.lfsrSeed, &err_off};
         if (xio::dataPattern(true, vp))
           config->verifyPass += static_cast<uint32_t>(
             nvmeConfig->ioParams.readIo);
-        else
+        else {
+          char mdts_ctx[192];
+          if (!nvmeConfig->mdtsIdentified) {
+            snprintf(mdts_ctx, sizeof(mdts_ctx),
+                     "Identify MDTS: not available (Identify Controller failed "
+                     "or was skipped)");
+          } else if (nvmeConfig->mdtsMaxXferBytes == 0) {
+            snprintf(mdts_ctx, sizeof(mdts_ctx),
+                     "Identify MDTS: no limit reported (MDTS field 0)");
+          } else {
+            snprintf(mdts_ctx, sizeof(mdts_ctx),
+                     "Identify MDTS max %llu bytes per NVM read/write command",
+                     (unsigned long long)nvmeConfig->mdtsMaxXferBytes);
+          }
+          ROCXIO_LOG_WARN(
+            "NVMe --verify: pattern mismatch at byte %zu of %zu "
+            "(queue %u). %s. If the command is within MDTS, this is often a "
+            "PRP / host DMA address translation issue for transfers spanning "
+            "multiple 4 KiB pages.\n",
+            err_off, verifyBytes, q, mdts_ctx);
+          dumpNvmeVerifyMismatchIfRequested(q, err_off, verifyBytes, rbuf, 0,
+                                            ioParams.lbaSize,
+                                            ioParams.lfsrSeed);
           config->verifyFail += static_cast<uint32_t>(
             nvmeConfig->ioParams.readIo);
+        }
       }
       free(host_rb);
     }
+    if (result == hipSuccess && config->verifyFail > 0)
+      result = hipErrorIllegalState;
+  }
+
+  if (result == hipSuccess && nvmeConfig->injectVerifyFail &&
+      nvmeConfig->verify && nvmeConfig->ioParams.readIo > 0 &&
+      nvmeConfig->ioParams.writeIo > 0) {
+    ROCXIO_LOG_WARN(
+      "NVMe: --inject-verify-fail forced non-zero exit (testing only)\n");
+    config->verifyFail += static_cast<uint32_t>(nvmeConfig->ioParams.readIo);
+    result = hipErrorIllegalState;
   }
 
   // ---- Aggregate per-queue timing stats ----
@@ -2111,6 +2322,85 @@ cleanup:
   if (id_ns) {
     xio::freeHostMemory(id_ns, XIO_HOST_MEM_PLAIN);
   }
+  return ret;
+}
+
+/** Byte offset of @c mdts in Identify Controller data (struct nvme_id_ctrl). */
+static constexpr size_t kNvmeIdCtrlMdtsOffset = 77;
+
+__host__ int queryMdtsMaxXferBytes(const char* nvme_device, uint32_t nsid,
+                                   uint64_t* max_xfer_bytes) {
+  int nvme_fd = -1;
+  int ret = 0;
+  struct nvme_passthru_cmd cmd;
+  uint8_t* id_buf = nullptr;
+  uint8_t mdts = 0;
+
+  if (!nvme_device || !max_xfer_bytes) {
+    return -EINVAL;
+  }
+  *max_xfer_bytes = 0;
+
+  NvmeDevicePath nvme_path;
+  ret = xio::resolveNvmeDevicePath(nvme_device, nsid, &nvme_path);
+  if (ret != 0)
+    return ret;
+
+  hipError_t herr = xio::allocHostMemory(nvme_ep::nvmeAdminRespSize,
+                                         (void**)&id_buf,
+                                         "Identify Controller (MDTS)",
+                                         XIO_HOST_MEM_PLAIN);
+  if (herr != hipSuccess || !id_buf)
+    return -ENOMEM;
+
+  nvme_fd = openDeviceWithRetry(nvme_path.controllerPath.c_str(), O_RDONLY,
+                                "NVMe device", 5, 100);
+  if (nvme_fd < 0) {
+    ret = -errno;
+    goto cleanup;
+  }
+
+  memset(&cmd, 0, sizeof(cmd));
+  cmd.opcode = nvme_admin_identify;
+  cmd.nsid = 0;
+  cmd.cdw10 = 1; // CNS = Identify Controller
+  cmd.addr = reinterpret_cast<uint64_t>(id_buf);
+  cmd.data_len = nvme_ep::nvmeAdminRespSize;
+
+  ret = ioctlEintrSafe(nvme_fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+  if (ret < 0) {
+    ret = -errno;
+    goto cleanup;
+  }
+
+  if (cmd.result & 0xFFFE) {
+    ret = -EIO;
+    goto cleanup;
+  }
+
+  if (kNvmeIdCtrlMdtsOffset >= nvme_ep::nvmeAdminRespSize) {
+    ret = -EINVAL;
+    goto cleanup;
+  }
+
+  mdts = id_buf[kNvmeIdCtrlMdtsOffset];
+  // NVMe: max transfer = (2^MDTS) * minimum memory page size; assume 4 KiB.
+  // MDTS=0 means no limit reported by the controller.
+  if (mdts == 0) {
+    *max_xfer_bytes = 0;
+  } else if (mdts >= sizeof(uint64_t) * 8) {
+    ret = -EINVAL;
+    goto cleanup;
+  } else {
+    *max_xfer_bytes = (1ULL << mdts) * 4096ULL;
+  }
+  ret = 0;
+
+cleanup:
+  if (nvme_fd >= 0)
+    close(nvme_fd);
+  if (id_buf)
+    xio::freeHostMemory(id_buf, XIO_HOST_MEM_PLAIN);
   return ret;
 }
 
@@ -2993,11 +3283,11 @@ extern "C" __host__ int nvme_ep_cleanup_queues(void* endpointConfig) {
       cleanupQinfo(&nvmeConfig->queueInfo);
     }
   }
-#endif // __HIP_DEVICE_COMPILE__
+#endif // !__HIP_DEVICE_COMPILE__
 
   return ret;
 }
 
 } // namespace xio::nvme_ep
 
-#endif // __HIP_DEVICE_COMPILE__
+#endif // !__HIP_DEVICE_COMPILE__

--- a/src/endpoints/rdma-ep/rdma-ep.hip
+++ b/src/endpoints/rdma-ep/rdma-ep.hip
@@ -542,11 +542,17 @@ static hipError_t rdma_ep_loopback(xio::XioEndpointConfig* config,
     if (!kStats && !forceLessTiming)
       kStats = config->timingStats;
 
+    const char* kernelName = useBatch ? "rdma_ep_batch_kernel"
+                                      : "rdma_ep_kernel";
+    const unsigned launchThreads = useBatch ? batchSize + 1 : 1;
+    const size_t launchShmem = useBatch
+                                 ? batchSize * sizeof(unsigned long long int)
+                                 : 0;
+    (void)xio::clearHipLaunchError("rdma-ep", kernelName, q);
     if (useBatch) {
-      size_t shmem = batchSize * sizeof(unsigned long long int);
-      unsigned threads = batchSize + 1;
-      hipLaunchKernelGGL(rdma_ep::rdma_ep_batch_kernel, dim3(1), dim3(threads),
-                         shmem, queues[q].stream, queues[q].gpu_qp,
+      hipLaunchKernelGGL(rdma_ep::rdma_ep_batch_kernel, dim3(1),
+                         dim3(launchThreads), launchShmem, queues[q].stream,
+                         queues[q].gpu_qp,
                          static_cast<uint8_t*>(queues[q].buf),
                          cfg->transferSize, batchSize, config->iterations,
                          kStats, config->stopRequested, cfg->verify, cfg->seed,
@@ -562,21 +568,21 @@ static hipError_t rdma_ep_loopback(xio::XioEndpointConfig* config,
                          config->substepStats);
     }
 
-    hipError_t le = hipGetLastError();
+    hipError_t le = xio::checkHipLaunchError("rdma-ep", kernelName, q, 1,
+                                             launchThreads, launchShmem,
+                                             queues[q].stream);
     if (le != hipSuccess) {
-      ROCXIO_LOG_ERROR("rdma-ep: Kernel launch failed"
-                       " (queue %u): %s\n",
-                       q, hipGetErrorString(le));
       result = le;
       goto cleanup;
     }
   }
 
-  {
-    hipError_t syncErr = hipDeviceSynchronize();
+  for (uint16_t q = 0; q < numQueues; q++) {
+    const char* kernelName = useBatch ? "rdma_ep_batch_kernel"
+                                      : "rdma_ep_kernel";
+    hipError_t syncErr = xio::syncHipKernel("rdma-ep", kernelName, q,
+                                            queues[q].stream);
     if (syncErr != hipSuccess) {
-      ROCXIO_LOG_ERROR("rdma-ep: Kernel sync failed: %s\n",
-                       hipGetErrorString(syncErr));
       result = syncErr;
       goto cleanup;
     }
@@ -835,9 +841,13 @@ hipError_t run(XioEndpointConfig* config) {
       ROCXIO_LOG_INFO("rdma-ep: WRITE %u bytes"
                       " to server...\n",
                       write_size);
+      (void)xio::clearHipLaunchError("rdma-ep", "rdma_write_kernel", 0);
       hipLaunchKernelGGL(rdma_write_kernel, dim3(1), dim3(1), 0, 0, gpu_qp,
                          remote_data, data_region, write_size);
-      herr = hipDeviceSynchronize();
+      herr = xio::checkHipLaunchError("rdma-ep", "rdma_write_kernel", 0, 1, 1,
+                                      0, nullptr);
+      if (herr == hipSuccess)
+        herr = xio::syncHipKernel("rdma-ep", "rdma_write_kernel", 0, nullptr);
       if (herr != hipSuccess) {
         ROCXIO_LOG_ERROR("rdma-ep: WRITE kernel failed:"
                          " %s\n",
@@ -950,11 +960,17 @@ hipError_t run(XioEndpointConfig* config) {
     }
 
     if (cfg->isClient) {
+      (void)xio::clearHipLaunchError("rdma-ep", "pingpong_client_kernel", 0);
       hipLaunchKernelGGL(pingpong_client_kernel, dim3(1), dim3(1), 0, 0, gpu_qp,
                          reinterpret_cast<PingPongBuf*>(pp_send_buf),
                          reinterpret_cast<volatile PingPongBuf*>(pp_recv_buf),
                          remote_recv, pp_size, pp_iters, d_errors, d_elapsed);
-      herr = hipDeviceSynchronize();
+      herr = xio::checkHipLaunchError("rdma-ep", "pingpong_client_kernel", 0,
+                                      1, 1, 0, nullptr);
+      if (herr == hipSuccess) {
+        herr = xio::syncHipKernel("rdma-ep", "pingpong_client_kernel", 0,
+                                  nullptr);
+      }
       if (herr != hipSuccess) {
         ROCXIO_LOG_ERROR("rdma-ep: Pingpong client kernel"
                          " failed: %s\n",
@@ -999,11 +1015,17 @@ hipError_t run(XioEndpointConfig* config) {
                       " all %u iterations correct.\n",
                       pp_iters);
     } else {
+      (void)xio::clearHipLaunchError("rdma-ep", "pingpong_server_kernel", 0);
       hipLaunchKernelGGL(pingpong_server_kernel, dim3(1), dim3(1), 0, 0, gpu_qp,
                          reinterpret_cast<PingPongBuf*>(pp_send_buf),
                          reinterpret_cast<volatile PingPongBuf*>(pp_recv_buf),
                          remote_recv, pp_size, pp_iters, d_errors);
-      herr = hipDeviceSynchronize();
+      herr = xio::checkHipLaunchError("rdma-ep", "pingpong_server_kernel", 0,
+                                      1, 1, 0, nullptr);
+      if (herr == hipSuccess) {
+        herr = xio::syncHipKernel("rdma-ep", "pingpong_server_kernel", 0,
+                                  nullptr);
+      }
       if (herr != hipSuccess) {
         ROCXIO_LOG_ERROR("rdma-ep: Pingpong server kernel"
                          " failed: %s\n",

--- a/src/endpoints/sdma-ep/sdma-ep.hip
+++ b/src/endpoints/sdma-ep/sdma-ep.hip
@@ -926,10 +926,17 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_p2p_kernel", 0);
     hipLaunchKernelGGL(sdma_p2p_kernel, dim3(numBlocks), dim3(threadsPerBlock),
                        0, 0, sdmaHandles[0], dstBuf, srcBuf, transferSize,
                        config->iterations, signals[0][0], config->startTimes,
                        config->endTimes, config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_p2p_kernel", 0,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
   } else if (testType == "buffer-reuse") {
     // For buffer-reuse kernel, launch on both GPUs with different ranks
     // signals[0] and signals[1] are device arrays containing signal pointers
@@ -941,12 +948,19 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 0);
     hipLaunchKernelGGL(sdma_buffer_reuse_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[0], dstBuf,
                        srcBuf, nElem, config->iterations, signals[0],
                        /*rank*/ 0, counter0, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 0,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
 
     // Launch rank 1 (responder) on destination GPU with dstGpu->srcGpu handle
     // Swap buffer arguments: rank 1's src should point to where rank 0 wrote
@@ -956,12 +970,19 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 1);
     hipLaunchKernelGGL(sdma_buffer_reuse_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[1], srcBuf,
                        dstBuf, nElem, config->iterations, signals[1],
                        /*rank*/ 1, counter1, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 1,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
   } else if (testType == "ping-pong") {
     // For ping-pong kernel, launch on both GPUs with different ranks
     // signals[0] and signals[1] are device arrays containing signal pointers
@@ -973,12 +994,19 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 0);
     hipLaunchKernelGGL(sdma_ping_pong_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[0], dstBuf,
                        srcBuf, nElem, config->iterations, signals[0],
                        /*rank*/ 0, counter0, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 0,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
 
     // Launch rank 1 (responder) on destination GPU with dstGpu->srcGpu handle
     // Swap buffer arguments: rank 1's src should point to where rank 0 wrote
@@ -988,24 +1016,23 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 1);
     hipLaunchKernelGGL(sdma_ping_pong_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[1], srcBuf,
                        dstBuf, nElem, config->iterations, signals[1],
                        /*rank*/ 1, counter1, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 1,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
   } else {
     std::cerr << "Unknown test type: " << testType << std::endl;
     cleanupAll();
     return hipErrorInvalidValue;
-  }
-
-  err = hipGetLastError();
-  if (err != hipSuccess) {
-    std::cerr << "Kernel launch failed: " << hipGetErrorString(err)
-              << std::endl;
-    cleanupAll();
-    return err;
   }
 
   // Wait for kernel to complete
@@ -1016,7 +1043,7 @@ hipError_t run(XioEndpointConfig* config) {
     cleanupAll();
     return err;
   }
-  err = hipDeviceSynchronize();
+  err = xio::syncHipKernel("sdma-ep", testType.c_str(), 0, nullptr);
   if (err != hipSuccess) {
     std::cerr << "Device sync on srcGpu failed: " << hipGetErrorString(err)
               << std::endl;
@@ -1033,7 +1060,7 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
-    err = hipDeviceSynchronize();
+    err = xio::syncHipKernel("sdma-ep", testType.c_str(), 1, nullptr);
     if (err != hipSuccess) {
       std::cerr << "Device sync on dstGpu failed: " << hipGetErrorString(err)
                 << std::endl;

--- a/src/endpoints/test-ep/test-ep.hip
+++ b/src/endpoints/test-ep/test-ep.hip
@@ -935,6 +935,7 @@ hipError_t run(XioEndpointConfig* config) {
         *d_vFail = 0;
     }
 
+    (void)xio::clearHipLaunchError("test-ep", "endpoint_kernel", 0);
     hipLaunchKernelGGL(endpoint_kernel, dim3(1), dim3(config->numThreads), 0, 0,
                        sqePtr, cqePtr, config->startTimes, config->endTimes,
                        config->timingStats, config->iterations,
@@ -943,7 +944,8 @@ hipError_t run(XioEndpointConfig* config) {
                        testEpConfig->verify, testEpConfig->seed, d_vPass,
                        d_vFail);
 
-    err = hipGetLastError();
+    err = xio::checkHipLaunchError("test-ep", "endpoint_kernel", 0, 1,
+                                   config->numThreads, 0, nullptr);
     if (err != hipSuccess) {
       for (auto& thread : cpuThreadHandles)
         thread.join();
@@ -954,7 +956,7 @@ hipError_t run(XioEndpointConfig* config) {
       return err;
     }
 
-    err = hipDeviceSynchronize();
+    err = xio::syncHipKernel("test-ep", "endpoint_kernel", 0, nullptr);
     if (err != hipSuccess) {
       for (auto& thread : cpuThreadHandles)
         thread.join();

--- a/src/include/rocm-xio-uapi.h
+++ b/src/include/rocm-xio-uapi.h
@@ -60,6 +60,9 @@ extern "C" {
 /** @brief Free contiguous queue memory allocated by the kernel helper. */
 #define ROCM_XIO_FREE_CONTIG_QUEUE                                             \
   _IOW(ROCM_XIO_IOC_MAGIC, 12, struct rocm_xio_free_contig_req)
+/** @brief Per-NVMe-page DMA addresses for a registered VRAM buffer (SG). */
+#define ROCM_XIO_GET_BUFFER_DMA_PAGES                                          \
+  _IOWR(ROCM_XIO_IOC_MAGIC, 13, struct rocm_xio_buffer_dma_pages_req)
 
 /** @brief Return the emulated BAR guest-physical address. */
 #define ROCM_XIO_FLAG_EMULATED (1 << 0)
@@ -124,17 +127,31 @@ struct rocm_xio_unregister_queue_addr_req {
 
 /** @brief Register data buffer for PRP injection (REGISTER_BUFFER). */
 struct rocm_xio_register_buffer_req {
-  int dmabuf_fd;   /**< DMA-BUF fd for VRAM, or -1 for host memory. */
+  int dmabuf_fd; /**< DMA-BUF fd for VRAM, or -1 for host memory. */
   __u64 virt_addr; /**< Userspace virtual buffer base address. */
   __u64 phys_addr; /**< Physical address, IOVA, or emulated GPA. */
-  __u64 size;      /**< Buffer size in bytes. */
-  __u16 nvme_bdf;  /**< Target NVMe device in 0xBBDD form. */
-  __u32 flags;     /**< ROCM_XIO_FLAG_* address selection flags. */
+  __u64 size; /**< Buffer size in bytes. */
+  /**
+   * Byte offset from the start of the DMA-BUF object to virt_addr (export
+   * often rounds the GPU pointer down to a page boundary). Use 0 when the
+   * buffer base matches the DMA-BUF base.
+   */
+  __u64 dmabuf_linear_off;
+  __u16 nvme_bdf; /**< Target NVMe device in 0xBBDD form. */
+  __u32 flags; /**< ROCM_XIO_FLAG_* address selection flags. */
 };
 
 /** @brief Unregister a data buffer by userspace virtual address. */
 struct rocm_xio_unregister_buffer_req {
   __u64 virt_addr; /**< Userspace virtual buffer base address. */
+};
+
+/** @brief Per-page DMA/IOVA list for a REGISTER_BUFFER VRAM mapping (ioctl 13). */
+struct rocm_xio_buffer_dma_pages_req {
+  __u64 virt_addr; /**< GPU virtual base passed to REGISTER_BUFFER. */
+  __u64 user_addrs_ptr; /**< Userspace output array of \a max_pages \c __u64. */
+  __u32 max_pages; /**< Capacity of \a user_addrs_ptr (must cover buffer). */
+  __u32 num_pages_out; /**< Kernel: NVMe 4K pages copied (equals expected). */
 };
 
 /** @brief MMIO bridge shadow buffer mapping (GET_MMIO_BRIDGE_SHADOW_BUFFER). */

--- a/src/include/xio-endpoint-core.h
+++ b/src/include/xio-endpoint-core.h
@@ -85,9 +85,16 @@ struct XioEndpointConfig {
   unsigned memoryMode = 0;    /**< XIO_MEM_MODE_* queue and data flags. */
   bool verbose = false;       /**< Enable endpoint-specific verbose logs. */
   bool pciMmioBridge = false; /**< Route MMIO doorbells through bridge. */
+  bool skipFirstIoTiming = true; /**< Omit first I/O latency from stats. */
 
   unsigned long long int* startTimes = nullptr; /**< Per-op start times. */
   unsigned long long int* endTimes = nullptr;   /**< Per-op end times. */
+  /** Optional NVMe per-op trace (length iterations * numThreads). */
+  uint64_t* verboseLbas = nullptr;
+  /** Bytes transferred per op (same length as verboseLbas). */
+  uint32_t* verboseXferBytes = nullptr;
+  /** 0 = write, 1 = read (same length as verboseLbas). */
+  uint8_t* verboseRwFlags = nullptr;
   XioTimingStats* timingStats = nullptr;        /**< Aggregate timing. */
   XioSubstepStats* substepStats = nullptr;      /**< Hot-path breakdown. */
 

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -7,6 +7,7 @@
 #define XIO_H
 
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <memory>
@@ -129,6 +130,62 @@ std::string getModelName(int deviceId);
 void printGpuDeviceDetails(int deviceId);
 
 /**
+ * @brief Clear and report any pending HIP launch error before a kernel launch.
+ *
+ * HIP records some launch/setup failures asynchronously in per-thread runtime
+ * state. Calling this immediately before a launch prevents stale failures from
+ * being attributed to the next kernel. A non-success return is diagnostic only;
+ * callers normally continue to launch after this helper returns.
+ *
+ * @param endpoint Endpoint name used in the diagnostic message.
+ * @param kernel Kernel name used in the diagnostic message.
+ * @param queue_id Logical queue identifier for the launch.
+ * @return The stale HIP status that was cleared, or hipSuccess.
+ */
+__host__ hipError_t clearHipLaunchError(const char* endpoint,
+                                        const char* kernel,
+                                        uint32_t queue_id);
+
+/**
+ * @brief Check and report the HIP status for the most recent kernel launch.
+ *
+ * Call this immediately after hipLaunchKernelGGL() and before synchronization.
+ * The helper reports the endpoint, kernel, logical queue id, launch dimensions,
+ * dynamic shared memory, and stream so launch-configuration failures are
+ * reported near their source instead of surfacing later at synchronization.
+ *
+ * @param endpoint Endpoint name used in the diagnostic message.
+ * @param kernel Kernel name used in the diagnostic message.
+ * @param queue_id Logical queue identifier for the launch.
+ * @param blocks Number of blocks requested by the launch.
+ * @param threads Number of threads per block requested by the launch.
+ * @param shmem_bytes Dynamic shared memory bytes requested by the launch.
+ * @param stream HIP stream used for the launch, or nullptr for default stream.
+ * @return hipSuccess when the launch was accepted, otherwise the HIP error.
+ */
+__host__ hipError_t checkHipLaunchError(const char* endpoint,
+                                        const char* kernel,
+                                        uint32_t queue_id, unsigned blocks,
+                                        unsigned threads, size_t shmem_bytes,
+                                        hipStream_t stream);
+
+/**
+ * @brief Synchronize a launched kernel and report queue-specific HIP failures.
+ *
+ * For non-null streams this helper synchronizes the provided stream. For the
+ * default stream it falls back to hipDeviceSynchronize(), preserving existing
+ * single-stream endpoint behavior while still giving consistent diagnostics.
+ *
+ * @param endpoint Endpoint name used in the diagnostic message.
+ * @param kernel Kernel name used in the diagnostic message.
+ * @param queue_id Logical queue identifier for the launched kernel.
+ * @param stream HIP stream to synchronize, or nullptr for default stream.
+ * @return hipSuccess when synchronization succeeds, otherwise the HIP error.
+ */
+__host__ hipError_t syncHipKernel(const char* endpoint, const char* kernel,
+                                  uint32_t queue_id, hipStream_t stream);
+
+/**
  * @brief Print timing statistics from duration data.
  * @param durations Vector of durations in nanoseconds.
  * @param totalIterations Total iteration count (0 to omit).
@@ -138,12 +195,13 @@ void printGpuDeviceDetails(int deviceId);
  * @param verifiedReadsCount Verified reads (0 to omit).
  * @param verifyPass Verified iterations passed (0 to omit).
  * @param verifyFail Verified iterations failed (0 to omit).
+ * @param firstIoIgnored true when the first I/O was omitted from stats.
  */
 void printStatistics(const std::vector<double>& durations,
                      unsigned totalIterations = 0, unsigned numThreads = 0,
                      unsigned readIterations = 0, unsigned writeIterations = 0,
                      unsigned verifiedReadsCount = 0, unsigned verifyPass = 0,
-                     unsigned verifyFail = 0);
+                     unsigned verifyFail = 0, bool firstIoIgnored = false);
 
 /**
  * @brief Print a histogram and statistics from durations.
@@ -155,12 +213,13 @@ void printStatistics(const std::vector<double>& durations,
  * @param verifiedReadsCount Verified reads (0 to omit).
  * @param verifyPass Verified iterations passed (0 to omit).
  * @param verifyFail Verified iterations failed (0 to omit).
+ * @param firstIoIgnored true when the first I/O was omitted from stats.
  */
 void printHistogram(const std::vector<double>& durations, unsigned nIterations,
                     unsigned numThreads = 0, unsigned readIterations = 0,
                     unsigned writeIterations = 0,
                     unsigned verifiedReadsCount = 0, unsigned verifyPass = 0,
-                    unsigned verifyFail = 0);
+                    unsigned verifyFail = 0, bool firstIoIgnored = false);
 
 /**
  * @brief Allocate queue memory (device or host).

--- a/src/tester/xio-cli-options.cpp
+++ b/src/tester/xio-cli-options.cpp
@@ -187,6 +187,12 @@ void registerNvmeEpCliOptions(CLI::App& app, xio::nvme_ep::nvmeEpConfig* cfg) {
               "read-back (requires --write-io and "
               "--read-io)")
     ->group(nvme_group);
+  app
+    .add_flag("--inject-verify-fail", cfg->injectVerifyFail,
+              "Testing only: after successful --verify, force failure "
+              "so xio-tester exits non-zero. Requires --verify, "
+              "--write-io, and --read-io.")
+    ->group(nvme_group);
 }
 
 void registerRdmaEpCliOptions(CLI::App& app, rdma_ep::RdmaEpConfig* cfg) {

--- a/src/tester/xio-tester.cpp
+++ b/src/tester/xio-tester.cpp
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <climits>
 #include <cmath>
+#include <cstdint>
 #include <csignal>
 #include <cstring>
 #include <ctime>
@@ -15,6 +16,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -105,6 +107,12 @@ int main(int argc, char** argv) {
     .add_flag("--less-timing", lessTiming,
               "Use lightweight timing mode (track min/max/mean only, "
               "useful for large iterations)")
+    ->group("Common Options");
+  app
+    .add_flag("--skip-first-io-timing,!--no-skip-first-io-timing",
+              commonConfig.skipFirstIoTiming,
+              "Exclude the first I/O latency from reported timing stats "
+              "(default: on)")
     ->group("Common Options");
 
   bool substepTiming = false;
@@ -400,6 +408,9 @@ int main(int argc, char** argv) {
   void* hostCqeAddr = nullptr;
   unsigned long long int* hostStartTime = nullptr;
   unsigned long long int* hostEndTime = nullptr;
+  uint64_t* hostVerboseLbas = nullptr;
+  uint32_t* hostVerboseXferBytes = nullptr;
+  uint8_t* hostVerboseRwFlags = nullptr;
 
   size_t totalSqeSize = sqeSize * sqeLength;
   size_t totalCqeSize = cqeSize * cqeLength;
@@ -448,7 +459,61 @@ int main(int argc, char** argv) {
                                          XIO_HOST_MEM_MAPPED);
     if (hipErr2 != hipSuccess) {
       std::cerr << "Error: Failed to allocate end time buffer" << std::endl;
+      freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
+      hostStartTime = nullptr;
       return EXIT_FAILURE;
+    }
+    if (baseConfig.verbose && endpoint->getType() == EndpointType::NVME_EP) {
+      const size_t ntrace = static_cast<size_t>(baseConfig.iterations) *
+                            static_cast<size_t>(baseConfig.numThreads);
+      const size_t lbBytes = ntrace * sizeof(uint64_t);
+      const size_t xfBytes = ntrace * sizeof(uint32_t);
+      const size_t flBytes = ntrace * sizeof(uint8_t);
+      hipError_t hv1 = allocHostMemory(lbBytes, (void**)&hostVerboseLbas,
+                                       "NVMe verbose LBA buffer",
+                                       XIO_HOST_MEM_MAPPED);
+      if (hv1 != hipSuccess) {
+        std::cerr << "Error: Failed to allocate NVMe verbose LBA buffer"
+                  << std::endl;
+        freeHostMemory(hostEndTime, XIO_HOST_MEM_MAPPED);
+        freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
+        hostEndTime = nullptr;
+        hostStartTime = nullptr;
+        return EXIT_FAILURE;
+      }
+      hipError_t hv2 = allocHostMemory(xfBytes, (void**)&hostVerboseXferBytes,
+                                         "NVMe verbose xfer buffer",
+                                         XIO_HOST_MEM_MAPPED);
+      if (hv2 != hipSuccess) {
+        std::cerr << "Error: Failed to allocate NVMe verbose xfer buffer"
+                  << std::endl;
+        freeHostMemory(hostVerboseLbas, XIO_HOST_MEM_MAPPED);
+        freeHostMemory(hostEndTime, XIO_HOST_MEM_MAPPED);
+        freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
+        hostVerboseLbas = nullptr;
+        hostEndTime = nullptr;
+        hostStartTime = nullptr;
+        return EXIT_FAILURE;
+      }
+      hipError_t hv3 = allocHostMemory(flBytes, (void**)&hostVerboseRwFlags,
+                                         "NVMe verbose RW buffer",
+                                         XIO_HOST_MEM_MAPPED);
+      if (hv3 != hipSuccess) {
+        std::cerr << "Error: Failed to allocate NVMe verbose RW buffer"
+                  << std::endl;
+        freeHostMemory(hostVerboseXferBytes, XIO_HOST_MEM_MAPPED);
+        freeHostMemory(hostVerboseLbas, XIO_HOST_MEM_MAPPED);
+        freeHostMemory(hostEndTime, XIO_HOST_MEM_MAPPED);
+        freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
+        hostVerboseXferBytes = nullptr;
+        hostVerboseLbas = nullptr;
+        hostEndTime = nullptr;
+        hostStartTime = nullptr;
+        return EXIT_FAILURE;
+      }
+      memset(hostVerboseLbas, 0, lbBytes);
+      memset(hostVerboseXferBytes, 0, xfBytes);
+      memset(hostVerboseRwFlags, 0, flBytes);
     }
   } else if (lessTiming) {
     hipError_t hipErr = allocHostMemory(sizeof(XioTimingStats),
@@ -472,6 +537,20 @@ int main(int argc, char** argv) {
     if (hipErr != hipSuccess) {
       std::cerr << "Error: Failed to allocate " << "substep stats buffer"
                 << std::endl;
+      if (hostVerboseRwFlags != nullptr)
+        freeHostMemory(hostVerboseRwFlags, XIO_HOST_MEM_MAPPED);
+      if (hostVerboseXferBytes != nullptr)
+        freeHostMemory(hostVerboseXferBytes, XIO_HOST_MEM_MAPPED);
+      if (hostVerboseLbas != nullptr)
+        freeHostMemory(hostVerboseLbas, XIO_HOST_MEM_MAPPED);
+      if (!lessTiming && hostStartTime != nullptr)
+        freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
+      if (!lessTiming && hostEndTime != nullptr)
+        freeHostMemory(hostEndTime, XIO_HOST_MEM_MAPPED);
+      if (lessTiming && timingStats != nullptr)
+        freeHostMemory(timingStats, XIO_HOST_MEM_MAPPED);
+      freeQueue(hostSqeAddr, sqIsDevice, "submission queue");
+      freeQueue(hostCqeAddr, cqIsDevice, "completion queue");
       return EXIT_FAILURE;
     }
     memset(substepStats, 0, sizeof(XioSubstepStats));
@@ -483,6 +562,12 @@ int main(int argc, char** argv) {
                                            "stop flag", XIO_HOST_MEM_MAPPED);
   if (stopFlagErr != hipSuccess) {
     std::cerr << "Error: Failed to allocate stop flag" << std::endl;
+    if (hostVerboseRwFlags != nullptr)
+      freeHostMemory(hostVerboseRwFlags, XIO_HOST_MEM_MAPPED);
+    if (hostVerboseXferBytes != nullptr)
+      freeHostMemory(hostVerboseXferBytes, XIO_HOST_MEM_MAPPED);
+    if (hostVerboseLbas != nullptr)
+      freeHostMemory(hostVerboseLbas, XIO_HOST_MEM_MAPPED);
     if (!lessTiming && hostStartTime != nullptr)
       freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
     if (!lessTiming && hostEndTime != nullptr)
@@ -500,6 +585,9 @@ int main(int argc, char** argv) {
   // Assign buffers to our config structure
   baseConfig.startTimes = hostStartTime;
   baseConfig.endTimes = hostEndTime;
+  baseConfig.verboseLbas = hostVerboseLbas;
+  baseConfig.verboseXferBytes = hostVerboseXferBytes;
+  baseConfig.verboseRwFlags = hostVerboseRwFlags;
   baseConfig.timingStats = timingStats;
   baseConfig.substepStats = substepStats;
   baseConfig.submissionQueue = hostSqeAddr;
@@ -522,24 +610,15 @@ int main(int argc, char** argv) {
 
   // Run endpoint test
   hipError_t err = endpoint->run(&baseConfig);
-  if (err != hipSuccess) {
+  const bool run_ok = (err == hipSuccess);
+  if (!run_ok) {
     std::cerr << "Endpoint run failed: " << hipGetErrorString(err)
-              << " (error code: " << err << ")" << std::endl;
-    freeQueue(hostSqeAddr, sqIsDevice, "submission queue");
-    freeQueue(hostCqeAddr, cqIsDevice, "completion queue");
-    if (!lessTiming && hostStartTime != nullptr)
-      freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
-    if (!lessTiming && hostEndTime != nullptr)
-      freeHostMemory(hostEndTime, XIO_HOST_MEM_MAPPED);
-    if (lessTiming && timingStats != nullptr)
-      freeHostMemory(timingStats, XIO_HOST_MEM_MAPPED);
-    if (substepStats != nullptr)
-      freeHostMemory(substepStats, XIO_HOST_MEM_MAPPED);
-    if (stopRequestedFlag != nullptr)
-      freeHostMemory(const_cast<bool*>(stopRequestedFlag), XIO_HOST_MEM_MAPPED);
-    g_configForSignalHandler = nullptr;
-    g_endpointNameForSignalHandler = nullptr;
-    return EXIT_FAILURE;
+              << " (error code: " << static_cast<int>(err) << ")"
+              << std::endl;
+    if (selectedEndpoint == "nvme-ep" && err == hipErrorIllegalState) {
+      std::cerr << "  NVMe: hipErrorIllegalState is used for LFSR --verify "
+                   "data mismatches and for --inject-verify-fail.\n";
+    }
   }
 
   // Check if test was interrupted by SIGINT
@@ -550,46 +629,141 @@ int main(int argc, char** argv) {
   }
 
   // Print raw timing data if verbose and full timing is enabled
-  if (baseConfig.verbose && !lessTiming) {
+  if (baseConfig.verbose && !lessTiming && hostStartTime != nullptr &&
+      hostEndTime != nullptr) {
+    const bool nvmeOpTrace =
+      (hostVerboseLbas != nullptr && hostVerboseXferBytes != nullptr &&
+       hostVerboseRwFlags != nullptr);
+    // Column widths for NVMe raw table (headers match data cells).
+    constexpr int kNvIx = 5;
+    constexpr int kNvOp = 5;
+    constexpr int kNvLba = 18;
+    constexpr int kNvBytes = 10;
+    constexpr int kNvClk = 18;
+    constexpr int durationWidth = 24;
+    const char oldFill = std::cout.fill();
+    auto printDurationColumn = [&](double durationNs, bool ignored) {
+      std::ostringstream durationText;
+      durationText << std::fixed << std::setprecision(3) << durationNs
+                   << " ns";
+      if (ignored) {
+        durationText << " (ignored)";
+      }
+      std::cout << std::setfill(' ') << std::left
+                << std::setw(durationWidth) << durationText.str()
+                << std::right << std::setfill(oldFill) << " |" << std::endl;
+    };
+    auto printInvalidDuration = [&]() {
+      std::cout << std::setfill(' ') << std::left
+                << std::setw(durationWidth) << "INVALID" << std::right
+                << std::setfill(oldFill) << " |" << std::endl;
+    };
+
     if (baseConfig.numThreads == 1) {
       std::cout << "\nRaw timing data:" << std::endl;
-      std::cout << "Index | Start Time      | End Time        | Duration"
-                << std::endl;
-      std::cout << "------|-----------------|-----------------|----------"
-                << std::endl;
+      if (nvmeOpTrace) {
+        std::cout << std::left << std::setfill(' ') << std::setw(kNvIx) << "Index"
+                  << " | " << std::setw(kNvOp) << "Op" << " | " << std::setw(kNvLba)
+                  << "LBA" << " | " << std::setw(kNvBytes) << "Bytes (B)"
+                  << " | " << std::setw(kNvClk) << "Start (clk)" << " | "
+                  << std::setw(kNvClk) << "End (clk)" << " | "
+                  << std::setw(durationWidth) << "Duration" << std::right
+                  << std::setfill(oldFill) << " |" << std::endl;
+        std::cout << std::string(static_cast<size_t>(kNvIx), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvOp), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvLba), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvBytes), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvClk), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvClk), '-') << "-|-"
+                  << std::string(static_cast<size_t>(durationWidth + 2), '-')
+                  << "|" << std::endl;
+      } else {
+        std::cout << "Index | Start Time      | End Time        | "
+                  << std::setfill(' ') << std::left
+                  << std::setw(durationWidth) << "Duration" << std::right
+                  << std::setfill(oldFill) << " |" << std::endl;
+        std::cout << "------|-----------------|-----------------|"
+                  << std::string(durationWidth + 2, '-') << "|" << std::endl;
+      }
       for (unsigned i = 0; i < baseConfig.iterations; ++i) {
-        std::cout << std::setw(5) << i << " | " << std::setw(15)
-                  << hostStartTime[i] << " | " << std::setw(15)
-                  << hostEndTime[i] << " | ";
+        std::cout << std::setfill(' ') << std::setw(kNvIx) << i << " | ";
+        if (nvmeOpTrace) {
+          const char* opLabel =
+            hostVerboseRwFlags[i] != 0 ? "read" : "write";
+          std::cout << std::setfill(' ') << std::left << std::setw(kNvOp)
+                    << opLabel << std::right << " | "
+                    << std::setw(kNvLba) << hostVerboseLbas[i] << " | "
+                    << std::setw(kNvBytes) << hostVerboseXferBytes[i] << " | "
+                    << std::setw(kNvClk) << hostStartTime[i] << " | "
+                    << std::setw(kNvClk) << hostEndTime[i] << " | ";
+        } else {
+          std::cout << std::setw(15) << hostStartTime[i] << " | " << std::setw(15)
+                    << hostEndTime[i] << " | ";
+        }
         if (hostEndTime[i] > hostStartTime[i]) {
           double durationNs = (hostEndTime[i] - hostStartTime[i]) *
                               gpuClockPeriodNs;
-          std::cout << std::fixed << std::setprecision(3) << durationNs << " ns"
-                    << std::endl;
+          printDurationColumn(durationNs, baseConfig.skipFirstIoTiming &&
+                                            i == 0);
         } else {
-          std::cout << "INVALID" << std::endl;
+          printInvalidDuration();
         }
       }
       std::cout << std::endl;
     } else {
+      constexpr int kNvTh = 6;
       std::cout << "\nRaw timing data (multi-threaded):" << std::endl;
-      std::cout << "Thread | Index | Start Time      | End Time        | "
-                << "Duration" << std::endl;
-      std::cout << "-------|-------|-----------------|-----------------|"
-                << "----------" << std::endl;
+      if (nvmeOpTrace) {
+        std::cout << std::left << std::setfill(' ') << std::setw(kNvTh) << "Thread"
+                  << " | " << std::setw(kNvIx) << "Index" << " | "
+                  << std::setw(kNvOp) << "Op" << " | " << std::setw(kNvLba) << "LBA"
+                  << " | " << std::setw(kNvBytes) << "Bytes (B)" << " | "
+                  << std::setw(kNvClk) << "Start (clk)" << " | "
+                  << std::setw(kNvClk) << "End (clk)" << " | "
+                  << std::setw(durationWidth) << "Duration" << std::right
+                  << std::setfill(oldFill) << " |" << std::endl;
+        std::cout << std::string(static_cast<size_t>(kNvTh), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvIx), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvOp), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvLba), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvBytes), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvClk), '-') << "-|-"
+                  << std::string(static_cast<size_t>(kNvClk), '-') << "-|-"
+                  << std::string(static_cast<size_t>(durationWidth + 2), '-')
+                  << "|" << std::endl;
+      } else {
+        std::cout << "Thread | Index | Start Time      | End Time        | "
+                  << std::setfill(' ') << std::left
+                  << std::setw(durationWidth) << "Duration" << std::right
+                  << std::setfill(oldFill) << " |" << std::endl;
+        std::cout << "-------|-------|-----------------|-----------------|"
+                  << std::string(durationWidth + 2, '-') << "|" << std::endl;
+      }
       for (unsigned t = 0; t < baseConfig.numThreads; ++t) {
         for (unsigned i = 0; i < baseConfig.iterations; ++i) {
           unsigned idx = t * baseConfig.iterations + i;
-          std::cout << std::setw(6) << t << " | " << std::setw(5) << i << " | "
-                    << std::setw(15) << hostStartTime[idx] << " | "
-                    << std::setw(15) << hostEndTime[idx] << " | ";
+          std::cout << std::setfill(' ') << std::setw(kNvTh) << t << " | "
+                    << std::setw(kNvIx) << i << " | ";
+          if (nvmeOpTrace) {
+            const char* opLabel =
+              hostVerboseRwFlags[idx] != 0 ? "read" : "write";
+            std::cout << std::setfill(' ') << std::left << std::setw(kNvOp)
+                      << opLabel << std::right << " | "
+                      << std::setw(kNvLba) << hostVerboseLbas[idx]
+                      << " | " << std::setw(kNvBytes) << hostVerboseXferBytes[idx]
+                      << " | " << std::setw(kNvClk) << hostStartTime[idx] << " | "
+                      << std::setw(kNvClk) << hostEndTime[idx] << " | ";
+          } else {
+            std::cout << std::setw(15) << hostStartTime[idx] << " | "
+                      << std::setw(15) << hostEndTime[idx] << " | ";
+          }
           if (hostEndTime[idx] > hostStartTime[idx]) {
             double durationNs = (hostEndTime[idx] - hostStartTime[idx]) *
                                 gpuClockPeriodNs;
-            std::cout << std::fixed << std::setprecision(3) << durationNs
-                      << " ns" << std::endl;
+            printDurationColumn(durationNs, baseConfig.skipFirstIoTiming &&
+                                              i == 0);
           } else {
-            std::cout << "INVALID" << std::endl;
+            printInvalidDuration();
           }
         }
       }
@@ -636,11 +810,12 @@ int main(int argc, char** argv) {
       unsigned actualIterations = static_cast<unsigned>(timingStats->count);
       if (showHistogram) {
         printHistogram(durations, actualIterations, baseConfig.numThreads, 0, 0,
-                       UINT_MAX, baseConfig.verifyPass, baseConfig.verifyFail);
+                       UINT_MAX, baseConfig.verifyPass, baseConfig.verifyFail,
+                       baseConfig.skipFirstIoTiming);
       } else {
         printStatistics(durations, actualIterations, baseConfig.numThreads, 0,
                         0, UINT_MAX, baseConfig.verifyPass,
-                        baseConfig.verifyFail);
+                        baseConfig.verifyFail, baseConfig.skipFirstIoTiming);
       }
     } else {
       std::cout << "Warning: No timing data collected in less-timing mode"
@@ -653,49 +828,59 @@ int main(int argc, char** argv) {
       }
     }
   } else if (!lessTiming) {
-    // Full timing mode: calculate durations from individual timestamps
-    // (skip first iteration per thread, as it tends to be larger)
-    std::vector<double> durations;
-    unsigned actualIterations = 0;
-    for (unsigned t = 0; t < baseConfig.numThreads; ++t) {
-      unsigned baseIdx = t * baseConfig.iterations;
-      for (unsigned i = 0; i < baseConfig.iterations; ++i) {
-        unsigned idx = baseIdx + i;
-        if (hostEndTime[idx] > hostStartTime[idx]) {
-          actualIterations++; // Count all completed iterations
-          if (i > 0) {
-            // Skip first iteration per thread for statistics
-            double durationNs = (hostEndTime[idx] - hostStartTime[idx]) *
-                                gpuClockPeriodNs;
-            durations.push_back(durationNs);
+    if (hostStartTime != nullptr && hostEndTime != nullptr) {
+      // Full timing mode: calculate durations from individual timestamps
+      // (skip first iteration per thread, as it tends to be larger)
+      std::vector<double> durations;
+      unsigned actualIterations = 0;
+      for (unsigned t = 0; t < baseConfig.numThreads; ++t) {
+        unsigned baseIdx = t * baseConfig.iterations;
+        for (unsigned i = 0; i < baseConfig.iterations; ++i) {
+          unsigned idx = baseIdx + i;
+          if (hostEndTime[idx] > hostStartTime[idx]) {
+            actualIterations++; // Count all completed iterations
+            if (!baseConfig.skipFirstIoTiming || i > 0) {
+              // Optionally skip first iteration per thread for statistics.
+              double durationNs = (hostEndTime[idx] - hostStartTime[idx]) *
+                                  gpuClockPeriodNs;
+              durations.push_back(durationNs);
+            }
           }
         }
       }
-    }
 
-    // Print statistics (showHistogram flag is already set from common options)
-    // Use actual count of completed iterations instead of configured iterations
-    // Note: readIterations/writeIterations not available without
-    // endpoint-specific headers, so pass 0 to show "Iterations" instead of
-    // "Reads/Writes" Note: verifiedReadsCount not tracked in normal mode, use
-    // UINT_MAX
-    if (durations.size() > 0) {
-      if (showHistogram) {
-        printHistogram(durations, actualIterations, baseConfig.numThreads, 0, 0,
-                       UINT_MAX, baseConfig.verifyPass, baseConfig.verifyFail);
+      // Print statistics (showHistogram flag is already set from common options)
+      // Use actual count of completed iterations instead of configured iterations
+      // Note: readIterations/writeIterations not available without
+      // endpoint-specific headers, so pass 0 to show "Iterations" instead of
+      // "Reads/Writes" Note: verifiedReadsCount not tracked in normal mode, use
+      // UINT_MAX
+      if (durations.size() > 0) {
+        if (showHistogram) {
+          printHistogram(durations, actualIterations, baseConfig.numThreads, 0, 0,
+                         UINT_MAX, baseConfig.verifyPass, baseConfig.verifyFail,
+                         baseConfig.skipFirstIoTiming);
+        } else {
+          printStatistics(durations, actualIterations, baseConfig.numThreads, 0,
+                          0, UINT_MAX, baseConfig.verifyPass,
+                          baseConfig.verifyFail, baseConfig.skipFirstIoTiming);
+        }
       } else {
-        printStatistics(durations, actualIterations, baseConfig.numThreads, 0,
-                        0, UINT_MAX, baseConfig.verifyPass,
-                        baseConfig.verifyFail);
+        std::cout << "Warning: No valid timing data collected" << std::endl;
+        if (baseConfig.verifyPass > 0 || baseConfig.verifyFail > 0) {
+          std::cout << "  Verify Passed:    " << std::setw(10)
+                    << baseConfig.verifyPass << std::endl;
+          std::cout << "  Verify Failed:    " << std::setw(10)
+                    << baseConfig.verifyFail << std::endl;
+        }
       }
-    } else {
-      std::cout << "Warning: No valid timing data collected" << std::endl;
-      if (baseConfig.verifyPass > 0 || baseConfig.verifyFail > 0) {
-        std::cout << "  Verify Passed:    " << std::setw(10)
-                  << baseConfig.verifyPass << std::endl;
-        std::cout << "  Verify Failed:    " << std::setw(10)
-                  << baseConfig.verifyFail << std::endl;
-      }
+    } else if (baseConfig.verifyPass > 0 || baseConfig.verifyFail > 0) {
+      std::cout << "Warning: No per-op timing buffers; verify summary only"
+                << std::endl;
+      std::cout << "  Verify Passed:    " << std::setw(10)
+                << baseConfig.verifyPass << std::endl;
+      std::cout << "  Verify Failed:    " << std::setw(10)
+                << baseConfig.verifyFail << std::endl;
     }
   }
 
@@ -733,7 +918,11 @@ int main(int argc, char** argv) {
 
   // Print completion message
   if (!wasInterrupted) {
-    std::cout << "\nTest completed successfully!" << std::endl;
+    if (run_ok) {
+      std::cout << "\nTest completed successfully!" << std::endl;
+    } else {
+      std::cout << "\nTest completed with errors." << std::endl;
+    }
   }
 
   freeQueue(hostSqeAddr, sqIsDevice, "submission queue");
@@ -742,6 +931,12 @@ int main(int argc, char** argv) {
     freeHostMemory(hostStartTime, XIO_HOST_MEM_MAPPED);
   if (!lessTiming && hostEndTime != nullptr)
     freeHostMemory(hostEndTime, XIO_HOST_MEM_MAPPED);
+  if (hostVerboseRwFlags != nullptr)
+    freeHostMemory(hostVerboseRwFlags, XIO_HOST_MEM_MAPPED);
+  if (hostVerboseXferBytes != nullptr)
+    freeHostMemory(hostVerboseXferBytes, XIO_HOST_MEM_MAPPED);
+  if (hostVerboseLbas != nullptr)
+    freeHostMemory(hostVerboseLbas, XIO_HOST_MEM_MAPPED);
   if (lessTiming && timingStats != nullptr)
     freeHostMemory(timingStats, XIO_HOST_MEM_MAPPED);
   if (substepStats != nullptr)
@@ -753,5 +948,5 @@ int main(int argc, char** argv) {
   g_configForSignalHandler = nullptr;
   g_endpointNameForSignalHandler = nullptr;
 
-  return EXIT_SUCCESS;
+  return run_ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/system/coherence/test-doorbell-coherence.hip
+++ b/tests/system/coherence/test-doorbell-coherence.hip
@@ -209,6 +209,19 @@ static int run_test(const char* label, bool use_fenced) {
 }
 
 int main() {
+  hipError_t herr = hipInit(0);
+  if (herr != hipSuccess) {
+    printf("SKIP: HIP init failed (%s)\n", hipGetErrorString(herr));
+    return 77;
+  }
+  int device_count = 0;
+  herr = hipGetDeviceCount(&device_count);
+  if (herr != hipSuccess || device_count == 0) {
+    printf("SKIP: no HIP devices found.\n");
+    return 77;
+  }
+  (void)hipSetDevice(0);
+
   int failures = 0;
 
   printf("=== Doorbell coherence stress test ===\n");

--- a/tests/system/nvme-ep/CMakeLists.txt
+++ b/tests/system/nvme-ep/CMakeLists.txt
@@ -271,7 +271,7 @@ xio_add_script_test(
   NAME nvme-verify-seq-device-mem-multi-lba
   SCRIPT ${_verify_wrapper}
   LABELS hardware nvme verify
-  TIMEOUT 120
+  TIMEOUT 30
   ARGS ${_seq_script}
   ENVIRONMENT
     "MEMORY_MODE=8"
@@ -403,6 +403,65 @@ xio_add_script_test(
   ENVIRONMENT "XIO_TESTER=${_xio_tester}"
 )
 
+# Inline --verify with >8 LBAs per I/O (host and VRAM data buffers).
+# Use 12 and 16 LBAs per command: both exceed 8*512 B and still fit the
+# <=2 NVMe 4K-page PRP1+PRP2 layout for page-aligned transfers. Larger
+# single-command sizes (e.g. 32 LBAs) need a PRP list; passthrough setups
+# may still fail --verify at the first list boundary, so those stay in
+# smoke-only tests without --verify.
+
+xio_add_script_test(
+  NAME nvme-verify-inline-lbas-12-host-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 45
+  ARGS --access-pattern random -m 0
+    --lbas-per-io 12 --lfsr-seed 0xB3
+    --write-io 8 --read-io 8
+    --queue-length 128 --batch-size 1
+    --data-buffer-size 1048576 --verify --less-timing
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-lbas-12-device-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 45
+  ARGS --access-pattern random -m 8
+    --lbas-per-io 12 --lfsr-seed 0xB4
+    --write-io 8 --read-io 8
+    --queue-length 128 --batch-size 1
+    --data-buffer-size 1048576 --verify --less-timing
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-lbas-16-host-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 45
+  ARGS --access-pattern random -m 0
+    --lbas-per-io 16 --lfsr-seed 0xB5
+    --write-io 8 --read-io 8
+    --queue-length 128 --batch-size 1
+    --data-buffer-size 1048576 --verify --less-timing
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-lbas-16-device-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 45
+  ARGS --access-pattern random -m 8
+    --lbas-per-io 16 --lfsr-seed 0xB6
+    --write-io 8 --read-io 8
+    --queue-length 128 --batch-size 1
+    --data-buffer-size 1048576 --verify --less-timing
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
 # --- Negative tests (expected failures) -----------------
 
 xio_add_script_test(
@@ -414,6 +473,23 @@ xio_add_script_test(
   ENVIRONMENT
     "XIO_TESTER=${_xio_tester}"
     "EXPECT_FAIL=1"
+)
+
+# Assert xio-tester exits non-zero when verification is forced to fail
+# (--inject-verify-fail). Requires GPU + NVMe like other nvme-ep tests.
+xio_add_script_test(
+  NAME nvme-negative-verify-exit-inject
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme negative
+  TIMEOUT 30
+  ARGS --access-pattern random -m 0
+    --lbas-per-io 8 --lfsr-seed 0xC0DE
+    --write-io 4 --read-io 4
+    --queue-length 128 --batch-size 1
+    --verify --inject-verify-fail --less-timing
+  ENVIRONMENT
+    "XIO_TESTER=${_xio_tester}"
+    "EXPECT_NONZERO=1"
 )
 
 xio_add_script_test(

--- a/tests/system/nvme-ep/run-nvme-smoke-test.sh
+++ b/tests/system/nvme-ep/run-nvme-smoke-test.sh
@@ -12,6 +12,8 @@
 #
 # For negative tests (expected failures), set
 # EXPECT_FAIL=1; the wrapper inverts the exit code.
+# For tests that expect xio-tester to exit non-zero (e.g. verify
+# mismatch or --inject-verify-fail), set EXPECT_NONZERO=1.
 #
 # Usage:
 #   run-nvme-smoke-test.sh [xio-tester-args...]
@@ -70,15 +72,27 @@ if [ -n "${ROCXIO_NVME_QUEUE_ID:-}" ]; then
 fi
 
 if [ "${EXPECT_FAIL:-0}" = "1" ]; then
-    if "$XIO_TESTER" nvme-ep \
-         --controller "$CONTROLLER" "${EXTRA_ARGS[@]}" \
-         >/dev/null 2>&1; then
-        echo "FAIL: expected failure but command succeeded"
-        exit 1
-    else
-        echo "OK: command failed as expected"
-        exit 0
-    fi
+  if "$XIO_TESTER" nvme-ep \
+       --controller "$CONTROLLER" "${EXTRA_ARGS[@]}" \
+       >/dev/null 2>&1; then
+    echo "FAIL: expected failure but command succeeded"
+    exit 1
+  else
+    echo "OK: command failed as expected"
+    exit 0
+  fi
+fi
+
+if [ "${EXPECT_NONZERO:-0}" = "1" ]; then
+  if "$XIO_TESTER" nvme-ep \
+       --controller "$CONTROLLER" "${EXTRA_ARGS[@]}" \
+       >/dev/null 2>&1; then
+    echo "FAIL: expected non-zero exit from xio-tester"
+    exit 1
+  else
+    echo "OK: xio-tester exited with non-zero status as expected"
+    exit 0
+  fi
 fi
 
 exec "$XIO_TESTER" nvme-ep \

--- a/tests/system/rdma-ep/run-rdma-script-test.sh
+++ b/tests/system/rdma-ep/run-rdma-script-test.sh
@@ -33,8 +33,18 @@ if [ "$EUID" -ne 0 ]; then
     exit 77
 fi
 
-# Auto-detect RDMA device if not specified
+# Auto-detect RDMA device if not specified. Prefer repo udev names
+# (rocm-rdma-*) so provider/vendor derivation matches setup-rdma-loopback.sh;
+# otherwise the first glob entry is often a kernel RoCE name (rocep*) that
+# shell scripts cannot map to bnxt|ionic|mlx5.
 RDMA_DEV="${ROCXIO_RDMA_DEVICE:-}"
+if [ -z "$RDMA_DEV" ]; then
+    for ib in /sys/class/infiniband/rocm-rdma-*; do
+        [ -d "$ib" ] || continue
+        RDMA_DEV="$(basename "$ib")"
+        break
+    done
+fi
 if [ -z "$RDMA_DEV" ]; then
     for ib in /sys/class/infiniband/*; do
         [ -d "$ib" ] || continue

--- a/tests/unit/common/test-rocm-xio-uapi-layout.hip
+++ b/tests/unit/common/test-rocm-xio-uapi-layout.hip
@@ -24,8 +24,10 @@ int main() {
 
   static_assert(sizeof(struct rocm_xio_register_queue_addr_req) == 40,
                 "rocm_xio_register_queue_addr_req size drift");
-  static_assert(sizeof(struct rocm_xio_register_buffer_req) == 40,
+  static_assert(sizeof(struct rocm_xio_register_buffer_req) == 48,
                 "rocm_xio_register_buffer_req size drift");
+  static_assert(sizeof(struct rocm_xio_buffer_dma_pages_req) == 24,
+                "rocm_xio_buffer_dma_pages_req size drift");
   static_assert(sizeof(struct rocm_xio_mmio_bridge_shadow_req) == 24,
                 "rocm_xio_mmio_bridge_shadow_req size drift");
   static_assert(sizeof(struct rocm_xio_alloc_contig_req) == 32,

--- a/tests/unit/nvme-ep/test-nvme-config.hip
+++ b/tests/unit/nvme-ep/test-nvme-config.hip
@@ -132,6 +132,12 @@ int test_config_defaults() {
   return 0;
 }
 
+int test_common_config_defaults() {
+  xio::XioEndpointConfig cfg;
+  ASSERT_TRUE(cfg.skipFirstIoTiming);
+  return 0;
+}
+
 int test_doorbell_constants() {
   ASSERT_EQ(doorbellBase, 0x1000u);
   ASSERT_EQ(doorBellStride, 4u);
@@ -207,6 +213,7 @@ int main() {
   failures += test_cqe_field_access();
   failures += test_cqe_cdw0_union();
   failures += test_config_defaults();
+  failures += test_common_config_defaults();
   failures += test_doorbell_constants();
   failures += test_admin_response_size();
   failures += test_command_opcodes();

--- a/tests/unit/nvme-ep/test-nvme-hardware.hip
+++ b/tests/unit/nvme-ep/test-nvme-hardware.hip
@@ -116,6 +116,15 @@ int test_validateConfig() {
 
   ASSERT_GT(cfg.queueId, 0u);
 
+  uint16_t max_qid = 0;
+  ASSERT_EQ(queryMaxQueueId(cfg.controller.c_str(), &max_qid), 0);
+  nvmeEpConfig invalid_cfg = cfg;
+  invalid_cfg.queueId = max_qid + 1;
+  err = validateConfig(&invalid_cfg);
+  ASSERT_TRUE(!err.empty());
+  ASSERT_TRUE(err.find("exceeds last available I/O queue ID") !=
+              std::string::npos);
+
   printf("  validateConfig: OK (lbaSize=%u, "
          "queueId=%u)\n",
          cfg.ioParams.lbaSize, cfg.queueId);

--- a/tests/unit/rdma-ep/CMakeLists.txt
+++ b/tests/unit/rdma-ep/CMakeLists.txt
@@ -53,8 +53,8 @@ xio_add_test(
 # hardware tests via FIXTURES_REQUIRED)
 if(GDA_BNXT OR GDA_IONIC OR GDA_ERNIC)
   add_test(NAME rdma-hw-setup
-    COMMAND sudo
-      ${CMAKE_SOURCE_DIR}/scripts/test/setup-rdma-loopback.sh)
+    COMMAND bash
+      "${CMAKE_SOURCE_DIR}/scripts/test/invoke-rdma-loopback-setup.sh")
   set_tests_properties(rdma-hw-setup PROPERTIES
     FIXTURES_SETUP RDMA_HW
     LABELS "hardware;fixture"


### PR DESCRIPTION
Add shared XIO helpers for clearing stale HIP launch errors, checking kernel launch status, and synchronizing kernels with endpoint/queue context. Use the helpers across endpoint launch sites so launch failures are reported near their source instead of surfacing later as ambiguous synchronization errors.

Tighten nvme-ep validation by rejecting explicit queue IDs above the selected controller's last available I/O queue, making invalid queue selection fail before queues or kernels are created. Also make PRP pool GPU pointer lookup a hard setup error and add hardware test coverage for invalid queue IDs.

Generalize AGENTS.md NVMe safety guidance to require user-confirmed by-id scratch devices, rootfs checks, explicit queue-id selection from queue_count, and bare-metal avoidance of PCI MMIO bridge mode.
