### PR TITLE
nvme-ep: fix PRP list DMA and isolate read/write list slots

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -986,6 +986,15 @@ listAvailableEndpoints
 loadKernelModule
 mapPciBar
 nvmeBufferParams
+nvmePrpListDmaSlotIndex
+nvmePrpListWordOffset
+nvmePrpSlotsPerBatchVal
+batchIdx
+isWrite
+params
+prpListDmaForSlot
+prpListEntriesPerPage
+prpSlotsPerBatch
 nvmeDoorbellParams
 nvmeEpConfig
 nvmeIoParams

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -114,6 +114,25 @@ NVMe Endpoint
    :members:
    :undoc-members:
 
+PRP list helpers
+^^^^^^^^^^^^^^^^
+
+When a batch issues both reads and writes and each direction needs a PRP
+list, ``nvmeBufferParams::prpSlotsPerBatch`` may be ``2`` so list memory uses
+separate pages (or slots) per direction. The helpers below map batch indices
+and DMA addresses the same way as the device kernels and optional host PRP
+dumps.
+
+.. doxygenfunction:: xio::nvme_ep::prpListEntriesPerPage
+
+.. doxygenfunction:: xio::nvme_ep::prpListDmaForSlot(const nvmeBufferParams &params, uint32_t slot)
+
+.. doxygenfunction:: xio::nvme_ep::nvmePrpSlotsPerBatchVal(const nvmeBufferParams &p)
+
+.. doxygenfunction:: xio::nvme_ep::nvmePrpListWordOffset(const nvmeBufferParams &p, uint32_t batchIdx, bool isWrite)
+
+.. doxygenfunction:: xio::nvme_ep::nvmePrpListDmaSlotIndex(const nvmeBufferParams &p, uint32_t batchIdx, bool isWrite)
+
 .. doxygenstruct:: xio::DataPatternParams
    :members:
    :undoc-members:

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -107,9 +107,94 @@ struct nvmeBufferParams {
   uint32_t readNumPages;        /**< Entries in readPagePhysAddrs. */
   uint32_t writeNumPages;       /**< Entries in writePagePhysAddrs. */
   uint64_t* prpListPool;        /**< PRP list backing storage for commands. */
+  uint64_t* prpListPageDmas;    /**< DMA address per PRP list command slot. */
   uint64_t prpListPoolDma;      /**< DMA address of prpListPool. */
   uint32_t prpEntriesPerCmd;    /**< PRP entries reserved per command. */
+  /**
+   * 1 for a single PRP list per batch, or 2 when read and write both use PRP
+   * lists so each batch reserves separate list pages for each direction.
+   */
+  uint32_t prpSlotsPerBatch;
 };
