### PR TITLE
ci: clarify rolling GitHub release copy and Debian artifact names

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -85,12 +85,17 @@ jobs:
     - name: Stage built packages
       run: |
         mkdir -p built-debs
-        cp ../*.deb ../*.buildinfo ../*.changes built-debs/
+        for f in ../*.deb ../*.buildinfo ../*.changes; do
+          if [ -f "$f" ]; then
+            base="$(basename "$f")"
+            cp "$f" "built-debs/rocm-xio-latest-${base}"
+          fi
+        done
 
     - name: Upload .deb artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: rocm-xio-debs-${{ github.sha }}
+        name: rocm-xio-debs-rolling-${{ github.sha }}
         path: built-debs/
 
     - name: Update rolling package pre-release
@@ -98,7 +103,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: rocm-xio-latest
-        name: Latest package build (main)
+        name: Pre-release packages — tag rocm-xio-latest
         body_path: debian/generated-release-notes.md
         prerelease: true
         make_latest: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,15 @@ Release branches are created retroactively and only when it is necessary to
 bugfix supported versions of the library. Bugfixing should take place on
 `main` and be cherry-picked to any branches that are being maintained.
 
+### Pre-release packages from `main`
+
+Each push to `main` rebuilds the Debian packages and updates the
+GitHub pre-release attached to tag `rocm-xio-latest`. That is the only
+rolling package channel maintained by this repository's CI. An older GitHub
+release or tag named `latest` is not produced by the current workflows; if
+it still appears on the releases page, it is legacy and may be removed to
+avoid confusion.
+
 ## Pull Requests
 
 We welcome pull requests from outside contributors. Pull requests must pass

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,10 @@
-rocm-xio (0.1.0~git2d9d85a) noble; urgency=low
+rocm-xio (0.1.0~gitb2abced) noble; urgency=low
 
-  * ci: rolling packages use rocm-xio-latest and shared release notes
+  * ci: align rolling GitHub release title with generated release notes
+  * ci: prefix rolling release assets as rocm-xio-latest-* and rename
+    Actions artifact to rocm-xio-debs-rolling-<sha>
+  * debian: simplify GitHub release-note body (Since line, drop duplicate
+    headline; wrap rolling disclaimer)
+  * docs: document rocm-xio-latest as sole rolling channel in CONTRIBUTING
 
- -- AMD ROCm Build <rocm-xio@amd.com>  Fri, 08 May 2026 14:25:12 -0400
+ -- AMD ROCm Build <rocm-xio@amd.com>  Mon, 11 May 2026 13:33:21 -0400

--- a/debian/gen-changelog.sh
+++ b/debian/gen-changelog.sh
@@ -59,7 +59,8 @@ DATE_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Determine git log range for changelog bullets (git only; same gate as
 # FULL_SHA — avoids invoking git under set -e when unavailable).
 RANGE=""
-RANGE_LABEL=""
+# User-facing line for GitHub release notes (omit when empty).
+SINCE_DISPLAY=""
 cd "${PROJECT_DIR}"
 
 if [ -n "${FULL_SHA}" ]; then
@@ -67,17 +68,17 @@ if [ -n "${FULL_SHA}" ]; then
     if git -C "${PROJECT_DIR}" rev-parse -q --verify \
       "refs/tags/${ROLLING_TAG}" >/dev/null 2>&1; then
       RANGE="${ROLLING_TAG}..HEAD"
-      RANGE_LABEL="since tag \`${ROLLING_TAG}\`"
+      SINCE_DISPLAY="after \`${ROLLING_TAG}\`"
     else
       PREV_V=$(git -C "${PROJECT_DIR}" describe --tags --abbrev=0 \
         --match='v[0-9]*.[0-9]*.[0-9]*' HEAD 2>/dev/null \
         || true)
       if [ -n "${PREV_V}" ]; then
         RANGE="${PREV_V}..HEAD"
-        RANGE_LABEL="since latest semver tag \`${PREV_V}\` (rolling tag absent)"
+        SINCE_DISPLAY="after semver tag \`${PREV_V}\`"
       else
         RANGE="HEAD"
-        RANGE_LABEL="single revision (no prior tag)"
+        SINCE_DISPLAY=""
       fi
     fi
   else
@@ -86,15 +87,15 @@ if [ -n "${FULL_SHA}" ]; then
       || true)
     if [ -n "${PREV_V}" ]; then
       RANGE="${PREV_V}..HEAD"
-      RANGE_LABEL="since \`${PREV_V}\`"
+      SINCE_DISPLAY="after \`${PREV_V}\`"
     else
       RANGE="HEAD"
-      RANGE_LABEL="initial or first tagged release"
+      SINCE_DISPLAY=""
     fi
   fi
 else
   RANGE="HEAD"
-  RANGE_LABEL="git unavailable (no revision range)"
+  SINCE_DISPLAY=""
 fi
 
 # Collect commit subjects (no merges), newest first, cap for Debian noise.
@@ -139,16 +140,14 @@ fi
 } > "${SCRIPT_DIR}/changelog"
 
 # Markdown release notes (GitHub Release body).
-HEAD_LINE="ROCm XIO ${DEB_VERSION}"
 if [ "${GEN_CHANGELOG_ROLLING:-}" = "1" ]; then
-  TITLE="# Rolling package build (\`${ROLLING_TAG}\`)"
+  TITLE="# Pre-release packages — tag \`${ROLLING_TAG}\`"
 else
   TITLE="# Release ${VERSION}"
 fi
 
 {
   printf '%s\n\n' "${TITLE}"
-  printf '%s\n\n' "${HEAD_LINE}"
   printf '%s\n' "**Package version:** \`${DEB_VERSION}\`  "
   if [ -n "${FULL_SHA}" ]; then
     printf '%s\n' "**Commit:** \`${FULL_SHA}\`  "
@@ -156,10 +155,14 @@ fi
     printf '%s\n' "**Commit:** (git unavailable)  "
   fi
   printf '%s\n' "**Built:** ${DATE_ISO}  "
-  printf '%s\n\n' "**Change range:** ${RANGE_LABEL}"
+  if [ -n "${SINCE_DISPLAY}" ]; then
+    printf '%s\n' "**Since:** ${SINCE_DISPLAY}  "
+  fi
+  printf '\n'
   if [ "${GEN_CHANGELOG_ROLLING:-}" = "1" ]; then
-    printf '%s\n\n' \
-"This pre-release is updated on each push to \`main\`. It may be less stable than a semver-tagged release; for production, prefer a tagged \`vX.Y.Z\` release."
+    printf '%s\n%s\n\n' \
+"This pre-release is updated on each push to \`main\`. It may be less stable" \
+"than a semver-tagged release; for production, prefer a tagged \`vX.Y.Z\` release."
   fi
   printf '%s\n\n' "## Changes"
   if [ ! -s "${TMP_SUBJ}" ]; then


### PR DESCRIPTION
Rewrite generated release notes to drop duplicate headline text, replace internal change-range wording with a concise Since line where helpful, and align the rolling markdown title with the GitHub release name. Wrap the rolling disclaimer for readable line length.

Document that only the rocm-xio-latest pre-release is maintained by CI and that an older latest tag on GitHub is legacy.

Stage rolling workflow assets as rocm-xio-latest-* for clearer downloads, rename the Actions artifact to rocm-xio-debs-rolling-<sha>, and refresh debian/changelog from gen-changelog.sh.