+
+/**
+ * @brief Number of @c uint64_t PRP list entries that fit in one NVMe page.
+ * @return @c NVME_PAGE_SIZE / sizeof(uint64_t).
+ */
+__host__ __device__ static inline uint32_t prpListEntriesPerPage() {
+  return NVME_PAGE_SIZE / sizeof(uint64_t);
+}
+
+/**
+ * @brief DMA base address of the PRP list for command slot @p slot.
+ *
+ * Uses @p prpListPageDmas[slot] when populated (one DMA per slot). Otherwise
+ * derives the address from @p prpListPoolDma using @p prpEntriesPerCmd stride,
+ * padded to at least one full list page when the stride is smaller.
+ *
+ * @param params Buffer and PRP pool parameters.
+ * @param slot   Linear slot index (pair read/write slots when
+ *               @c prpSlotsPerBatch is 2; see nvmePrpListDmaSlotIndex()).
+ * @return List DMA base for @p slot, or 0 when lists are not configured.
+ */
+__host__ __device__ static inline uint64_t prpListDmaForSlot(
+  const nvmeBufferParams& params, uint32_t slot) {
+  if (params.prpListPageDmas)
+    return params.prpListPageDmas[slot];
+  if (params.prpListPoolDma && params.prpEntriesPerCmd) {
+    uint32_t stride = params.prpEntriesPerCmd;
+    if (stride < prpListEntriesPerPage())
+      stride = prpListEntriesPerPage();
+    return params.prpListPoolDma + (uint64_t)slot * stride * sizeof(uint64_t);
+  }
+  return 0;
+}
+
+/**
+ * @brief Effective PRP list slots reserved per batch (1 or 2).
+ * @param p Buffer parameters; @c prpSlotsPerBatch == 2 selects dual lists.
+ * @return 2 when @p p.prpSlotsPerBatch is 2, otherwise 1.
+ */
+__host__ __device__ static inline uint32_t nvmePrpSlotsPerBatchVal(
+  const nvmeBufferParams& p) {
+  return p.prpSlotsPerBatch == 2u ? 2u : 1u;
+}
+
+/**
+ * @brief Word offset into @c prpListPool for batch @p batchIdx.
+ *
+ * When @c nvmePrpSlotsPerBatchVal(p) is 2, write lists follow read lists for
+ * the same batch inside the pool.
+ *
+ * @param p         Buffer parameters (stride @c prpEntriesPerCmd).
+ * @param batchIdx  Batch index within the doorbell group.
+ * @param isWrite   @c true for the write SQE list, @c false for read.
+ * @return Index in @c uint64_t words from the start of @c prpListPool.
+ */
+__host__ __device__ static inline uint32_t nvmePrpListWordOffset(
+  const nvmeBufferParams& p, uint32_t batchIdx, bool isWrite) {
+  const uint32_t mul = nvmePrpSlotsPerBatchVal(p);
+  uint32_t off = batchIdx * mul * p.prpEntriesPerCmd;
+  if (mul > 1u && isWrite)
+    off += p.prpEntriesPerCmd;
+  return off;
+}
+
+/**
+ * @brief Linear PRP list slot index for DMA lookup with prpListDmaForSlot().
+ *
+ * @param p         Buffer parameters.
+ * @param batchIdx  Batch index within the doorbell group.
+ * @param isWrite   @c true for the write path when dual lists are enabled.
+ * @return Slot index into @c prpListPageDmas or the derived pool layout.
+ */
+__host__ __device__ static inline uint32_t nvmePrpListDmaSlotIndex(
+  const nvmeBufferParams& p, uint32_t batchIdx, bool isWrite) {
+  const uint32_t mul = nvmePrpSlotsPerBatchVal(p);
+  if (mul > 1u)
+    return batchIdx * mul + (isWrite ? 1u : 0u);
+  return batchIdx;
+}
 
 /**
  * Drive NVMe endpoint I/O operations from GPU device code

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -1075,7 +1075,11 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
  * read vs write list pages match the device when @p bp.prpSlotsPerBatch is 2.
  *
  * @param queue_id        I/O queue id (for log lines).
- * @param bp              Per-queue buffer and PRP parameters.
+ * @param bp              Per-queue buffer and PRP parameters. When
+ *                        @c prpListPageDmas is set, it must point to
+ *                        host-readable memory (values are read on the
+ *                        CPU); do not pass the device alias from
+ *                        @c hipHostGetDevicePointer.
  * @param lbas_per_io     LBAs per NVMe command.
  * @param lba_size        Namespace logical block size in bytes.
  * @param eff_batch       Effective batch size for this launch.
@@ -1774,14 +1778,8 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     if (!kernelConfig.completionQueue &&
         failMissingKernelArg("completionQueue"))
       goto cleanup;
-    if (!kernelConfig.stopRequested && failMissingKernelArg("stopRequested"))
-      goto cleanup;
     if (useLessTiming && !kernelConfig.timingStats &&
         failMissingKernelArg("timingStats"))
-      goto cleanup;
-    if (!useLessTiming &&
-        (!kernelConfig.startTimes || !kernelConfig.endTimes) &&
-        failMissingKernelArg("startTimes/endTimes"))
       goto cleanup;
     if (nvmeConfig->ioParams.readIo != 0) {
       if (!qBufParams.readBuffer && failMissingKernelArg("readBuffer"))
@@ -1810,7 +1808,14 @@ __host__ hipError_t run(XioEndpointConfig* config) {
       goto cleanup;
     }
 
-    dumpNvmeDataPrpIfRequested(qid, qBufParams, nvmeConfig->ioParams.lbasPerIo,
+    // PRP dump runs on the host: prpListDmaForSlot() indexes
+    // prpListPageDmas[], so use the hipHostMalloc mapping, not the
+    // hipHostGetDevicePointer() alias passed to the kernel.
+    nvme_ep::nvmeBufferParams qBufParamsForDump = qBufParams;
+    if (prpPools[q].pageDmas != nullptr)
+      qBufParamsForDump.prpListPageDmas = prpPools[q].pageDmas;
+    dumpNvmeDataPrpIfRequested(qid, qBufParamsForDump,
+                               nvmeConfig->ioParams.lbasPerIo,
                                nvmeConfig->ioParams.lbaSize, effBatch,
                                prpStridePerCmd,
                                nvmeConfig->ioParams.readIo != 0,

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -290,19 +290,17 @@ __device__ static void driveEndpointSingle(
     sqeType tmpSqe = {};
     for (uint32_t b = 0; b < precompute_count; b++) {
       uint64_t buf_off = (uint64_t)b * transfer_size;
-      uint32_t prpOff = b * bufferParams.prpEntriesPerCmd;
-      uint64_t* prpSlot = bufferParams.prpListPool
-                            ? bufferParams.prpListPool + prpOff
-                            : nullptr;
-      uint64_t prpSlotDma = bufferParams.prpListPoolDma
-                              ? bufferParams.prpListPoolDma +
-                                  prpOff * sizeof(uint64_t)
-                              : 0;
       uint32_t pageOff = (uint32_t)(buf_off / NVME_PAGE_SIZE);
       uint64_t intraPageOff = buf_off % NVME_PAGE_SIZE;
 
       if (has_read_buffer &&
           buf_off + transfer_size <= bufferParams.bufferSize) {
+        uint32_t prpOff = nvmePrpListWordOffset(bufferParams, b, false);
+        uint64_t* prpSlot = bufferParams.prpListPool
+                              ? bufferParams.prpListPool + prpOff
+                              : nullptr;
+        uint64_t prpSlotDma = prpListDmaForSlot(
+          bufferParams, nvmePrpListDmaSlotIndex(bufferParams, b, false));
         uint64_t addr = bufferParams.readPagePhysAddrs
                           ? bufferParams.readPagePhysAddrs[pageOff] +
                               intraPageOff
@@ -317,6 +315,12 @@ __device__ static void driveEndpointSingle(
 
       if (has_write_buffer &&
           buf_off + transfer_size <= bufferParams.bufferSize) {
+        uint32_t prpOff = nvmePrpListWordOffset(bufferParams, b, true);
+        uint64_t* prpSlot = bufferParams.prpListPool
+                              ? bufferParams.prpListPool + prpOff
+                              : nullptr;
+        uint64_t prpSlotDma = prpListDmaForSlot(
+          bufferParams, nvmePrpListDmaSlotIndex(bufferParams, b, true));
         uint64_t addr = bufferParams.writePagePhysAddrs
                           ? bufferParams.writePagePhysAddrs[pageOff] +
                               intraPageOff
@@ -379,14 +383,13 @@ __device__ static void driveEndpointSingle(
         }
       } else {
         uint64_t buf_off = (uint64_t)b * transfer_size;
-        uint32_t prpOff = b * bufferParams.prpEntriesPerCmd;
+        const bool is_write_sq = !is_read_op;
+        uint32_t prpOff = nvmePrpListWordOffset(bufferParams, b, is_write_sq);
         uint64_t* prpSlot = bufferParams.prpListPool
                               ? bufferParams.prpListPool + prpOff
                               : nullptr;
-        uint64_t prpSlotDma = bufferParams.prpListPoolDma
-                                ? bufferParams.prpListPoolDma +
-                                    prpOff * sizeof(uint64_t)
-                                : 0;
+        uint64_t prpSlotDma = prpListDmaForSlot(
+          bufferParams, nvmePrpListDmaSlotIndex(bufferParams, b, is_write_sq));
         uint32_t pageOff = (uint32_t)(buf_off / NVME_PAGE_SIZE);
         uint64_t intraPageOff = buf_off % NVME_PAGE_SIZE;
 
@@ -657,14 +660,13 @@ __device__ static void driveEndpointWavefront(
         uint64_t buf_off = (uint64_t)b * transfer_size;
         bool prp_valid = false;
 
-        uint32_t prpOff = b * bufferParams.prpEntriesPerCmd;
+        const bool is_write_sq = !is_read_op;
+        uint32_t prpOff = nvmePrpListWordOffset(bufferParams, b, is_write_sq);
         uint64_t* prpSlot = bufferParams.prpListPool
                               ? bufferParams.prpListPool + prpOff
                               : nullptr;
-        uint64_t prpSlotDma = bufferParams.prpListPoolDma
-                                ? bufferParams.prpListPoolDma +
-                                    prpOff * sizeof(uint64_t)
-                                : 0;
+        uint64_t prpSlotDma = prpListDmaForSlot(
+          bufferParams, nvmePrpListDmaSlotIndex(bufferParams, b, is_write_sq));
         uint32_t pageOff = (uint32_t)(buf_off / NVME_PAGE_SIZE);
         uint64_t intraPageOff = buf_off % NVME_PAGE_SIZE;
 
@@ -1063,6 +1065,133 @@ __host__ std::string validateConfig(nvmeEpConfig* config) {
 }
 
 /**
+ * @brief Optional host-side PRP dump for debugging (env ROCXIO_NVME_DUMP_PRP).
+ *
+ * When @c ROCXIO_NVME_DUMP_PRP is set (any non-empty value), logs PRP1/PRP2
+ * and PRP list slot contents for the first @c N batch indices (@c N from
+ * @c ROCXIO_NVME_DUMP_PRP_BATCH, default 4). Uses the same @c calculatePrps()
+ * path as the device kernel with host-writable scratch for list entries.
+ * PRP2 addresses use @c prpListDmaForSlot and @c nvmePrpListDmaSlotIndex so
+ * read vs write list pages match the device when @p bp.prpSlotsPerBatch is 2.
+ *
+ * @param queue_id        I/O queue id (for log lines).
+ * @param bp              Per-queue buffer and PRP parameters.
+ * @param lbas_per_io     LBAs per NVMe command.
+ * @param lba_size        Namespace logical block size in bytes.
+ * @param eff_batch       Effective batch size for this launch.
+ * @param prp_stride_per_cmd  PRP list stride in @c uint64_t entries per slot.
+ * @param dump_reads      Log read-buffer PRPs when true.
+ * @param dump_writes     Log write-buffer PRPs when true.
+ */
+static __host__ void dumpNvmeDataPrpIfRequested(
+  uint16_t queue_id, const nvme_ep::nvmeBufferParams& bp, uint32_t lbas_per_io,
+  uint32_t lba_size, uint32_t eff_batch, uint32_t prp_stride_per_cmd,
+  bool dump_reads, bool dump_writes) {
+  const char* flag = getenv("ROCXIO_NVME_DUMP_PRP");
+  if (!flag || !flag[0])
+    return;
+
+  int max_b = xio::getEnvInt("ROCXIO_NVME_DUMP_PRP_BATCH", 4);
+  if (max_b < 1)
+    max_b = 1;
+  if (max_b > 256)
+    max_b = 256;
+
+  const uint64_t xfer64 = (uint64_t)lbas_per_io * (uint64_t)lba_size;
+  if (xfer64 > 0xffffffffULL) {
+    ROCXIO_LOG_WARN("ROCXIO_NVME_DUMP_PRP: transfer size > 4GiB, "
+                    "skipping PRP dump for queue %u\n",
+                    (unsigned)queue_id);
+    return;
+  }
+  const uint32_t xfer_u32 = (uint32_t)xfer64;
+
+  constexpr uint32_t kMaxList = NVME_PAGE_SIZE / sizeof(uint64_t);
+  uint64_t scratch[kMaxList];
+
+  ROCXIO_LOG_INFO("ROCXIO_NVME_DUMP_PRP queue=%u xfer=%u bytes "
+                  "prp_stride=%u prp_pool_dma=0x%016llx eff_batch=%u "
+                  "prp_slots_per_batch=%u\n",
+                  (unsigned)queue_id, xfer_u32, prp_stride_per_cmd,
+                  (unsigned long long)bp.prpListPoolDma, eff_batch,
+                  (unsigned)nvmePrpSlotsPerBatchVal(bp));
+
+  auto list_entry_count = [](uint64_t buffer_addr,
+                             uint32_t buffer_size) -> uint32_t {
+    constexpr uint32_t kMax = NVME_PAGE_SIZE / sizeof(uint64_t);
+    uint64_t offset_in_page = buffer_addr & (NVME_PAGE_SIZE - 1);
+    uint64_t first_page_size = NVME_PAGE_SIZE - offset_in_page;
+    if (buffer_size <= first_page_size)
+      return 0;
+    uint32_t remaining = (uint32_t)(buffer_size - first_page_size);
+    uint32_t num_remaining = (remaining + NVME_PAGE_SIZE - 1) / NVME_PAGE_SIZE;
+    if (num_remaining > kMax)
+      num_remaining = kMax;
+    if (num_remaining <= 1)
+      return 0;
+    return num_remaining;
+  };
+
+  auto dump_direction = [&](const char* label, bool active, uint64_t buf_dma,
+                            const uint64_t* page_addrs, bool is_write) {
+    if (!active)
+      return;
+    uint32_t limit_b = eff_batch;
+    if (limit_b > (uint32_t)max_b)
+      limit_b = (uint32_t)max_b;
+    for (uint32_t b = 0; b < limit_b; b++) {
+      uint64_t buf_off = (uint64_t)b * xfer64;
+      if (buf_off + xfer64 > bp.bufferSize)
+        break;
+      const uint64_t prp_slot_dma =
+        prp_stride_per_cmd != 0
+          ? prpListDmaForSlot(bp, nvmePrpListDmaSlotIndex(bp, b, is_write))
+          : 0ULL;
+      const uint32_t page_off = (uint32_t)(buf_off / (uint64_t)NVME_PAGE_SIZE);
+      const uint64_t intra_page_off = buf_off % (uint64_t)NVME_PAGE_SIZE;
+
+      uint64_t addr = 0;
+      if (page_addrs) {
+        addr = page_addrs[page_off] + intra_page_off;
+      } else if (buf_dma) {
+        addr = buf_dma + buf_off;
+      } else {
+        ROCXIO_LOG_WARN("ROCXIO_NVME_DUMP_PRP %s b=%u: no DMA base for "
+                        "PRP dump\n",
+                        label, b);
+        continue;
+      }
+
+      nvme_ep::sqeType tmp = {};
+      memset(scratch, 0, sizeof(scratch));
+      nvme_ep::calculatePrps(addr, xfer_u32, &tmp,
+                             (prp_stride_per_cmd != 0) ? scratch : nullptr,
+                             prp_slot_dma, page_addrs, page_off);
+
+      const uint32_t list_entries = list_entry_count(addr, xfer_u32);
+      ROCXIO_LOG_INFO("  %s b=%u buf_off=0x%llx data_addr=0x%016llx "
+                      "prp1=0x%016llx prp2=0x%016llx list_entries=%u\n",
+                      label, b, (unsigned long long)buf_off,
+                      (unsigned long long)addr,
+                      (unsigned long long)tmp.dptr.prp.prp1,
+                      (unsigned long long)tmp.dptr.prp.prp2, list_entries);
+
+      if (list_entries > 0 && prp_stride_per_cmd != 0) {
+        for (uint32_t i = 0; i < list_entries; i++) {
+          ROCXIO_LOG_INFO("    prp_list[%u]=0x%016llx\n", i,
+                          (unsigned long long)scratch[i]);
+        }
+      }
+    }
+  };
+
+  dump_direction("read", dump_reads, bp.readBufferDma, bp.readPagePhysAddrs,
+                 false);
+  dump_direction("write", dump_writes, bp.writeBufferDma, bp.writePagePhysAddrs,
+                 true);
+}
+
+/**
  * Run NVMe endpoint operations
  *
  * Sets up queues, allocates buffers, and launches GPU
@@ -1307,16 +1436,17 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     return hipErrorInvalidValue;
   }
   uint32_t prpEntriesPerCmd = (xfer_size > NVME_PAGE_SIZE)
-                                ? (uint32_t)((xfer_size / NVME_PAGE_SIZE) + 1)
+                                ? prpListEntriesPerPage()
                                 : 0;
   uint32_t prpStridePerCmd = prpEntriesPerCmd;
-  if (prpStridePerCmd > 0) {
-    uint32_t s = 1;
-    while (s < prpStridePerCmd)
-      s <<= 1;
-    prpStridePerCmd = s;
-  }
-  uint32_t prpPoolEntriesPerQueue = prpStridePerCmd * effBatch;
+  uint32_t prpSlotsPerBatch = (nvmeConfig->ioParams.readIo != 0 &&
+                               nvmeConfig->ioParams.writeIo != 0)
+                                ? 2u
+                                : 1u;
+  if (prpStridePerCmd == 0)
+    prpSlotsPerBatch = 1u;
+  uint32_t prpPoolEntriesPerQueue = prpStridePerCmd * effBatch *
+                                    prpSlotsPerBatch;
   size_t prpPoolBytes = (size_t)prpPoolEntriesPerQueue * sizeof(uint64_t);
   long sys_page_sz = sysconf(_SC_PAGESIZE);
   size_t host_page = (sys_page_sz > 0) ? (size_t)sys_page_sz : 4096;
@@ -1327,6 +1457,8 @@ __host__ hipError_t run(XioEndpointConfig* config) {
   struct PrpPool {
     void* ptr = nullptr;
     void* gpuPtr = nullptr;
+    uint64_t* pageDmas = nullptr;
+    uint64_t* pageDmasGpu = nullptr;
     uint64_t dma = 0;
     size_t size = 0;
     bool hipAllocated = false;
@@ -1487,6 +1619,14 @@ __host__ hipError_t run(XioEndpointConfig* config) {
         result = hipErrorMemoryAllocation;
         goto cleanup;
       }
+      if ((reinterpret_cast<uintptr_t>(pool) & (NVME_PAGE_SIZE - 1)) != 0) {
+        ROCXIO_LOG_ERROR("PRP list pool for queue %u is not "
+                         "page-aligned\n",
+                         qid);
+        (void)hipHostFree(pool);
+        result = hipErrorInvalidValue;
+        goto cleanup;
+      }
       memset(pool, 0, prpPoolBytes);
 
       uint64_t pool_dma = getPhysAddr(pool);
@@ -1505,8 +1645,44 @@ __host__ hipError_t run(XioEndpointConfig* config) {
         gpu_pool = pool;
       }
 
+      uint64_t* page_dmas = nullptr;
+      const uint32_t prp_dma_slots = effBatch * prpSlotsPerBatch;
+      hipError_t dmas_err = hipHostMalloc((void**)&page_dmas,
+                                          sizeof(*page_dmas) * prp_dma_slots,
+                                          hipHostMallocMapped);
+      if (dmas_err != hipSuccess || !page_dmas) {
+        ROCXIO_LOG_ERROR("Failed to allocate PRP list DMA "
+                         "table for queue %u: %s\n",
+                         qid, hipGetErrorString(dmas_err));
+        (void)hipHostFree(pool);
+        result = hipErrorMemoryAllocation;
+        goto cleanup;
+      }
+      memset(page_dmas, 0, sizeof(*page_dmas) * prp_dma_slots);
+      for (uint32_t s = 0; s < prp_dma_slots; s++) {
+        uint8_t* slot = static_cast<uint8_t*>(pool) +
+                        (size_t)s * prpStridePerCmd * sizeof(uint64_t);
+        page_dmas[s] = getPhysAddr(slot);
+        if (!page_dmas[s] || (page_dmas[s] & (NVME_PAGE_SIZE - 1)) != 0) {
+          ROCXIO_LOG_ERROR("Failed to get PRP list page "
+                           "phys addr for queue %u slot %u\n",
+                           qid, s);
+          (void)hipHostFree(page_dmas);
+          (void)hipHostFree(pool);
+          result = hipErrorInvalidValue;
+          goto cleanup;
+        }
+      }
+      void* gpu_page_dmas = nullptr;
+      (void)hipHostGetDevicePointer(&gpu_page_dmas, page_dmas, 0);
+      if (!gpu_page_dmas)
+        gpu_page_dmas = page_dmas;
+      pool_dma = page_dmas[0];
+
       prpPools[q].ptr = pool;
       prpPools[q].gpuPtr = gpu_pool;
+      prpPools[q].pageDmas = page_dmas;
+      prpPools[q].pageDmasGpu = static_cast<uint64_t*>(gpu_page_dmas);
       prpPools[q].dma = pool_dma;
       prpPools[q].size = prpPoolBytes;
       prpPools[q].hipAllocated = true;
@@ -1558,8 +1734,10 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     qBufParams.prpListPool = prpPools[q].gpuPtr
                                ? static_cast<uint64_t*>(prpPools[q].gpuPtr)
                                : static_cast<uint64_t*>(prpPools[q].ptr);
+    qBufParams.prpListPageDmas = prpPools[q].pageDmasGpu;
     qBufParams.prpListPoolDma = prpPools[q].dma;
     qBufParams.prpEntriesPerCmd = prpStridePerCmd;
+    qBufParams.prpSlotsPerBatch = prpSlotsPerBatch;
 
     XioEndpointConfig kernelConfig = *config;
     kernelConfig.endpointConfig = nullptr;
@@ -1573,6 +1751,70 @@ __host__ hipError_t run(XioEndpointConfig* config) {
     if (useLessTiming) {
       kernelConfig.timingStats = perQueueStats[q];
     }
+
+    auto failMissingKernelArg = [&](const char* arg_name) -> bool {
+      ROCXIO_LOG_ERROR("Missing required NVMe kernel argument "
+                       "'%s' for queue %u\n",
+                       arg_name, qid);
+      result = hipErrorInvalidValue;
+      return true;
+    };
+
+    auto failZeroKernelArg = [&](const char* arg_name) -> bool {
+      ROCXIO_LOG_ERROR("Required NVMe kernel argument '%s' "
+                       "is zero for queue %u\n",
+                       arg_name, qid);
+      result = hipErrorInvalidValue;
+      return true;
+    };
+
+    if (!kernelConfig.submissionQueue &&
+        failMissingKernelArg("submissionQueue"))
+      goto cleanup;
+    if (!kernelConfig.completionQueue &&
+        failMissingKernelArg("completionQueue"))
+      goto cleanup;
+    if (!kernelConfig.stopRequested && failMissingKernelArg("stopRequested"))
+      goto cleanup;
+    if (useLessTiming && !kernelConfig.timingStats &&
+        failMissingKernelArg("timingStats"))
+      goto cleanup;
+    if (!useLessTiming &&
+        (!kernelConfig.startTimes || !kernelConfig.endTimes) &&
+        failMissingKernelArg("startTimes/endTimes"))
+      goto cleanup;
+    if (nvmeConfig->ioParams.readIo != 0) {
+      if (!qBufParams.readBuffer && failMissingKernelArg("readBuffer"))
+        goto cleanup;
+      if (qBufParams.readBufferDma == 0 && failZeroKernelArg("readBufferDma"))
+        goto cleanup;
+    }
+    if (nvmeConfig->ioParams.writeIo != 0) {
+      if (!qBufParams.writeBuffer && failMissingKernelArg("writeBuffer"))
+        goto cleanup;
+      if (qBufParams.writeBufferDma == 0 && failZeroKernelArg("writeBufferDma"))
+        goto cleanup;
+    }
+    if (prpStridePerCmd > 0) {
+      if (!qBufParams.prpListPool && failMissingKernelArg("prpListPool"))
+        goto cleanup;
+      if (qBufParams.prpListPoolDma == 0 && failZeroKernelArg("prpListPoolDma"))
+        goto cleanup;
+    }
+    if (qDoorbellParams.usePciMmioBridge) {
+      if (!qDoorbellParams.shadowBufferVirt &&
+          failMissingKernelArg("shadowBufferVirt"))
+        goto cleanup;
+    } else if (!qDoorbellParams.nvmeBar0Gpu &&
+               failMissingKernelArg("nvmeBar0Gpu")) {
+      goto cleanup;
+    }
+
+    dumpNvmeDataPrpIfRequested(qid, qBufParams, nvmeConfig->ioParams.lbasPerIo,
+                               nvmeConfig->ioParams.lbaSize, effBatch,
+                               prpStridePerCmd,
+                               nvmeConfig->ioParams.readIo != 0,
+                               nvmeConfig->ioParams.writeIo != 0);
 
     // Keep backward compat: update nvmeConfig
     // with the first queue's info for single-queue
@@ -1704,6 +1946,9 @@ cleanup:
 
   // Free per-queue PRP list pools
   for (uint16_t q = 0; q < numQueues; q++) {
+    if (prpPools[q].pageDmas) {
+      (void)hipHostFree(prpPools[q].pageDmas);
+    }
     if (prpPools[q].ptr && prpPools[q].hipAllocated) {
       (void)hipHostFree(prpPools[q].ptr);
     }

--- a/tests/system/nvme-ep/CMakeLists.txt
+++ b/tests/system/nvme-ep/CMakeLists.txt
@@ -283,6 +283,45 @@ xio_add_script_test(
     "XIO_TESTER=${_xio_tester}"
 )
 
+# --- Per-command I/O strictly greater than 8 KiB ----------
+# Most verify tests above use 1 or 8 LBAs per command (8 * 512 B = 4 KiB
+# on 512-byte namespaces), which does not span more than two 4 KiB PRP
+# pages.  BLOCKS_PER_CMD=20 yields 20 * 512 B = 10240 B (> 8192 B) on
+# typical 512e/512 namespaces; on 4 KiB LBAs the transfer is even larger.
+# Inline --verify tests use --lbas-per-io 20 for the same guarantee.
+
+xio_add_script_test(
+  NAME nvme-verify-seq-host-mem-gt8k
+  SCRIPT ${_verify_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 120
+  ARGS ${_seq_script}
+  ENVIRONMENT
+    "MEMORY_MODE=0"
+    "WRITE_IO=4"
+    "BLOCKS_PER_CMD=20"
+    "LFSR_SEED=0xD001"
+    "BASE_LBA=2048"
+    "USE_PCI_MMIO_BRIDGE=0"
+    "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-seq-device-mem-gt8k
+  SCRIPT ${_verify_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 120
+  ARGS ${_seq_script}
+  ENVIRONMENT
+    "MEMORY_MODE=8"
+    "WRITE_IO=4"
+    "BLOCKS_PER_CMD=20"
+    "LFSR_SEED=0xD002"
+    "BASE_LBA=2048"
+    "USE_PCI_MMIO_BRIDGE=0"
+    "XIO_TESTER=${_xio_tester}"
+)
+
 # --- Inline read-back verification (--verify) ----------
 # Write-then-read with LFSR verification in a single
 # xio-tester invocation.  Requires --batch-size 1
@@ -335,6 +374,32 @@ xio_add_script_test(
     --write-io 8 --read-io 8
     --queue-length 128
     --data-buffer-size 524288 --verify
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-gt8k-host-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 60
+  ARGS --access-pattern sequential -m 0
+    --lbas-per-io 20 --lfsr-seed 0xB1
+    --write-io 8 --read-io 8
+    --queue-length 128
+    --data-buffer-size 2097152 --verify
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME nvme-verify-inline-gt8k-device-mem
+  SCRIPT ${_smoke_wrapper}
+  LABELS hardware nvme verify
+  TIMEOUT 60
+  ARGS --access-pattern sequential -m 8
+    --lbas-per-io 20 --lfsr-seed 0xB2
+    --write-io 8 --read-io 8
+    --queue-length 128 --less-timing
+    --data-buffer-size 2097152 --verify
   ENVIRONMENT "XIO_TESTER=${_xio_tester}"
 )
 

--- a/tests/unit/nvme-ep/test-nvme-helpers.hip
+++ b/tests/unit/nvme-ep/test-nvme-helpers.hip
@@ -4,7 +4,9 @@
  *
  * Unit tests for nvme-ep helper functions: sqeSetup, calculatePrps, cqeOk,
  * cqeStatusCode, cqeStatusType, sqeRead/sqeWrite, cqeRead/cqeWrite,
- * NVME_CQE_STATUS_* macros, NVME_STATUS_MAKE round-trip, and dataPattern.
+ * NVME_CQE_STATUS_* macros, NVME_STATUS_MAKE round-trip, dataPattern, and
+ * dual-slot PRP list index helpers (nvmePrpListWordOffset /
+ * nvmePrpListDmaSlotIndex).
  */
 
 #include <cassert>
@@ -761,6 +763,80 @@ int test_prp_list_dma_legacy_fallback() {
   return 0;
 }
 
+/* Dual read/write PRP list slots (prpSlotsPerBatch == 2). */
+
+int test_prp_slots_per_batch_val() {
+  nvmeBufferParams p = {};
+  p.prpSlotsPerBatch = 0;
+  ASSERT_EQ(nvmePrpSlotsPerBatchVal(p), 1u);
+  p.prpSlotsPerBatch = 1;
+  ASSERT_EQ(nvmePrpSlotsPerBatchVal(p), 1u);
+  p.prpSlotsPerBatch = 2;
+  ASSERT_EQ(nvmePrpSlotsPerBatchVal(p), 2u);
+  p.prpSlotsPerBatch = 3;
+  ASSERT_EQ(nvmePrpSlotsPerBatchVal(p), 1u);
+  return 0;
+}
+
+int test_prp_dual_slot_dma_index() {
+  nvmeBufferParams p = {};
+  p.prpSlotsPerBatch = 2;
+  p.prpEntriesPerCmd = 8;
+
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 0, false), 0u);
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 0, true), 1u);
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 1, false), 2u);
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 1, true), 3u);
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 5, false), 10u);
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 5, true), 11u);
+  return 0;
+}
+
+int test_prp_dual_slot_word_offset() {
+  nvmeBufferParams p = {};
+  p.prpSlotsPerBatch = 2;
+  p.prpEntriesPerCmd = 8;
+
+  ASSERT_EQ(nvmePrpListWordOffset(p, 0, false), 0u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 0, true), 8u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 1, false), 16u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 1, true), 24u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 3, false), 48u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 3, true), 56u);
+  return 0;
+}
+
+int test_prp_single_slot_word_offset_and_dma_index() {
+  nvmeBufferParams p = {};
+  p.prpSlotsPerBatch = 1;
+  p.prpEntriesPerCmd = 16;
+
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 4, false), 4u);
+  ASSERT_EQ(nvmePrpListDmaSlotIndex(p, 4, true), 4u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 4, false), 64u);
+  ASSERT_EQ(nvmePrpListWordOffset(p, 4, true), 64u);
+  return 0;
+}
+
+int test_prp_dual_slot_list_dma_with_slot_index() {
+  nvmeBufferParams p = {};
+  uint64_t dmas[6] = {0xA000, 0xA100, 0xA200, 0xA300, 0xA400, 0xA500};
+  p.prpListPageDmas = dmas;
+  p.prpListPoolDma = dmas[0];
+  p.prpEntriesPerCmd = prpListEntriesPerPage();
+  p.prpSlotsPerBatch = 2;
+
+  ASSERT_EQ(prpListDmaForSlot(p, nvmePrpListDmaSlotIndex(p, 0, false)),
+            (uint64_t)0xA000);
+  ASSERT_EQ(prpListDmaForSlot(p, nvmePrpListDmaSlotIndex(p, 0, true)),
+            (uint64_t)0xA100);
+  ASSERT_EQ(prpListDmaForSlot(p, nvmePrpListDmaSlotIndex(p, 2, false)),
+            (uint64_t)0xA400);
+  ASSERT_EQ(prpListDmaForSlot(p, nvmePrpListDmaSlotIndex(p, 2, true)),
+            (uint64_t)0xA500);
+  return 0;
+}
+
 int main() {
   int failures = 0;
 
@@ -787,6 +863,11 @@ int main() {
   failures += test_prp_list_noncontiguous_page_offset();
   failures += test_prp_list_dma_for_page_slots();
   failures += test_prp_list_dma_legacy_fallback();
+  failures += test_prp_slots_per_batch_val();
+  failures += test_prp_dual_slot_dma_index();
+  failures += test_prp_dual_slot_word_offset();
+  failures += test_prp_dual_slot_list_dma_with_slot_index();
+  failures += test_prp_single_slot_word_offset_and_dma_index();
 
   failures += test_cqeOk_success();
   failures += test_cqeOk_success_with_phase();

--- a/tests/unit/nvme-ep/test-nvme-helpers.hip
+++ b/tests/unit/nvme-ep/test-nvme-helpers.hip
@@ -735,6 +735,32 @@ int test_prp_list_noncontiguous_page_offset() {
   return 0;
 }
 
+int test_prp_list_dma_for_page_slots() {
+  nvmeBufferParams params = {};
+  uint64_t pageDmas[3] = {0x100000, 0x310000, 0x520000};
+
+  params.prpListPageDmas = pageDmas;
+  params.prpListPoolDma = pageDmas[0];
+  params.prpEntriesPerCmd = prpListEntriesPerPage();
+
+  ASSERT_EQ(prpListDmaForSlot(params, 0), (uint64_t)0x100000);
+  ASSERT_EQ(prpListDmaForSlot(params, 1), (uint64_t)0x310000);
+  ASSERT_EQ(prpListDmaForSlot(params, 2), (uint64_t)0x520000);
+  return 0;
+}
+
+int test_prp_list_dma_legacy_fallback() {
+  nvmeBufferParams params = {};
+
+  params.prpListPoolDma = 0x100000;
+  params.prpEntriesPerCmd = 4;
+
+  ASSERT_EQ(prpListDmaForSlot(params, 0), (uint64_t)0x100000);
+  ASSERT_EQ(prpListDmaForSlot(params, 1), (uint64_t)0x101000);
+  ASSERT_EQ(prpListDmaForSlot(params, 2), (uint64_t)0x102000);
+  return 0;
+}
+
 int main() {
   int failures = 0;
 
@@ -759,6 +785,8 @@ int main() {
   failures += test_prp_list_contiguous_with_offset();
   failures += test_prp_list_max_transfer_32_pages();
   failures += test_prp_list_noncontiguous_page_offset();
+  failures += test_prp_list_dma_for_page_slots();
+  failures += test_prp_list_dma_legacy_fallback();
 
   failures += test_cqeOk_success();
   failures += test_cqeOk_success_with_phase();


### PR DESCRIPTION
PRP list entries must use DMA addresses the controller can reach. Prefer per-command-slot list DMA bases via prpListPageDmas and prpListDmaForSlot(), with a documented fallback from prpListPoolDma when page slots are absent.

When both read and write paths use PRP lists in the same batch, a single shared list page made the second calculatePrps pass overwrite entries needed for reads. Introduce prpSlotsPerBatch (2 when both directions need lists), nvmePrpListWordOffset(), and nvmePrpListDmaSlotIndex() so read and write SQEs each get their own list region in single-thread and wavefront batch paths. Align optional ROCXIO_NVME_DUMP_PRP host simulation with the same slot rules.

Extend test-nvme-helpers with coverage for prpListDmaForSlot() page-slot layout and legacy pool stride fallback.
