### PR TITLE
tests: broaden CPU-only unit CTests and harden CLI transfer-size parsing

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -64,10 +64,6 @@ jobs:
           -DROCM_PATH=/opt/rocm \
           -DBUILD_TESTING=ON ..
         cmake --build . --target all
-    - name: Run unit tests (CPU-only).
-      run: |
-        ctest --test-dir build -V -L "unit" \
-          --parallel --output-on-failure
     - name: Run tester application.
       run: |
         ./build/xio-tester -h
@@ -75,10 +71,6 @@ jobs:
       run: |
         cd build
         cmake --install . --prefix /tmp/rocm-xio-test
-    - name: Run integration tests (install + examples).
-      run: |
-        ctest --test-dir build -V -L "integration" \
-          --parallel --output-on-failure
     - name: Build examples against installed prefix.
       run: |
         for ex in list-endpoints endpoint-info \

--- a/.github/workflows/ctest-no-hardware.yml
+++ b/.github/workflows/ctest-no-hardware.yml
@@ -1,0 +1,77 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Runs every CTest that does not require dedicated hardware or a HIP GPU.
+# Use a single --label-exclude regex: CMake treats multiple --label-exclude
+# flags as AND (a test is dropped only if it matches every pattern), so
+# separate -LE hardware -LE system would still run hardware-only and system-only
+# tests. See tests/CMakeLists.txt for the label convention.
+
+name: ctest-no-hardware
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - 'feat/**'
+    paths:
+      - '**.hip'
+      - '**.cpp'
+      - '**.c'
+      - '**.h'
+      - '**.hpp'
+      - '**.cc'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'examples/**'
+      - 'scripts/**'
+      - 'Makefile'
+      - 'tests/**'
+
+jobs:
+  ctest-no-hardware:
+    name: CTest (no hardware / no GPU)
+    runs-on: ubuntu-latest
+    container:
+      image: rocm/dev-ubuntu-24.04:7.2
+      options: --user root
+    env:
+      LD_LIBRARY_PATH: /opt/rocm/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+      HSA_FORCE_FINE_GRAIN_PCIE: '1'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5.0.0
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y \
+            cmake \
+            curl \
+            libcli11-dev \
+            libdrm-dev \
+            libopenmpi-dev \
+            openmpi-bin
+
+      - name: Configure and build
+        run: |
+          mkdir -p build && cd build
+          cmake -DOFFLOAD_ARCH=gfx942:xnack+ \
+            -DROCM_PATH=/opt/rocm \
+            -DBUILD_TESTING=ON ..
+          cmake --build . --target all -j "$(nproc)"
+        env:
+          CLANGXX: /opt/rocm/llvm/bin/clang++
+
+      - name: Run CTests (--label-exclude hardware|system)
+        run: |
+          ctest --test-dir "${GITHUB_WORKSPACE}/build" -V \
+            --label-exclude 'hardware|system' \
+            --resource-spec-file "${GITHUB_WORKSPACE}/build/ctest-resources.json" \
+            --parallel "$(nproc)" \
+            --output-on-failure

--- a/.github/workflows/test-emulate.yml
+++ b/.github/workflows/test-emulate.yml
@@ -45,10 +45,6 @@ jobs:
           -DROCM_PATH=/opt/rocm \
           -DBUILD_TESTING=ON ..
         cmake --build . --target all
-    - name: Run unit tests (CPU-only).
-      run: |
-        ctest --test-dir build -V -L "unit" \
-          --parallel --output-on-failure
     - name: Run tester using test-ep in emulate mode
       run: |
         ./build/xio-tester test-ep --emulate -n 100 -t 1 -v

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -78,8 +78,14 @@ sdma
 SHMEM
 subnet
 TCP
+tcp
 XGMI
 xgmierr
+
+# ===== CLI and environment helpers (docs / tests) =====
+getEnvInt
+getEnvStr
+subcommand
 
 # ===== MPI and Collectives =====
 allgather

--- a/cmake/XIOTestHelpers.cmake
+++ b/cmake/XIOTestHelpers.cmake
@@ -91,6 +91,11 @@ function(xio_add_test)
     endif()
   endforeach()
 
+  if(XIO_SDMA_OSS7)
+    target_compile_definitions(${XIO_TEST_NAME}
+      PRIVATE XIO_SDMA_OSS7=1)
+  endif()
+
   # Register test with CTest
   if(XIO_TEST_EXTRA_ARGS)
     add_test(

--- a/docs/how-to/testing.rst
+++ b/docs/how-to/testing.rst
@@ -70,6 +70,7 @@ Label         Definition
 ``stress``    Long-running (timeout: 600 seconds)
 ``rdma``      RDMA-related test
 ``common``    Common library utilities
+``scripts``   Shell-script syntax checks
 ``fixture``   CTest fixture (setup/teardown)
 ============  =========================================
 
@@ -90,13 +91,17 @@ Unit tests (CPU-only)
 These run in CI without hardware:
 
 - ``test-data-pattern`` -- LFSR data pattern generation and verification
-- ``test-rdma-config`` -- ``RdmaEpConfig`` validation, ``Provider``
-  enum, ``provider_name()``, ``provider_from_string()`` (all vendors
-  including ROCM_ERNIC)
+- ``test-xio-env`` -- environment parsing and cached log-level helpers
+- ``test-xio-cli-options`` -- ``xio-tester`` CLI option registration,
+  validation, and SDMA subcommand detection
+- ``test-rdma-config`` -- ``RdmaEpConfig`` validation, ``Provider`` enum,
+  ``provider_name()``, ``provider_from_string()``, iteration handling, and
+  2-node validation
 - ``test-rdma-vendors`` -- Vendor ID constants, ``RmaDescriptor``,
   ``AmoDescriptor`` struct layout
-- ``test-rdma-endian`` -- Endian byte-swap helpers (host and
-  optional device)
+- ``test-rdma-endian`` -- Endian byte-swap helpers (host and optional device)
+- ``test-rdma-common`` -- Provider key normalization, RD atomic depth,
+  queue-pair init attributes, and backend config mapping
 - ``test-bnxt-sizing`` -- BNXT DV queue sizing math:
   ``roundup_pow2``, ``align_up``, ``calc_wqe_sz``, ``compute_sq``,
   ``compute_rq``, ``cqe_size``
@@ -104,7 +109,21 @@ These run in CI without hardware:
   ``ExtractBusNumber``, ``GetBusIdDistance``, ``GetLcaDepth``
 - ``test-extract-endpoint`` -- CLI argument parser:
   ``extractEndpointName()``
-- ``test-ep-config`` -- test-ep configuration defaults
+- ``test-xio-env`` -- environment variable parsing helpers:
+  ``getEnvInt()`` and ``getEnvStr()``
+- ``test-xio-timing`` -- host-side ``XioTimingStats`` aggregation
+- ``test-tcp-exchange-layout`` -- two-node RDMA TCP exchange wire
+  layout and socket byte helpers
+- ``test-nvme-config`` -- NVMe command/status constants and config defaults
+- ``test-nvme-helpers`` -- NVMe SQE/CQE helpers, PRP edge cases, and data
+  pattern verification
+- ``test-ep-config`` -- test-ep configuration defaults and SQE/CQE layout
+- ``test-sdma-config`` -- SDMA endpoint config validation, host-visible type
+  defaults, and validation rules
+- ``test-sdma-packet-layout`` -- SDMA packet sizes, offsets, and
+  opcode constants
+- ``test-script-*`` -- ``bash -n`` syntax checks for build, test,
+  udev, and DKMS helper scripts
 
 System tests
 ------------

--- a/src/tester/xio-cli-options.cpp
+++ b/src/tester/xio-cli-options.cpp
@@ -33,7 +33,11 @@ static std::string transferSizeTransform(std::string& s) {
     return "Invalid transfer size (missing number)";
   unsigned long long num = 0;
   try {
-    num = std::stoull(val, nullptr, 0);
+    size_t pos = 0;
+    num = std::stoull(val, &pos, 0);
+    if (pos != val.size()) {
+      return "Transfer size must be a number (e.g. 4096 or 1M)";
+    }
   } catch (...) {
     return "Transfer size must be a number (e.g. 4096 or 1M)";
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,13 +4,17 @@
 
 # Top-level test coordinator for rocm-xio.
 #
-# Label convention (filter with ctest -L):
+# Label convention (filter with ctest -L / ctest -LE):
 #   unit        - CPU-only, no GPU or NIC required
 #   system      - Requires a HIP-capable GPU
 #   hardware    - Requires specific NIC/device hardware
 #   stress      - Long-running concurrency tests
 #   rdma        - RDMA-specific tests
 #   integration - Install + build examples against prefix
+#
+# CI (no device / no GPU): ctest --label-exclude 'hardware|system'
+# (Do not pass two -LE flags: CMake ANDs them, so each single-label test would
+# still run.)
 
 add_subdirectory(unit)
 add_subdirectory(system)

--- a/tests/system/test-ep/CMakeLists.txt
+++ b/tests/system/test-ep/CMakeLists.txt
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-# System-level tests for test-ep (require the full
-# library; emulate mode does not need a GPU).
+# System-level tests for test-ep (require the full library).  Emulate mode
+# does not need a GPU, so omit the "system" label (reserved for HIP tests
+# that require a ROCm device).
 
 xio_add_test(
   NAME test-ep-emulate
   SOURCE test-ep-emulate.hip
-  LABELS system test-ep
+  LABELS test-ep
   TIMEOUT 120
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
 )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,3 +9,10 @@ add_subdirectory(common)
 add_subdirectory(test-ep)
 add_subdirectory(rdma-ep)
 add_subdirectory(nvme-ep)
+add_subdirectory(sdma-ep)
+
+if(BUILD_CLIENTS)
+  add_subdirectory(tester)
+endif()
+
+add_subdirectory(scripts)

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -19,6 +19,13 @@ xio_add_test(
 )
 
 xio_add_test(
+  NAME test-xio-env
+  SOURCE test-xio-env.hip
+  LABELS unit common
+  TIMEOUT 30
+)
+
+xio_add_test(
   NAME test-extract-endpoint
   SOURCE test-extract-endpoint.hip
   LABELS unit common
@@ -35,6 +42,34 @@ xio_add_test(
 xio_add_test(
   NAME test-endpoint-registry
   SOURCE test-endpoint-registry.hip
+  LABELS unit common
+  TIMEOUT 30
+)
+
+xio_add_test(
+  NAME test-xio-com
+  SOURCE test-xio-com.hip
+  LABELS unit common
+  TIMEOUT 30
+)
+
+xio_add_test(
+  NAME test-xio-timing
+  SOURCE test-xio-timing.hip
+  LABELS unit common
+  TIMEOUT 60
+)
+
+xio_add_test(
+  NAME test-pci-mmio-bridge
+  SOURCE test-pci-mmio-bridge.hip
+  LABELS unit common
+  TIMEOUT 30
+)
+
+xio_add_test(
+  NAME test-tcp-exchange-layout
+  SOURCE test-tcp-exchange-layout.hip
   LABELS unit common
   TIMEOUT 30
 )

--- a/tests/unit/common/test-pci-mmio-bridge.hip
+++ b/tests/unit/common/test-pci-mmio-bridge.hip
@@ -1,0 +1,197 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for the PCI MMIO bridge shadow buffer structures and the
+ * host-side genPciMmioBridgeCmd() helper. The structures must match the
+ * out-of-process QEMU device exactly, so layout regressions are caught here
+ * at build time via static_assert and at runtime via field offsets.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+
+#include "xio-test-assert.h"
+#include "xio.h"
+
+/* ---------- Compile-time layout checks ---------- */
+
+static_assert(sizeof(xio::pci_mmio_bridge_ring_meta) == 16,
+              "pci_mmio_bridge_ring_meta size drift");
+static_assert(offsetof(xio::pci_mmio_bridge_ring_meta, producer_idx) == 0,
+              "producer_idx offset drift");
+static_assert(offsetof(xio::pci_mmio_bridge_ring_meta, consumer_idx) == 4,
+              "consumer_idx offset drift");
+static_assert(offsetof(xio::pci_mmio_bridge_ring_meta, queue_depth) == 8,
+              "queue_depth offset drift");
+static_assert(offsetof(xio::pci_mmio_bridge_ring_meta, reserved) == 12,
+              "reserved offset drift");
+
+static_assert(sizeof(xio::pci_mmio_bridge_command) == 24,
+              "pci_mmio_bridge_command size drift");
+static_assert(offsetof(xio::pci_mmio_bridge_command, target_bdf) == 0, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, target_bar) == 2, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, reserved1) == 3, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, offset) == 4, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, value) == 8, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, command) == 16, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, size) == 17, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, status) == 18, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, reserved2) == 19, "");
+static_assert(offsetof(xio::pci_mmio_bridge_command, sequence) == 20, "");
+
+int test_command_constants() {
+  ASSERT_EQ(PCI_MMIO_BRIDGE_CMD_NOP, 0);
+  ASSERT_EQ(PCI_MMIO_BRIDGE_CMD_WRITE, 1);
+  ASSERT_EQ(PCI_MMIO_BRIDGE_CMD_READ, 2);
+
+  ASSERT_EQ(PCI_MMIO_BRIDGE_STATUS_PENDING, 0);
+  ASSERT_EQ(PCI_MMIO_BRIDGE_STATUS_COMPLETE, 1);
+  ASSERT_EQ(PCI_MMIO_BRIDGE_STATUS_ERROR, 2);
+  return 0;
+}
+
+namespace {
+
+constexpr uint32_t kQueueDepth = 4;
+constexpr size_t kShadowSize = sizeof(xio::pci_mmio_bridge_ring_meta) +
+                               kQueueDepth *
+                                 sizeof(xio::pci_mmio_bridge_command);
+
+struct ShadowBuffer {
+  std::vector<uint8_t> bytes;
+  xio::pci_mmio_bridge_ring_meta* meta() {
+    return reinterpret_cast<xio::pci_mmio_bridge_ring_meta*>(bytes.data());
+  }
+  xio::pci_mmio_bridge_command* slot(uint32_t i) {
+    auto* base = bytes.data() + sizeof(xio::pci_mmio_bridge_ring_meta);
+    return reinterpret_cast<xio::pci_mmio_bridge_command*>(
+      base + i * sizeof(xio::pci_mmio_bridge_command));
+  }
+};
+
+ShadowBuffer make_shadow_buffer() {
+  ShadowBuffer s;
+  s.bytes.assign(kShadowSize, 0);
+  s.meta()->producer_idx = 0;
+  s.meta()->consumer_idx = 0;
+  s.meta()->queue_depth = kQueueDepth;
+  s.meta()->reserved = 0;
+  return s;
+}
+
+} // namespace
+
+int test_genPciMmioBridgeCmd_writes_first_slot() {
+  ShadowBuffer s = make_shadow_buffer();
+
+  xio::genPciMmioBridgeCmd(s.bytes.data(),
+                           /*targetBdf=*/0x0030,
+                           /*targetBar=*/0,
+                           /*offset=*/0x1000,
+                           /*value=*/0xDEADBEEFCAFEBABEULL,
+                           /*command=*/PCI_MMIO_BRIDGE_CMD_WRITE,
+                           /*size=*/8);
+
+  ASSERT_EQ(s.meta()->producer_idx, 1u);
+  ASSERT_EQ(s.meta()->consumer_idx, 0u);
+
+  auto* cmd = s.slot(0);
+  ASSERT_EQ(cmd->target_bdf, static_cast<uint16_t>(0x0030));
+  ASSERT_EQ(cmd->target_bar, static_cast<uint8_t>(0));
+  ASSERT_EQ(cmd->reserved1, static_cast<uint8_t>(0));
+  ASSERT_EQ(cmd->offset, 0x1000u);
+  ASSERT_EQ(cmd->value, 0xDEADBEEFCAFEBABEULL);
+  ASSERT_EQ(cmd->command, static_cast<uint8_t>(PCI_MMIO_BRIDGE_CMD_WRITE));
+  ASSERT_EQ(cmd->size, static_cast<uint8_t>(8));
+  ASSERT_EQ(cmd->status, static_cast<uint8_t>(PCI_MMIO_BRIDGE_STATUS_PENDING));
+  ASSERT_EQ(cmd->reserved2, static_cast<uint8_t>(0));
+  ASSERT_EQ(cmd->sequence, 0u);
+  return 0;
+}
+
+int test_genPciMmioBridgeCmd_advances_through_slots() {
+  ShadowBuffer s = make_shadow_buffer();
+
+  for (uint32_t i = 0; i < kQueueDepth; i++) {
+    xio::genPciMmioBridgeCmd(s.bytes.data(),
+                             /*targetBdf=*/static_cast<uint16_t>(0xAA00u + i),
+                             /*targetBar=*/static_cast<uint8_t>(i & 0xFF),
+                             /*offset=*/0x100u * i,
+                             /*value=*/0x1000ULL + i,
+                             /*command=*/PCI_MMIO_BRIDGE_CMD_WRITE,
+                             /*size=*/4);
+  }
+
+  ASSERT_EQ(s.meta()->producer_idx, kQueueDepth);
+  for (uint32_t i = 0; i < kQueueDepth; i++) {
+    auto* cmd = s.slot(i);
+    ASSERT_EQ(cmd->target_bdf, static_cast<uint16_t>(0xAA00u + i));
+    ASSERT_EQ(cmd->target_bar, static_cast<uint8_t>(i & 0xFF));
+    ASSERT_EQ(cmd->offset, 0x100u * i);
+    ASSERT_EQ(cmd->value, 0x1000ULL + i);
+    ASSERT_EQ(cmd->sequence, i);
+  }
+  return 0;
+}
+
+int test_genPciMmioBridgeCmd_wraps_around_ring() {
+  ShadowBuffer s = make_shadow_buffer();
+  s.meta()->producer_idx = kQueueDepth;
+
+  xio::genPciMmioBridgeCmd(s.bytes.data(),
+                           /*targetBdf=*/0xBEEF,
+                           /*targetBar=*/2,
+                           /*offset=*/0x2000,
+                           /*value=*/0x42ULL,
+                           /*command=*/PCI_MMIO_BRIDGE_CMD_READ,
+                           /*size=*/4);
+
+  /* slot index = producer_idx % queue_depth = 0 for the first wrap. */
+  ASSERT_EQ(s.meta()->producer_idx, kQueueDepth + 1u);
+  auto* cmd = s.slot(0);
+  ASSERT_EQ(cmd->target_bdf, static_cast<uint16_t>(0xBEEF));
+  ASSERT_EQ(cmd->offset, 0x2000u);
+  ASSERT_EQ(cmd->value, 0x42ULL);
+  ASSERT_EQ(cmd->command, static_cast<uint8_t>(PCI_MMIO_BRIDGE_CMD_READ));
+  ASSERT_EQ(cmd->sequence, 0u);
+  return 0;
+}
+
+int test_genPciMmioBridgeCmd_zero_value_and_offset() {
+  ShadowBuffer s = make_shadow_buffer();
+  xio::genPciMmioBridgeCmd(s.bytes.data(), 0, 0, 0, 0, PCI_MMIO_BRIDGE_CMD_NOP,
+                           1);
+  ASSERT_EQ(s.meta()->producer_idx, 1u);
+  auto* cmd = s.slot(0);
+  ASSERT_EQ(cmd->target_bdf, 0u);
+  ASSERT_EQ(cmd->target_bar, 0u);
+  ASSERT_EQ(cmd->offset, 0u);
+  ASSERT_EQ(cmd->value, 0ULL);
+  ASSERT_EQ(cmd->command, static_cast<uint8_t>(PCI_MMIO_BRIDGE_CMD_NOP));
+  ASSERT_EQ(cmd->size, static_cast<uint8_t>(1));
+  ASSERT_EQ(cmd->status, static_cast<uint8_t>(PCI_MMIO_BRIDGE_STATUS_PENDING));
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_command_constants();
+  failures += test_genPciMmioBridgeCmd_writes_first_slot();
+  failures += test_genPciMmioBridgeCmd_advances_through_slots();
+  failures += test_genPciMmioBridgeCmd_wraps_around_ring();
+  failures += test_genPciMmioBridgeCmd_zero_value_and_offset();
+
+  if (failures == 0) {
+    printf("All PCI MMIO bridge tests passed.\n");
+    return 0;
+  }
+  printf("%d PCI MMIO bridge test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/common/test-tcp-exchange-layout.hip
+++ b/tests/unit/common/test-tcp-exchange-layout.hip
@@ -1,0 +1,86 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for TCP exchange wire layout and byte helpers.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "tcp-exchange.hpp"
+#include "xio-test-assert.h"
+
+int test_exchange_msg_wire_layout() {
+  ASSERT_EQ(sizeof(xio::ExchangeMsg), 36u);
+  ASSERT_EQ(offsetof(xio::ExchangeMsg, qpn), 0u);
+  ASSERT_EQ(offsetof(xio::ExchangeMsg, rkey), 4u);
+  ASSERT_EQ(offsetof(xio::ExchangeMsg, lid), 8u);
+  ASSERT_EQ(offsetof(xio::ExchangeMsg, pad), 10u);
+  ASSERT_EQ(offsetof(xio::ExchangeMsg, remote_addr), 12u);
+  ASSERT_EQ(offsetof(xio::ExchangeMsg, gid), 20u);
+  ASSERT_EQ(xio::TCP_EXCHANGE_PORT, static_cast<uint16_t>(18515));
+  return 0;
+}
+
+int test_exchange_msg_field_access() {
+  xio::ExchangeMsg msg = {};
+  msg.qpn = 0x11223344u;
+  msg.rkey = 0xaabbccddu;
+  msg.lid = 0x55aau;
+  msg.pad = 0;
+  msg.remote_addr = 0x0102030405060708ULL;
+  for (unsigned i = 0; i < sizeof(msg.gid); i++) {
+    msg.gid[i] = static_cast<uint8_t>(i);
+  }
+
+  ASSERT_EQ(msg.qpn, 0x11223344u);
+  ASSERT_EQ(msg.rkey, 0xaabbccddu);
+  ASSERT_EQ(msg.lid, 0x55aau);
+  ASSERT_EQ(msg.remote_addr, 0x0102030405060708ULL);
+  ASSERT_EQ(msg.gid[15], static_cast<uint8_t>(15));
+  return 0;
+}
+
+int test_tcp_send_recv_all_socketpair() {
+  int fds[2] = {-1, -1};
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  const uint8_t tx[] = {0, 1, 2, 3, 0xaa, 0xbb, 0xcc, 0xdd};
+  uint8_t rx[sizeof(tx)] = {};
+
+  ASSERT_EQ(xio::tcp_send_all(fds[0], tx, sizeof(tx)), 0);
+  ASSERT_EQ(xio::tcp_recv_all(fds[1], rx, sizeof(rx)), 0);
+  ASSERT_EQ(memcmp(tx, rx, sizeof(tx)), 0);
+
+  close(fds[0]);
+  close(fds[1]);
+  return 0;
+}
+
+int test_tcp_helpers_reject_bad_fd() {
+  uint8_t byte = 0;
+  ASSERT_EQ(xio::tcp_send_all(-1, &byte, 1), -1);
+  ASSERT_EQ(xio::tcp_recv_all(-1, &byte, 1), -1);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_exchange_msg_wire_layout();
+  failures += test_exchange_msg_field_access();
+  failures += test_tcp_send_recv_all_socketpair();
+  failures += test_tcp_helpers_reject_bad_fd();
+
+  if (failures == 0) {
+    printf("All tcp-exchange layout tests passed.\n");
+    return 0;
+  }
+  printf("%d tcp-exchange layout test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/common/test-xio-com.hip
+++ b/tests/unit/common/test-xio-com.hip
@@ -1,0 +1,151 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for the host-side specializations of XioComEnqueue<Size>,
+ * XioComDequeue<Size>, and XioComDoorbell<T> from xio.h. These templates are
+ * the canonical 8-byte-wide store/load helpers used by every endpoint to fill
+ * SQE/WQE slots and ring doorbells. They are declared __host__ __device__, so
+ * the host path can be exercised in CPU-only CTest runs.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <hip/hip_runtime.h>
+
+#include "xio-test-assert.h"
+#include "xio.h"
+
+namespace {
+
+template <uint32_t Size>
+void check_enqueue_dequeue_pattern() {
+  static_assert(Size % sizeof(uint64_t) == 0, "Size must be multiple of 8");
+  alignas(8) uint8_t src[Size];
+  alignas(8) uint8_t dst[Size];
+  alignas(8) uint8_t readback[Size];
+
+  for (uint32_t i = 0; i < Size; i++) {
+    src[i] = static_cast<uint8_t>((i * 13 + 7) & 0xFF);
+    dst[i] = 0x00;
+    readback[i] = 0xFF;
+  }
+
+  xio::XioComEnqueue<Size>(src, dst);
+  if (memcmp(src, dst, Size) != 0) {
+    printf("XioComEnqueue<%u> did not copy bytes correctly\n", Size);
+    abort();
+  }
+
+  xio::XioComDequeue<Size>(dst, readback);
+  if (memcmp(src, readback, Size) != 0) {
+    printf("XioComDequeue<%u> did not copy bytes correctly\n", Size);
+    abort();
+  }
+}
+
+} // namespace
+
+int test_enqueue_dequeue_sizes() {
+  check_enqueue_dequeue_pattern<8>();
+  check_enqueue_dequeue_pattern<16>();
+  check_enqueue_dequeue_pattern<24>();
+  check_enqueue_dequeue_pattern<32>();
+  check_enqueue_dequeue_pattern<40>();
+  check_enqueue_dequeue_pattern<48>();
+  check_enqueue_dequeue_pattern<56>();
+  check_enqueue_dequeue_pattern<64>();
+  check_enqueue_dequeue_pattern<128>();
+  check_enqueue_dequeue_pattern<256>();
+  return 0;
+}
+
+int test_enqueue_does_not_touch_neighbors() {
+  alignas(8) uint8_t buf[64];
+  memset(buf, 0xCC, sizeof(buf));
+
+  alignas(8) uint8_t src[16];
+  memset(src, 0x55, sizeof(src));
+
+  xio::XioComEnqueue<16>(src, buf + 16);
+
+  for (uint32_t i = 0; i < 16; i++)
+    ASSERT_EQ(buf[i], static_cast<uint8_t>(0xCC));
+  for (uint32_t i = 16; i < 32; i++)
+    ASSERT_EQ(buf[i], static_cast<uint8_t>(0x55));
+  for (uint32_t i = 32; i < 64; i++)
+    ASSERT_EQ(buf[i], static_cast<uint8_t>(0xCC));
+  return 0;
+}
+
+int test_enqueue_fenced_specialization() {
+  /* Fence=true is a no-op on the host path; verify the same byte-copy
+   * semantics still hold so we do not regress the host build. */
+  alignas(8) uint64_t src = 0x0102030405060708ULL;
+  alignas(8) uint64_t dst = 0;
+  xio::XioComEnqueue<sizeof(uint64_t), true>(&src, &dst);
+  ASSERT_EQ(dst, 0x0102030405060708ULL);
+  return 0;
+}
+
+int test_doorbell_uint32() {
+  uint32_t db = 0;
+  xio::XioComDoorbell<uint32_t>(&db, 0xDEADBEEFu);
+  ASSERT_EQ(db, 0xDEADBEEFu);
+
+  xio::XioComDoorbell<uint32_t>(&db, 0u);
+  ASSERT_EQ(db, 0u);
+
+  xio::XioComDoorbell<uint32_t>(&db, 0xFFFFFFFFu);
+  ASSERT_EQ(db, 0xFFFFFFFFu);
+  return 0;
+}
+
+int test_doorbell_uint64() {
+  uint64_t db = 0;
+  xio::XioComDoorbell<uint64_t>(&db, 0x0123456789ABCDEFULL);
+  ASSERT_EQ(db, 0x0123456789ABCDEFULL);
+
+  xio::XioComDoorbell<uint64_t>(&db, 0ULL);
+  ASSERT_EQ(db, 0ULL);
+
+  xio::XioComDoorbell<uint64_t>(&db, 0xFFFFFFFFFFFFFFFFULL);
+  ASSERT_EQ(db, 0xFFFFFFFFFFFFFFFFULL);
+  return 0;
+}
+
+int test_ring_doorbell_base_offset() {
+  alignas(8) uint32_t bar[4] = {0, 0, 0, 0};
+  xio::ringDoorbell(static_cast<void*>(bar), 4u, 0x12345678u);
+  ASSERT_EQ(bar[0], 0u);
+  ASSERT_EQ(bar[1], 0x12345678u);
+  ASSERT_EQ(bar[2], 0u);
+  ASSERT_EQ(bar[3], 0u);
+
+  /* Nullptr base must be a no-op (defensive guard). */
+  xio::ringDoorbell(static_cast<void*>(nullptr), 4u, 0xFFu);
+
+  xio::ringDoorbell(static_cast<void*>(bar), 12u, 0xCAFEBABEu);
+  ASSERT_EQ(bar[3], 0xCAFEBABEu);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_enqueue_dequeue_sizes();
+  failures += test_enqueue_does_not_touch_neighbors();
+  failures += test_enqueue_fenced_specialization();
+  failures += test_doorbell_uint32();
+  failures += test_doorbell_uint64();
+  failures += test_ring_doorbell_base_offset();
+
+  if (failures == 0) {
+    printf("All XioComEnqueue/Dequeue/Doorbell tests passed.\n");
+    return 0;
+  }
+  printf("%d XioComEnqueue/Dequeue/Doorbell test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/common/test-xio-env.hip
+++ b/tests/unit/common/test-xio-env.hip
@@ -1,0 +1,139 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for rocm-xio environment parsing helpers.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "xio-env.h"
+#include "xio-test-assert.h"
+
+template <typename Fn>
+int run_in_child(Fn fn) {
+  pid_t pid = fork();
+  ASSERT_TRUE(pid >= 0);
+  if (pid == 0) {
+    fn();
+    _exit(0);
+  }
+
+  int status = 0;
+  ASSERT_EQ(waitpid(pid, &status, 0), pid);
+  ASSERT_TRUE(WIFEXITED(status));
+  ASSERT_EQ(WEXITSTATUS(status), 0);
+  return 0;
+}
+
+int test_get_env_int_default_for_unset_and_empty() {
+  unsetenv("ROCXIO_TEST_ENV_INT");
+  ASSERT_EQ(xio::getEnvInt("ROCXIO_TEST_ENV_INT", 42), 42);
+
+  setenv("ROCXIO_TEST_ENV_INT", "", 1);
+  ASSERT_EQ(xio::getEnvInt("ROCXIO_TEST_ENV_INT", 43), 43);
+  unsetenv("ROCXIO_TEST_ENV_INT");
+  return 0;
+}
+
+int test_get_env_int_decimal_values() {
+  setenv("ROCXIO_TEST_ENV_INT", "12345", 1);
+  ASSERT_EQ(xio::getEnvInt("ROCXIO_TEST_ENV_INT", 0), 12345);
+
+  setenv("ROCXIO_TEST_ENV_INT", "-7", 1);
+  ASSERT_EQ(xio::getEnvInt("ROCXIO_TEST_ENV_INT", 0), -7);
+  unsetenv("ROCXIO_TEST_ENV_INT");
+  return 0;
+}
+
+int test_get_env_int_rejects_partial_values() {
+  setenv("ROCXIO_TEST_ENV_INT", "12kb", 1);
+  ASSERT_EQ(xio::getEnvInt("ROCXIO_TEST_ENV_INT", 77), 77);
+
+  setenv("ROCXIO_TEST_ENV_INT", "0x10", 1);
+  ASSERT_EQ(xio::getEnvInt("ROCXIO_TEST_ENV_INT", 78), 78);
+  unsetenv("ROCXIO_TEST_ENV_INT");
+  return 0;
+}
+
+int test_get_env_str_default_for_unset_and_empty() {
+  unsetenv("ROCXIO_TEST_ENV_STR");
+  ASSERT_STREQ(xio::getEnvStr("ROCXIO_TEST_ENV_STR", "fallback"), "fallback");
+
+  setenv("ROCXIO_TEST_ENV_STR", "", 1);
+  ASSERT_STREQ(xio::getEnvStr("ROCXIO_TEST_ENV_STR", "empty-fallback"),
+               "empty-fallback");
+  unsetenv("ROCXIO_TEST_ENV_STR");
+  return 0;
+}
+
+int test_get_env_str_returns_value() {
+  setenv("ROCXIO_TEST_ENV_STR", "configured", 1);
+  ASSERT_STREQ(xio::getEnvStr("ROCXIO_TEST_ENV_STR", "fallback"), "configured");
+  unsetenv("ROCXIO_TEST_ENV_STR");
+  return 0;
+}
+
+int test_rocxio_verbose_initialization() {
+  return run_in_child([] {
+           unsetenv("ROCXIO_VERBOSE");
+           ASSERT_TRUE(!xio::rocxioVerbose());
+         }) +
+         run_in_child([] {
+           setenv("ROCXIO_VERBOSE", "1", 1);
+           ASSERT_TRUE(xio::rocxioVerbose());
+         }) +
+         run_in_child([] {
+           setenv("ROCXIO_VERBOSE", "true", 1);
+           ASSERT_TRUE(xio::rocxioVerbose());
+         }) +
+         run_in_child([] {
+           setenv("ROCXIO_VERBOSE", "yes", 1);
+           ASSERT_TRUE(!xio::rocxioVerbose());
+         });
+}
+
+int test_rocxio_log_level_initialization() {
+  return run_in_child([] {
+           unsetenv("ROCXIO_VERBOSE");
+           unsetenv("ROCXIO_LOG_LEVEL");
+           ASSERT_EQ(xio::rocxioLogLevel(), static_cast<int>(xio::LOG_WARN));
+         }) +
+         run_in_child([] {
+           unsetenv("ROCXIO_VERBOSE");
+           setenv("ROCXIO_LOG_LEVEL", "-10", 1);
+           ASSERT_EQ(xio::rocxioLogLevel(), static_cast<int>(xio::LOG_NONE));
+         }) +
+         run_in_child([] {
+           unsetenv("ROCXIO_VERBOSE");
+           setenv("ROCXIO_LOG_LEVEL", "99", 1);
+           ASSERT_EQ(xio::rocxioLogLevel(), static_cast<int>(xio::LOG_TRACE));
+         }) +
+         run_in_child([] {
+           setenv("ROCXIO_VERBOSE", "1", 1);
+           setenv("ROCXIO_LOG_LEVEL", "1", 1);
+           ASSERT_EQ(xio::rocxioLogLevel(), static_cast<int>(xio::LOG_INFO));
+         });
+}
+
+int main() {
+  int failures = 0;
+  failures += test_get_env_int_default_for_unset_and_empty();
+  failures += test_get_env_int_decimal_values();
+  failures += test_get_env_int_rejects_partial_values();
+  failures += test_get_env_str_default_for_unset_and_empty();
+  failures += test_get_env_str_returns_value();
+  failures += test_rocxio_verbose_initialization();
+  failures += test_rocxio_log_level_initialization();
+
+  if (failures == 0) {
+    printf("All xio-env tests passed.\n");
+    return 0;
+  }
+  printf("%d xio-env test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/common/test-xio-timing.hip
+++ b/tests/unit/common/test-xio-timing.hip
@@ -1,0 +1,160 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for updateTimingStats() and the XioTimingStats accumulator
+ * defined in xio-timing.h. These exercise the host (std::atomic) path that
+ * every endpoint uses to aggregate per-iteration durations into a single
+ * XioTimingStats instance.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+
+#include "xio-test-assert.h"
+#include "xio-timing.h"
+
+namespace {
+
+constexpr unsigned long long ULL_MAX = static_cast<unsigned long long>(-1);
+
+void reset_stats(xio::XioTimingStats& s) {
+  s.minDuration = ULL_MAX;
+  s.maxDuration = 0;
+  s.sumDuration = 0;
+  s.count = 0;
+}
+
+} // namespace
+
+int test_initial_state_after_reset() {
+  xio::XioTimingStats s;
+  ASSERT_EQ(s.minDuration, ULL_MAX);
+  ASSERT_EQ(s.maxDuration, 0ULL);
+  ASSERT_EQ(s.sumDuration, 0ULL);
+  ASSERT_EQ(s.count, 0ULL);
+  return 0;
+}
+
+int test_null_stats_is_noop() {
+  /* Must not crash and must not write through. */
+  updateTimingStats(nullptr, 100ULL);
+  updateTimingStats(nullptr, 0ULL);
+  updateTimingStats(nullptr, ULL_MAX);
+  return 0;
+}
+
+int test_single_sample() {
+  xio::XioTimingStats s;
+  reset_stats(s);
+  updateTimingStats(&s, 250ULL);
+  ASSERT_EQ(s.count, 1ULL);
+  ASSERT_EQ(s.sumDuration, 250ULL);
+  ASSERT_EQ(s.minDuration, 250ULL);
+  ASSERT_EQ(s.maxDuration, 250ULL);
+  return 0;
+}
+
+int test_min_max_track_extremes() {
+  xio::XioTimingStats s;
+  reset_stats(s);
+  updateTimingStats(&s, 500ULL);
+  updateTimingStats(&s, 100ULL);
+  updateTimingStats(&s, 800ULL);
+  updateTimingStats(&s, 300ULL);
+  updateTimingStats(&s, 200ULL);
+  ASSERT_EQ(s.count, 5ULL);
+  ASSERT_EQ(s.sumDuration, 500ULL + 100ULL + 800ULL + 300ULL + 200ULL);
+  ASSERT_EQ(s.minDuration, 100ULL);
+  ASSERT_EQ(s.maxDuration, 800ULL);
+  return 0;
+}
+
+int test_monotonic_increasing() {
+  xio::XioTimingStats s;
+  reset_stats(s);
+  for (unsigned long long i = 1; i <= 10; i++)
+    updateTimingStats(&s, i * 10ULL);
+  ASSERT_EQ(s.count, 10ULL);
+  ASSERT_EQ(s.sumDuration, 550ULL);
+  ASSERT_EQ(s.minDuration, 10ULL);
+  ASSERT_EQ(s.maxDuration, 100ULL);
+  return 0;
+}
+
+int test_monotonic_decreasing() {
+  xio::XioTimingStats s;
+  reset_stats(s);
+  for (unsigned long long i = 10; i >= 1; i--)
+    updateTimingStats(&s, i * 10ULL);
+  ASSERT_EQ(s.count, 10ULL);
+  ASSERT_EQ(s.sumDuration, 550ULL);
+  ASSERT_EQ(s.minDuration, 10ULL);
+  ASSERT_EQ(s.maxDuration, 100ULL);
+  return 0;
+}
+
+int test_zero_duration_allowed() {
+  xio::XioTimingStats s;
+  reset_stats(s);
+  updateTimingStats(&s, 0ULL);
+  ASSERT_EQ(s.count, 1ULL);
+  ASSERT_EQ(s.minDuration, 0ULL);
+  ASSERT_EQ(s.maxDuration, 0ULL);
+  return 0;
+}
+
+int test_concurrent_updates() {
+  xio::XioTimingStats s;
+  reset_stats(s);
+
+  constexpr unsigned kThreads = 8;
+  constexpr unsigned kPerThread = 1000;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (unsigned t = 0; t < kThreads; t++) {
+    threads.emplace_back([&s, t]() {
+      for (unsigned i = 0; i < kPerThread; i++) {
+        unsigned long long sample = static_cast<unsigned long long>(t + 1) *
+                                      1000ULL +
+                                    i;
+        updateTimingStats(&s, sample);
+      }
+    });
+  }
+  for (auto& th : threads)
+    th.join();
+
+  ASSERT_EQ(s.count, static_cast<unsigned long long>(kThreads) *
+                       static_cast<unsigned long long>(kPerThread));
+
+  /* Min/Max are determined by the smallest/largest sample we generated. */
+  ASSERT_EQ(s.minDuration, 1000ULL);
+  ASSERT_EQ(s.maxDuration, static_cast<unsigned long long>(kThreads) * 1000ULL +
+                             (kPerThread - 1));
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_initial_state_after_reset();
+  failures += test_null_stats_is_noop();
+  failures += test_single_sample();
+  failures += test_min_max_track_extremes();
+  failures += test_monotonic_increasing();
+  failures += test_monotonic_decreasing();
+  failures += test_zero_duration_allowed();
+  failures += test_concurrent_updates();
+
+  if (failures == 0) {
+    printf("All xio-timing tests passed.\n");
+    return 0;
+  }
+  printf("%d xio-timing test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/nvme-ep/test-nvme-helpers.hip
+++ b/tests/unit/nvme-ep/test-nvme-helpers.hip
@@ -87,6 +87,15 @@ int test_sqeSetup_nlb_one() {
   return 0;
 }
 
+int test_sqeSetup_large_nlb() {
+  struct nvme_sqe sqe = {};
+  sqeSetup(&sqe, 0x1234, 65536);
+  ASSERT_EQ(sqe.cdw10, 0x1234u);
+  ASSERT_EQ(sqe.cdw11, 0u);
+  ASSERT_EQ(sqe.cdw12, 65535u);
+  return 0;
+}
+
 /* ---- calculatePrps tests ---- */
 
 int test_prp_single_page_aligned() {
@@ -142,6 +151,35 @@ int test_prp_two_full_pages() {
   calculatePrps(addr, size, &sqe);
   ASSERT_EQ(sqe.dptr.prp.prp1, addr);
   ASSERT_EQ(sqe.dptr.prp.prp2, 0x21000u);
+  return 0;
+}
+
+int test_prp_unaligned_exact_first_page() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x10F00;
+  uint32_t size = 0x100;
+  calculatePrps(addr, size, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0u);
+  return 0;
+}
+
+int test_prp_unaligned_crosses_by_one_byte() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x10F00;
+  uint32_t size = 0x101;
+  calculatePrps(addr, size, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0x11000u);
+  return 0;
+}
+
+int test_prp_zero_size_keeps_single_prp() {
+  struct nvme_sqe sqe = {};
+  uint64_t addr = 0x12345000;
+  calculatePrps(addr, 0, &sqe);
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, 0u);
   return 0;
 }
 
@@ -837,6 +875,36 @@ int test_prp_dual_slot_list_dma_with_slot_index() {
   return 0;
 }
 
+int test_prp_list_two_pages_ignores_prp_list_dma() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[2] = {0xABCD, 0xDCBA};
+  uint64_t pageAddrs[2] = {0x100000, 0x140000};
+
+  calculatePrps(pageAddrs[0], 2 * NVME_PAGE_SIZE, &sqe, prpList, 0x777000,
+                pageAddrs, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, (uint64_t)0x100000);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0x140000);
+  ASSERT_EQ(prpList[0], (uint64_t)0xABCD);
+  ASSERT_EQ(prpList[1], (uint64_t)0xDCBA);
+  return 0;
+}
+
+int test_prp_list_unaligned_two_remaining_pages() {
+  struct nvme_sqe sqe = {};
+  uint64_t prpList[4] = {};
+  uint64_t addr = 0x200800;
+  uint32_t size = (NVME_PAGE_SIZE - 0x800) + 2 * NVME_PAGE_SIZE;
+
+  calculatePrps(addr, size, &sqe, prpList, 0x600000, nullptr, 0);
+
+  ASSERT_EQ(sqe.dptr.prp.prp1, addr);
+  ASSERT_EQ(sqe.dptr.prp.prp2, (uint64_t)0x600000);
+  ASSERT_EQ(prpList[0], (uint64_t)0x201000);
+  ASSERT_EQ(prpList[1], (uint64_t)0x202000);
+  return 0;
+}
+
 int main() {
   int failures = 0;
 
@@ -844,6 +912,7 @@ int main() {
   failures += test_sqeSetup_large_lba();
   failures += test_sqeSetup_zero_preserves();
   failures += test_sqeSetup_nlb_one();
+  failures += test_sqeSetup_large_nlb();
 
   failures += test_prp_single_page_aligned();
   failures += test_prp_single_page_fits();
@@ -851,6 +920,9 @@ int main() {
   failures += test_prp_unaligned_within_page();
   failures += test_prp_at_page_boundary();
   failures += test_prp_two_full_pages();
+  failures += test_prp_unaligned_exact_first_page();
+  failures += test_prp_unaligned_crosses_by_one_byte();
+  failures += test_prp_zero_size_keeps_single_prp();
 
   failures += test_prp_list_three_pages_contiguous();
   failures += test_prp_list_eight_pages_contiguous();
@@ -868,6 +940,8 @@ int main() {
   failures += test_prp_dual_slot_word_offset();
   failures += test_prp_dual_slot_list_dma_with_slot_index();
   failures += test_prp_single_slot_word_offset_and_dma_index();
+  failures += test_prp_list_two_pages_ignores_prp_list_dma();
+  failures += test_prp_list_unaligned_two_remaining_pages();
 
   failures += test_cqeOk_success();
   failures += test_cqeOk_success_with_phase();

--- a/tests/unit/rdma-ep/CMakeLists.txt
+++ b/tests/unit/rdma-ep/CMakeLists.txt
@@ -38,6 +38,16 @@ xio_add_test(
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
 )
 
+xio_add_test(
+  NAME test-rdma-backend-config
+  SOURCE test-rdma-backend-config.hip
+  LABELS unit rdma
+  TIMEOUT 30
+  INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
+    ${CMAKE_SOURCE_DIR}/src/common
+)
+
 # BNXT queue sizing math (CPU-only, no GPU or NIC)
 xio_add_test(
   NAME test-bnxt-sizing

--- a/tests/unit/rdma-ep/test-rdma-backend-config.hip
+++ b/tests/unit/rdma-ep/test-rdma-backend-config.hip
@@ -1,0 +1,164 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for xio::rdma_ep::make_backend_config(). The mapping from the
+ * public RdmaEpConfig / XioEndpointConfig pair to the runtime BackendConfig
+ * is critical glue: regressions here silently change provider, queue depth,
+ * inline thresholds, traffic class, or queue memory placement.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include <hip/hip_runtime.h>
+
+#include "gda-backend.hpp"
+#include "rdma-common.h"
+#include "rdma-ep.h"
+#include "xio-test-assert.h"
+#include "xio.h"
+
+using xio::XioEndpointConfig;
+using xio::rdma_ep::BackendConfig;
+using xio::rdma_ep::make_backend_config;
+using xio::rdma_ep::Provider;
+using xio::rdma_ep::QueueMemMode;
+using xio::rdma_ep::RdmaEpConfig;
+
+int test_defaults_map_to_host_coherent_loopback() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+  rcfg.provider = Provider::BNXT;
+
+  BackendConfig out = make_backend_config(cfg, rcfg, /*loopback=*/true);
+  ASSERT_EQ(out.provider, Provider::BNXT);
+  ASSERT_EQ(out.gpu_device_id, 0);
+  ASSERT_EQ(out.sq_depth, 256);
+  ASSERT_EQ(out.cq_depth, 256);
+  ASSERT_EQ(out.inline_threshold, 28u);
+  ASSERT_TRUE(!out.pcie_relaxed_ordering);
+  ASSERT_EQ(out.traffic_class, 0);
+  ASSERT_TRUE(out.loopback);
+  ASSERT_TRUE(!out.pci_mmio_bridge);
+  ASSERT_TRUE(out.queue_mem == QueueMemMode::HOST_COHERENT);
+  ASSERT_TRUE(out.hca_list == nullptr);
+  return 0;
+}
+
+int test_loopback_flag_passthrough() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+  BackendConfig out_lb = make_backend_config(cfg, rcfg, /*loopback=*/true);
+  BackendConfig out_2node = make_backend_config(cfg, rcfg, /*loopback=*/false);
+  ASSERT_TRUE(out_lb.loopback);
+  ASSERT_TRUE(!out_2node.loopback);
+  return 0;
+}
+
+int test_provider_passthrough() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+  for (auto p : {Provider::BNXT, Provider::MLX5, Provider::IONIC,
+                 Provider::ROCM_ERNIC}) {
+    rcfg.provider = p;
+    BackendConfig out = make_backend_config(cfg, rcfg, true);
+    ASSERT_EQ(out.provider, p);
+  }
+  return 0;
+}
+
+int test_queue_sizing_passthrough() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+  rcfg.sqDepth = 64;
+  rcfg.cqDepth = 128;
+  rcfg.inlineThreshold = 256;
+  rcfg.trafficClass = 3;
+  rcfg.gpuDeviceId = 5;
+  rcfg.pcieRelaxedOrdering = true;
+  BackendConfig out = make_backend_config(cfg, rcfg, true);
+  ASSERT_EQ(out.sq_depth, 64);
+  ASSERT_EQ(out.cq_depth, 128);
+  ASSERT_EQ(out.inline_threshold, 256u);
+  ASSERT_EQ(out.traffic_class, 3);
+  ASSERT_EQ(out.gpu_device_id, 5);
+  ASSERT_TRUE(out.pcie_relaxed_ordering);
+  return 0;
+}
+
+int test_queue_mem_mode_follows_memory_mode_bit() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+
+  cfg.memoryMode = 0;
+  BackendConfig host = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(host.queue_mem == QueueMemMode::HOST_COHERENT);
+
+  cfg.memoryMode = XIO_MEM_MODE_SQ_DEVICE;
+  BackendConfig vram = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(vram.queue_mem == QueueMemMode::DEVICE_VRAM);
+
+  cfg.memoryMode = XIO_MEM_MODE_SQ_DEVICE | XIO_MEM_MODE_CQ_DEVICE |
+                   XIO_MEM_MODE_DATA_DEVICE;
+  BackendConfig vram_full = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(vram_full.queue_mem == QueueMemMode::DEVICE_VRAM);
+
+  cfg.memoryMode = XIO_MEM_MODE_CQ_DEVICE;
+  BackendConfig host_cq = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(host_cq.queue_mem == QueueMemMode::HOST_COHERENT);
+  return 0;
+}
+
+int test_pci_mmio_bridge_passthrough() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+
+  cfg.pciMmioBridge = false;
+  BackendConfig off = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(!off.pci_mmio_bridge);
+
+  cfg.pciMmioBridge = true;
+  BackendConfig on = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(on.pci_mmio_bridge);
+  return 0;
+}
+
+int test_hca_list_empty_remains_null() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+  rcfg.deviceName = "";
+  BackendConfig out = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(out.hca_list == nullptr);
+  return 0;
+}
+
+int test_hca_list_nonempty_sets_pointer() {
+  XioEndpointConfig cfg;
+  RdmaEpConfig rcfg;
+  rcfg.deviceName = "rocm-rdma-bnxt0";
+  BackendConfig out = make_backend_config(cfg, rcfg, true);
+  ASSERT_TRUE(out.hca_list != nullptr);
+  ASSERT_EQ(std::string(out.hca_list), std::string("rocm-rdma-bnxt0"));
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_defaults_map_to_host_coherent_loopback();
+  failures += test_loopback_flag_passthrough();
+  failures += test_provider_passthrough();
+  failures += test_queue_sizing_passthrough();
+  failures += test_queue_mem_mode_follows_memory_mode_bit();
+  failures += test_pci_mmio_bridge_passthrough();
+  failures += test_hca_list_empty_remains_null();
+  failures += test_hca_list_nonempty_sets_pointer();
+
+  if (failures == 0) {
+    printf("All make_backend_config tests passed.\n");
+    return 0;
+  }
+  printf("%d make_backend_config test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/rdma-ep/test-rdma-common.hip
+++ b/tests/unit/rdma-ep/test-rdma-common.hip
@@ -7,12 +7,15 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 
 #include <endian.h>
 
+#include "gda-backend.hpp"
 #include "ibv-core.hpp"
 #include "rdma-common.h"
 #include "xio-test-assert.h"
+#include "xio.h"
 
 int test_provider_allowed_names() {
   ASSERT_STREQ(xio::rdma_ep::provider_allowed_names(),
@@ -86,6 +89,77 @@ int test_rd_atomic_cap() {
   return 0;
 }
 
+int test_fill_rc_qp_init_attr() {
+  struct ibv_qp_init_attr_ex attr;
+  memset(&attr, 0xA5, sizeof(attr));
+  auto* pd = reinterpret_cast<struct ibv_pd*>(static_cast<uintptr_t>(0x1000));
+  auto* cq = reinterpret_cast<struct ibv_cq*>(static_cast<uintptr_t>(0x2000));
+
+  xio::rdma_ep::fill_rc_qp_init_attr(&attr, pd, cq, 17, 3, 2, 28);
+
+  ASSERT_EQ(attr.send_cq, cq);
+  ASSERT_EQ(attr.recv_cq, cq);
+  ASSERT_EQ(attr.srq, nullptr);
+  ASSERT_EQ(attr.cap.max_send_wr, 17u);
+  ASSERT_EQ(attr.cap.max_recv_wr, 3u);
+  ASSERT_EQ(attr.cap.max_send_sge, 1u);
+  ASSERT_EQ(attr.cap.max_recv_sge, 2u);
+  ASSERT_EQ(attr.cap.max_inline_data, 28u);
+  ASSERT_EQ(attr.qp_type, IBV_QPT_RC);
+  ASSERT_EQ(attr.sq_sig_all, 0);
+  ASSERT_EQ(attr.comp_mask, static_cast<uint32_t>(IBV_QP_INIT_ATTR_PD));
+  ASSERT_EQ(attr.pd, pd);
+  return 0;
+}
+
+int test_make_backend_config_host_queues() {
+  xio::XioEndpointConfig config;
+  config.memoryMode = 0;
+  config.pciMmioBridge = true;
+
+  xio::rdma_ep::RdmaEpConfig rdma;
+  rdma.provider = xio::rdma_ep::Provider::IONIC;
+  rdma.gpuDeviceId = 2;
+  rdma.sqDepth = 512;
+  rdma.cqDepth = 1024;
+  rdma.inlineThreshold = 64;
+  rdma.pcieRelaxedOrdering = true;
+  rdma.trafficClass = 6;
+  rdma.deviceName = "rocm-rdma-ionic0";
+
+  xio::rdma_ep::BackendConfig backend =
+    xio::rdma_ep::make_backend_config(config, rdma, false);
+
+  ASSERT_EQ(backend.provider, xio::rdma_ep::Provider::IONIC);
+  ASSERT_EQ(backend.gpu_device_id, 2);
+  ASSERT_EQ(backend.sq_depth, 512);
+  ASSERT_EQ(backend.cq_depth, 1024);
+  ASSERT_EQ(backend.inline_threshold, 64u);
+  ASSERT_TRUE(backend.pcie_relaxed_ordering);
+  ASSERT_EQ(backend.traffic_class, 6);
+  ASSERT_TRUE(!backend.loopback);
+  ASSERT_TRUE(backend.pci_mmio_bridge);
+  ASSERT_EQ(backend.queue_mem, xio::rdma_ep::QueueMemMode::HOST_COHERENT);
+  ASSERT_STREQ(backend.hca_list, "rocm-rdma-ionic0");
+  return 0;
+}
+
+int test_make_backend_config_device_queues() {
+  xio::XioEndpointConfig config;
+  config.memoryMode = XIO_MEM_MODE_SQ_DEVICE;
+
+  xio::rdma_ep::RdmaEpConfig rdma;
+  rdma.deviceName.clear();
+
+  xio::rdma_ep::BackendConfig backend =
+    xio::rdma_ep::make_backend_config(config, rdma, true);
+
+  ASSERT_TRUE(backend.loopback);
+  ASSERT_EQ(backend.queue_mem, xio::rdma_ep::QueueMemMode::DEVICE_VRAM);
+  ASSERT_EQ(backend.hca_list, nullptr);
+  return 0;
+}
+
 int main() {
   int failures = 0;
   failures += test_provider_allowed_names();
@@ -93,6 +167,9 @@ int main() {
   failures += test_normalize_qp_key_native_providers();
   failures += test_normalize_mr_keys();
   failures += test_rd_atomic_cap();
+  failures += test_fill_rc_qp_init_attr();
+  failures += test_make_backend_config_host_queues();
+  failures += test_make_backend_config_device_queues();
 
   if (failures == 0) {
     printf("All rdma-common tests passed.\n");

--- a/tests/unit/rdma-ep/test-rdma-config.hip
+++ b/tests/unit/rdma-ep/test-rdma-config.hip
@@ -72,8 +72,21 @@ int test_config_defaults() {
   ASSERT_EQ(cfg.cqDepth, 256u);
   ASSERT_EQ(cfg.transferSize, 4096u);
   ASSERT_EQ(cfg.inlineThreshold, 28u);
+  ASSERT_TRUE(!cfg.pcieRelaxedOrdering);
+  ASSERT_EQ(cfg.trafficClass, 0);
   ASSERT_TRUE(cfg.loopback);
   ASSERT_EQ(cfg.gpuDeviceId, 0);
+  ASSERT_TRUE(!cfg.verify);
+  ASSERT_EQ(cfg.seed, 1u);
+  ASSERT_EQ(cfg.queueMem, xio::rdma_ep::QueueMemMode::HOST_COHERENT);
+  ASSERT_EQ(cfg.batchSize, 1u);
+  ASSERT_EQ(cfg.numQueues, 1u);
+  ASSERT_TRUE(!cfg.infiniteMode);
+  ASSERT_TRUE(!cfg.isServer);
+  ASSERT_TRUE(!cfg.isClient);
+  ASSERT_TRUE(cfg.serverHost.empty());
+  ASSERT_EQ(cfg.ppSize, 64u);
+  ASSERT_EQ(cfg.ppIters, 100u);
   return 0;
 }
 
@@ -103,6 +116,74 @@ int test_config_validate_zero_iterations() {
   return 0;
 }
 
+int test_config_validate_infinite_mode() {
+  xio::rdma_ep::RdmaEpConfig cfg;
+  cfg.providerStr = "bnxt";
+  cfg.iterations = 99;
+  cfg.infiniteMode = true;
+  std::string err = xio::rdma_ep::validateConfig(&cfg);
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(cfg.iterations, 0u);
+  ASSERT_EQ(xio::rdma_ep::getIterations(&cfg), 0u);
+  return 0;
+}
+
+int test_config_validate_bad_queue_settings() {
+  xio::rdma_ep::RdmaEpConfig cfg;
+  cfg.providerStr = "bnxt";
+
+  cfg.sqDepth = 0;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "SQ depth must be > 0");
+
+  cfg.sqDepth = 256;
+  cfg.transferSize = 0;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "Transfer size must be > 0");
+
+  cfg.transferSize = 4096;
+  cfg.batchSize = 256;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "--batch-size must be < --sq-depth");
+  return 0;
+}
+
+int test_config_validate_2node_modes() {
+  xio::rdma_ep::RdmaEpConfig cfg;
+  cfg.providerStr = "bnxt";
+  cfg.loopback = false;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "--no-loopback requires --server or --client");
+
+  cfg.isClient = true;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "--client requires --server-host");
+
+  cfg.serverHost = "127.0.0.1";
+  cfg.ppSize = 15;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "Ping-pong size must be >= 16 bytes"
+               " (8-byte seq header + payload)");
+
+  cfg.ppSize = 18;
+  ASSERT_STREQ(xio::rdma_ep::validateConfig(&cfg).c_str(),
+               "Ping-pong size must be a multiple of 8"
+               " (PingPongBuf alignment)");
+
+  cfg.ppSize = 64;
+  ASSERT_TRUE(xio::rdma_ep::validateConfig(&cfg).empty());
+  return 0;
+}
+
+int test_get_iterations_default_and_config() {
+  ASSERT_EQ(xio::rdma_ep::getIterations(nullptr), 128u);
+
+  xio::rdma_ep::RdmaEpConfig cfg;
+  cfg.iterations = 17;
+  ASSERT_EQ(xio::rdma_ep::getIterations(&cfg), 17u);
+  return 0;
+}
+
 int test_config_validate_null() {
   std::string err = xio::rdma_ep::validateConfig(nullptr);
   ASSERT_TRUE(!err.empty());
@@ -118,6 +199,10 @@ int main() {
   failures += test_config_validate_good();
   failures += test_config_validate_bad_provider();
   failures += test_config_validate_zero_iterations();
+  failures += test_config_validate_infinite_mode();
+  failures += test_config_validate_bad_queue_settings();
+  failures += test_config_validate_2node_modes();
+  failures += test_get_iterations_default_and_config();
   failures += test_config_validate_null();
 
   if (failures == 0) {

--- a/tests/unit/scripts/CMakeLists.txt
+++ b/tests/unit/scripts/CMakeLists.txt
@@ -1,0 +1,83 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# CPU-only syntax checks for repository shell scripts.
+
+function(xio_add_bash_syntax_test name script)
+  add_test(NAME ${name}
+    COMMAND bash -n ${script})
+  set_tests_properties(${name} PROPERTIES
+    LABELS "unit;scripts"
+    TIMEOUT 30)
+endfunction()
+
+xio_add_bash_syntax_test(
+  test-script-generate-endpoint-files
+  ${CMAKE_SOURCE_DIR}/scripts/build/generate-endpoint-files.sh)
+xio_add_bash_syntax_test(
+  test-script-generate-rdma-vendor-headers
+  ${CMAKE_SOURCE_DIR}/scripts/build/generate-rdma-vendor-headers.sh)
+xio_add_bash_syntax_test(
+  test-script-fetch-rdma-headers
+  ${CMAKE_SOURCE_DIR}/scripts/build/fetch-rdma-headers.sh)
+xio_add_bash_syntax_test(
+  test-script-build-rdma-core
+  ${CMAKE_SOURCE_DIR}/scripts/build/build-rdma-core.sh)
+xio_add_bash_syntax_test(
+  test-script-fetch-nvme-headers
+  ${CMAKE_SOURCE_DIR}/scripts/build/fetch-nvme-headers.sh)
+xio_add_bash_syntax_test(
+  test-script-extract-nvme-defines
+  ${CMAKE_SOURCE_DIR}/scripts/build/extract-nvme-defines.sh)
+xio_add_bash_syntax_test(
+  test-script-test-nvme-random-write-verify
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-nvme-ep-random-write-verify.sh)
+xio_add_bash_syntax_test(
+  test-script-test-xio-tester-nvme-ep
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-xio-tester-nvme-ep.sh)
+xio_add_bash_syntax_test(
+  test-script-test-nvme-data-verification
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-nvme-ep-data-verification.sh)
+xio_add_bash_syntax_test(
+  test-script-test-rdma-write-bw-loopback
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-rdma-ep-write-bw-loopback.sh)
+xio_add_bash_syntax_test(
+  test-script-test-rdma-verbs-loopback
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-rdma-ep-verbs-loopback.sh)
+xio_add_bash_syntax_test(
+  test-script-test-xio-tester-rdma-ep
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-xio-tester-rdma-ep.sh)
+xio_add_bash_syntax_test(
+  test-script-test-rdma-xio-loopback
+  ${CMAKE_SOURCE_DIR}/scripts/test/test-rdma-ep-xio-loopback.sh)
+xio_add_bash_syntax_test(
+  test-script-setup-rdma-loopback
+  ${CMAKE_SOURCE_DIR}/scripts/test/setup-rdma-loopback.sh)
+xio_add_bash_syntax_test(
+  test-script-run-nvme-smoke-test
+  ${CMAKE_SOURCE_DIR}/tests/system/nvme-ep/run-nvme-smoke-test.sh)
+xio_add_bash_syntax_test(
+  test-script-run-nvme-script-test
+  ${CMAKE_SOURCE_DIR}/tests/system/nvme-ep/run-nvme-script-test.sh)
+xio_add_bash_syntax_test(
+  test-script-run-2node-test
+  ${CMAKE_SOURCE_DIR}/tests/unit/rdma-ep/run-2node-test.sh)
+xio_add_bash_syntax_test(
+  test-script-run-rdma-script-test
+  ${CMAKE_SOURCE_DIR}/tests/system/rdma-ep/run-rdma-script-test.sh)
+xio_add_bash_syntax_test(
+  test-script-setup-udev-rules
+  ${CMAKE_SOURCE_DIR}/udev/setup-udev-rules.sh)
+xio_add_bash_syntax_test(
+  test-script-setup-bnxt-re-dkms
+  ${CMAKE_SOURCE_DIR}/kernel/bnxt/setup-bnxt-re-dkms.sh)
+xio_add_bash_syntax_test(
+  test-script-setup-rocm-ernic-eth-rdma-dkms
+  ${CMAKE_SOURCE_DIR}/kernel/rocm-ernic/setup-rocm-ernic-eth-rdma-dkms.sh)
+xio_add_bash_syntax_test(
+  test-script-setup-ionic-eth-rdma-dkms
+  ${CMAKE_SOURCE_DIR}/kernel/ionic/setup-ionic-eth-rdma-dkms.sh)
+xio_add_bash_syntax_test(
+  test-script-dkms-common
+  ${CMAKE_SOURCE_DIR}/kernel/dkms-common.sh)

--- a/tests/unit/sdma-ep/CMakeLists.txt
+++ b/tests/unit/sdma-ep/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# CPU-only unit tests for the sdma-ep endpoint. Device-side packet builders
+# remain in tests/system since they require a HIP-capable GPU.
+
+xio_add_test(
+  NAME test-sdma-config
+  SOURCE test-sdma-config.hip
+  LABELS unit sdma
+  TIMEOUT 30
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/sdma-ep
+)
+
+xio_add_test(
+  NAME test-sdma-packet-layout
+  SOURCE test-sdma-packet-layout.hip
+  LABELS unit sdma
+  TIMEOUT 30
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/sdma-ep
+)

--- a/tests/unit/sdma-ep/test-sdma-config.hip
+++ b/tests/unit/sdma-ep/test-sdma-config.hip
@@ -1,0 +1,160 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for sdma-ep configuration validation and host-visible types.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include "sdma-ep.h"
+#include "xio-test-assert.h"
+
+using namespace xio::sdma_ep;
+
+int test_config_defaults() {
+  SdmaEpConfig cfg;
+
+  ASSERT_TRUE(cfg.testType.empty());
+  ASSERT_TRUE(!cfg.useHostDst);
+  ASSERT_TRUE(!cfg.verifyData);
+  ASSERT_TRUE(!cfg.useCounter);
+  ASSERT_TRUE(!cfg.useFlush);
+  ASSERT_EQ(cfg.srcDeviceId, -1);
+  ASSERT_EQ(cfg.dstDeviceId, -1);
+  ASSERT_EQ(cfg.transferSize, static_cast<size_t>(4096));
+  ASSERT_EQ(cfg.iterations, 128u);
+  return 0;
+}
+
+int test_validate_null_is_noop() {
+  std::string err = validateConfig(nullptr);
+  ASSERT_TRUE(err.empty());
+  return 0;
+}
+
+int test_validate_requires_subcommand() {
+  SdmaEpConfig cfg;
+  std::string err = validateConfig(&cfg);
+  ASSERT_TRUE(!err.empty());
+  ASSERT_STREQ(err.c_str(), "Missing test subcommand. Available: "
+                            "p2p, ping-pong, buffer-reuse");
+  return 0;
+}
+
+int test_validate_accepts_supported_subcommands() {
+  const char* names[] = {"p2p", "ping-pong", "buffer-reuse"};
+  for (const char* name : names) {
+    SdmaEpConfig cfg;
+    cfg.testType = name;
+    std::string err = validateConfig(&cfg);
+    ASSERT_TRUE(err.empty());
+  }
+  return 0;
+}
+
+int test_validate_rejects_counter_and_flush() {
+  SdmaEpConfig cfg;
+  cfg.testType = "ping-pong";
+  cfg.useCounter = true;
+  cfg.useFlush = true;
+
+  std::string err = validateConfig(&cfg);
+  ASSERT_TRUE(!err.empty());
+  ASSERT_STREQ(err.c_str(), "Cannot use both --use-counter and "
+                            "--use-flush at the same time");
+  return 0;
+}
+
+int test_validate_transfer_size_bounds() {
+  SdmaEpConfig cfg;
+  cfg.testType = "p2p";
+  cfg.transferSize = 0;
+  ASSERT_STREQ(validateConfig(&cfg).c_str(), "transfer-size must be > 0");
+
+  cfg.transferSize = 3;
+  ASSERT_STREQ(validateConfig(&cfg).c_str(),
+               "transfer-size must be a multiple of 4 "
+               "(LFSR uses dwords)");
+
+  cfg.transferSize = 4;
+  ASSERT_TRUE(validateConfig(&cfg).empty());
+
+  cfg.transferSize = 1024 * 1024;
+  ASSERT_TRUE(validateConfig(&cfg).empty());
+  return 0;
+}
+
+int test_connection_info_fields() {
+  SdmaConnectionInfo conn{};
+  conn.srcDeviceId = 1;
+  conn.dstDeviceId = 3;
+  conn.engineId = 7;
+
+  ASSERT_EQ(conn.srcDeviceId, 1);
+  ASSERT_EQ(conn.dstDeviceId, 3);
+  ASSERT_EQ(conn.engineId, 7u);
+  return 0;
+}
+
+int test_queue_info_defaults_and_fields() {
+  SdmaQueueInfo info{};
+  ASSERT_EQ(info.deviceHandle, nullptr);
+  ASSERT_EQ(info.srcDeviceId, 0);
+  ASSERT_EQ(info.dstDeviceId, 0);
+  ASSERT_EQ(info.channelIdx, 0);
+
+  info.deviceHandle = reinterpret_cast<void*>(static_cast<uintptr_t>(0x1000));
+  info.srcDeviceId = 2;
+  info.dstDeviceId = 4;
+  info.channelIdx = 6;
+
+  ASSERT_EQ(info.deviceHandle,
+            reinterpret_cast<void*>(static_cast<uintptr_t>(0x1000)));
+  ASSERT_EQ(info.srcDeviceId, 2);
+  ASSERT_EQ(info.dstDeviceId, 4);
+  ASSERT_EQ(info.channelIdx, 6);
+  return 0;
+}
+
+int test_device_side_constants_are_sane() {
+  ASSERT_EQ(SDMA_QUEUE_SIZE, 1024u * 1024u);
+  ASSERT_TRUE((SDMA_QUEUE_SIZE & (SDMA_QUEUE_SIZE - 1)) == 0);
+  ASSERT_GT(MAX_RETRIES, 0);
+  ASSERT_TRUE(!BREAK_ON_RETRIES);
+  return 0;
+}
+
+int test_getIterations_returns_fixed_value() {
+  SdmaEpConfig cfg;
+  cfg.iterations = 999;
+  unsigned iters = getIterations(&cfg);
+  ASSERT_EQ(iters, 128u);
+  iters = getIterations(nullptr);
+  ASSERT_EQ(iters, 128u);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_config_defaults();
+  failures += test_validate_null_is_noop();
+  failures += test_validate_requires_subcommand();
+  failures += test_validate_accepts_supported_subcommands();
+  failures += test_validate_rejects_counter_and_flush();
+  failures += test_validate_transfer_size_bounds();
+  failures += test_connection_info_fields();
+  failures += test_queue_info_defaults_and_fields();
+  failures += test_device_side_constants_are_sane();
+  failures += test_getIterations_returns_fixed_value();
+
+  if (failures == 0) {
+    printf("All sdma-ep config tests passed.\n");
+    return 0;
+  }
+  printf("%d sdma-ep config test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/sdma-ep/test-sdma-packet-layout.hip
+++ b/tests/unit/sdma-ep/test-sdma-packet-layout.hip
@@ -1,0 +1,118 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for SDMA packet wire layouts and opcode constants.
+ */
+
+#include <cstddef>
+#include <cstdio>
+
+#include "sdma_pkt_struct.h"
+#include "xio-test-assert.h"
+
+int test_opcode_constants() {
+  ASSERT_EQ(SDMA_OP_NOP, 0u);
+  ASSERT_EQ(SDMA_OP_COPY, 1u);
+  ASSERT_EQ(SDMA_OP_WRITE, 2u);
+  ASSERT_EQ(SDMA_OP_FENCE, 5u);
+  ASSERT_EQ(SDMA_OP_TRAP, 6u);
+  ASSERT_EQ(SDMA_OP_POLL_REGMEM, 8u);
+  ASSERT_EQ(SDMA_OP_ATOMIC, 10u);
+  ASSERT_EQ(SDMA_OP_CONST_FILL, 11u);
+  ASSERT_EQ(SDMA_OP_TIMESTAMP, 13u);
+  ASSERT_EQ(SDMA_SUBOP_COPY_LINEAR, 0u);
+  ASSERT_EQ(SDMA_SUBOP_COPY_LINEAR_SUB_WINDOW, 36u);
+  ASSERT_EQ(SDMA_ATOMIC_ADD64, 47u);
+  return 0;
+}
+
+int test_packet_sizes() {
+  ASSERT_EQ(sizeof(SDMA_PKT_COPY_LINEAR), 7u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_WRITE_UNTILED), 5u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_FENCE), 4u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_CONSTANT_FILL), 5u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_TRAP), 2u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_POLL_REGMEM), 6u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_TIMESTAMP), 3u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_NOP), 2u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_ATOMIC), 8u * sizeof(unsigned int));
+  ASSERT_EQ(sizeof(SDMA_PKT_LINEAR_LARGE_SUB_WINDOW_COPY),
+            20u * sizeof(unsigned int));
+  return 0;
+}
+
+int test_copy_linear_dword_offsets() {
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, HEADER_UNION), 0u);
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, COUNT_UNION), 4u);
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, PARAMETER_UNION), 8u);
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, SRC_ADDR_LO_UNION), 12u);
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, SRC_ADDR_HI_UNION), 16u);
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, DST_ADDR_LO_UNION), 20u);
+  ASSERT_EQ(offsetof(SDMA_PKT_COPY_LINEAR, DST_ADDR_HI_UNION), 24u);
+  return 0;
+}
+
+int test_copy_linear_field_access() {
+  SDMA_PKT_COPY_LINEAR pkt = {};
+  pkt.HEADER_UNION.op = SDMA_OP_COPY;
+  pkt.HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR;
+  pkt.COUNT_UNION.count = 4095;
+  pkt.SRC_ADDR_LO_UNION.src_addr_31_0 = 0x11223344u;
+  pkt.SRC_ADDR_HI_UNION.src_addr_63_32 = 0x55667788u;
+  pkt.DST_ADDR_LO_UNION.dst_addr_31_0 = 0x99aabbccu;
+  pkt.DST_ADDR_HI_UNION.dst_addr_63_32 = 0xddeeff00u;
+
+  ASSERT_EQ(pkt.HEADER_UNION.op, SDMA_OP_COPY);
+  ASSERT_EQ(pkt.HEADER_UNION.sub_op, SDMA_SUBOP_COPY_LINEAR);
+  ASSERT_EQ(pkt.COUNT_UNION.count, 4095u);
+  ASSERT_EQ(pkt.SRC_ADDR_LO_UNION.src_addr_31_0, 0x11223344u);
+  ASSERT_EQ(pkt.SRC_ADDR_HI_UNION.src_addr_63_32, 0x55667788u);
+  ASSERT_EQ(pkt.DST_ADDR_LO_UNION.dst_addr_31_0, 0x99aabbccu);
+  ASSERT_EQ(pkt.DST_ADDR_HI_UNION.dst_addr_63_32, 0xddeeff00u);
+  return 0;
+}
+
+int test_atomic_packet_field_access() {
+  SDMA_PKT_ATOMIC pkt = {};
+  pkt.HEADER_UNION.op = SDMA_OP_ATOMIC;
+  pkt.HEADER_UNION.operation = SDMA_ATOMIC_ADD64;
+  pkt.ADDR_LO_UNION.addr_31_0 = 0x11111111u;
+  pkt.ADDR_HI_UNION.addr_63_32 = 0x22222222u;
+  pkt.SRC_DATA_LO_UNION.src_data_31_0 = 1u;
+  pkt.SRC_DATA_HI_UNION.src_data_63_32 = 0u;
+
+  ASSERT_EQ(pkt.HEADER_UNION.op, SDMA_OP_ATOMIC);
+  ASSERT_EQ(pkt.HEADER_UNION.operation, SDMA_ATOMIC_ADD64);
+  ASSERT_EQ(pkt.ADDR_LO_UNION.addr_31_0, 0x11111111u);
+  ASSERT_EQ(pkt.ADDR_HI_UNION.addr_63_32, 0x22222222u);
+  ASSERT_EQ(pkt.SRC_DATA_LO_UNION.src_data_31_0, 1u);
+  ASSERT_EQ(pkt.SRC_DATA_HI_UNION.src_data_63_32, 0u);
+  return 0;
+}
+
+int test_sub_window_copy_layout() {
+  ASSERT_EQ(offsetof(SDMA_PKT_LINEAR_LARGE_SUB_WINDOW_COPY, HEADER_UNION), 0u);
+  ASSERT_EQ(offsetof(SDMA_PKT_LINEAR_LARGE_SUB_WINDOW_COPY, SRC_X_UNION), 12u);
+  ASSERT_EQ(offsetof(SDMA_PKT_LINEAR_LARGE_SUB_WINDOW_COPY, DST_ADDR_LO_UNION),
+            36u);
+  ASSERT_EQ(offsetof(SDMA_PKT_LINEAR_LARGE_SUB_WINDOW_COPY, RECT_Z_UNION), 76u);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_opcode_constants();
+  failures += test_packet_sizes();
+  failures += test_copy_linear_dword_offsets();
+  failures += test_copy_linear_field_access();
+  failures += test_atomic_packet_field_access();
+  failures += test_sub_window_copy_layout();
+
+  if (failures == 0) {
+    printf("All sdma packet layout tests passed.\n");
+    return 0;
+  }
+  printf("%d sdma packet layout test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/test-ep/test-ep-config.hip
+++ b/tests/unit/test-ep/test-ep-config.hip
@@ -6,6 +6,7 @@
  */
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -60,6 +61,33 @@ int test_config_defaults() {
   ASSERT_EQ(cfg.doorbell, 0u);
   ASSERT_TRUE(!cfg.emulate);
   ASSERT_EQ(cfg.iterations, 128u);
+  ASSERT_TRUE(!cfg.verify);
+  ASSERT_EQ(cfg.seed, 1u);
+  return 0;
+}
+
+int test_sqe_field_offsets() {
+  ASSERT_EQ(offsetof(xio::test_ep::test_sqe, magic), 0u);
+  ASSERT_EQ(offsetof(xio::test_ep::test_sqe, iteration), 8u);
+  ASSERT_EQ(offsetof(xio::test_ep::test_sqe, gpuTime), 16u);
+  ASSERT_EQ(offsetof(xio::test_ep::test_sqe, data), 24u);
+  ASSERT_EQ(sizeof(((xio::test_ep::test_sqe*)nullptr)->data), 40u);
+  return 0;
+}
+
+int test_cqe_field_offsets() {
+  ASSERT_EQ(offsetof(xio::test_ep::test_cqe, magic), 0u);
+  ASSERT_EQ(offsetof(xio::test_ep::test_cqe, cpuTime), 8u);
+  return 0;
+}
+
+int test_sqe_payload_roundtrip() {
+  xio::test_ep::test_sqe sqe = {};
+  for (size_t i = 0; i < 5; i++)
+    sqe.data[i] = 0x1000 + i;
+
+  for (size_t i = 0; i < 5; i++)
+    ASSERT_EQ(sqe.data[i], 0x1000u + i);
   return 0;
 }
 
@@ -76,6 +104,9 @@ int main() {
   failures += test_sqe_struct_layout();
   failures += test_cqe_struct_layout();
   failures += test_config_defaults();
+  failures += test_sqe_field_offsets();
+  failures += test_cqe_field_offsets();
+  failures += test_sqe_payload_roundtrip();
   failures += test_type_aliases();
 
   if (failures == 0) {

--- a/tests/unit/tester/CMakeLists.txt
+++ b/tests/unit/tester/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# CPU-only unit tests for xio-tester CLI option helpers. Built like other unit
+# tests but without device RDC or hip::device linkage so the process does not
+# register GPU kernels for this TU.
+
+add_executable(test-xio-cli-options test-xio-cli-options.hip)
+
+set_target_properties(test-xio-cli-options PROPERTIES LINKER_LANGUAGE HIP)
+
+target_compile_options(test-xio-cli-options PRIVATE
+  -std=c++17
+  -Wall
+  -Wextra
+  -Wno-unused-parameter
+)
+
+target_include_directories(test-xio-cli-options PRIVATE
+  ${XIO_INCLUDE_DIR}
+  ${XIO_COMMON_DIR}
+  ${XIO_TEST_COMMON_DIR}
+  ${CMAKE_SOURCE_DIR}/src/tester
+  ${CMAKE_SOURCE_DIR}/src/endpoints/nvme-ep
+  ${CMAKE_SOURCE_DIR}/src/endpoints/rdma-ep
+  ${CMAKE_SOURCE_DIR}/src/endpoints/sdma-ep
+  ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)
+
+target_link_libraries(test-xio-cli-options PRIVATE
+  rocm-xio
+  hip::host
+  hsa-runtime64::hsa-runtime64
+  dl
+)
+
+foreach(vendor BNXT MLX5 IONIC ERNIC)
+  if(GDA_${vendor})
+    target_compile_definitions(test-xio-cli-options PRIVATE GDA_${vendor})
+  endif()
+endforeach()
+
+if(XIO_SDMA_OSS7)
+  target_compile_definitions(test-xio-cli-options PRIVATE XIO_SDMA_OSS7=1)
+endif()
+
+add_test(NAME test-xio-cli-options COMMAND test-xio-cli-options)
+set_tests_properties(test-xio-cli-options PROPERTIES
+  LABELS "unit;tester"
+  TIMEOUT 30
+)

--- a/tests/unit/tester/test-xio-cli-options.hip
+++ b/tests/unit/tester/test-xio-cli-options.hip
@@ -1,0 +1,177 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for xio-tester CLI option registration helpers.
+ */
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <CLI/CLI.hpp>
+
+#include "xio-cli-options.cpp"
+#include "xio-test-assert.h"
+
+namespace {
+
+void parse_app(CLI::App& app, std::initializer_list<const char*> args) {
+  std::vector<std::string> owned;
+  owned.emplace_back("test-xio-cli-options");
+  for (const char* a : args) {
+    owned.emplace_back(a);
+  }
+  std::vector<char*> argv;
+  for (auto& s : owned) {
+    argv.push_back(s.data());
+  }
+  app.parse(static_cast<int>(argv.size()), argv.data());
+}
+
+} // namespace
+
+int test_transfer_size_transform_plain_and_suffixes() {
+  std::string value = "4096";
+  ASSERT_TRUE(transferSizeTransform(value).empty());
+  ASSERT_STREQ(value.c_str(), "4096");
+
+  value = "4k";
+  ASSERT_TRUE(transferSizeTransform(value).empty());
+  ASSERT_STREQ(value.c_str(), "4096");
+
+  value = " 2M ";
+  ASSERT_TRUE(transferSizeTransform(value).empty());
+  ASSERT_STREQ(value.c_str(), "2097152");
+
+  value = "1G";
+  ASSERT_TRUE(transferSizeTransform(value).empty());
+  ASSERT_STREQ(value.c_str(), "1073741824");
+  return 0;
+}
+
+int test_transfer_size_transform_rejects_invalid_values() {
+  std::string value = "";
+  ASSERT_TRUE(!transferSizeTransform(value).empty());
+
+  value = "   ";
+  ASSERT_TRUE(!transferSizeTransform(value).empty());
+
+  value = "k";
+  ASSERT_STREQ(transferSizeTransform(value).c_str(),
+               "Invalid transfer size (missing number)");
+
+  value = "0";
+  ASSERT_STREQ(transferSizeTransform(value).c_str(),
+               "Transfer size must be > 0");
+
+  value = "12x";
+  ASSERT_STREQ(transferSizeTransform(value).c_str(),
+               "Transfer size must be a number (e.g. 4096 or 1M)");
+  return 0;
+}
+
+int test_detect_sdma_test_type() {
+  xio::sdma_ep::SdmaEpConfig cfg;
+  CLI::App app{"sdma"};
+  registerSdmaEpCliOptions(app, &cfg);
+
+  parse_app(app, {"p2p", "--to-host", "--verify"});
+  detectSdmaTestType(app, &cfg);
+
+  ASSERT_STREQ(cfg.testType.c_str(), "p2p");
+  ASSERT_TRUE(cfg.useHostDst);
+  ASSERT_TRUE(cfg.verifyData);
+  return 0;
+}
+
+int test_detect_sdma_ping_pong_options() {
+  xio::sdma_ep::SdmaEpConfig cfg;
+  CLI::App app{"sdma"};
+  registerSdmaEpCliOptions(app, &cfg);
+
+  parse_app(app, {"--transfer-size", "8k", "ping-pong", "--use-counter"});
+  detectSdmaTestType(app, &cfg);
+
+  ASSERT_STREQ(cfg.testType.c_str(), "ping-pong");
+  ASSERT_EQ(cfg.transferSize, static_cast<size_t>(8192));
+  ASSERT_TRUE(cfg.useCounter);
+  ASSERT_TRUE(!cfg.useFlush);
+  return 0;
+}
+
+int test_test_ep_cli_options() {
+  xio::test_ep::TestEpConfig cfg;
+  CLI::App app{"test"};
+  registerTestEpCliOptions(app, &cfg);
+
+  parse_app(app, {"--iterations", "9", "--doorbell", "32", "--emulate",
+                  "--verify", "--seed", "123"});
+
+  ASSERT_EQ(cfg.iterations, 9u);
+  ASSERT_EQ(cfg.doorbell, 32u);
+  ASSERT_TRUE(cfg.emulate);
+  ASSERT_TRUE(cfg.verify);
+  ASSERT_EQ(cfg.seed, 123u);
+  return 0;
+}
+
+int test_rdma_cli_provider_alias_and_2node_fields() {
+  xio::rdma_ep::RdmaEpConfig cfg;
+  CLI::App app{"rdma"};
+  registerRdmaEpCliOptions(app, &cfg);
+
+  parse_app(app,
+            {"--provider", "pensando", "--client", "--server-host", "127.0.0.1",
+             "--pingpong-size", "128", "--pingpong-iters", "7"});
+
+  ASSERT_STREQ(cfg.providerStr.c_str(), "pensando");
+  ASSERT_TRUE(cfg.isClient);
+  ASSERT_TRUE(!cfg.isServer);
+  ASSERT_STREQ(cfg.serverHost.c_str(), "127.0.0.1");
+  ASSERT_EQ(cfg.ppSize, 128u);
+  ASSERT_EQ(cfg.ppIters, 7u);
+  return 0;
+}
+
+int test_nvme_cli_rejects_non_power_of_two_queue_length() {
+  xio::nvme_ep::nvmeEpConfig cfg;
+  CLI::App app{"nvme"};
+  registerNvmeEpCliOptions(app, &cfg);
+
+  std::vector<std::string> args = {"--controller", "/dev/null",
+                                   "--queue-length", "100"};
+  bool threw = false;
+  try {
+    std::vector<char*> argv;
+    std::string prog = "test-xio-cli-options";
+    argv.push_back(prog.data());
+    for (auto& s : args) {
+      argv.push_back(s.data());
+    }
+    app.parse(static_cast<int>(argv.size()), argv.data());
+  } catch (const CLI::ParseError&) {
+    threw = true;
+  }
+
+  ASSERT_TRUE(threw);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_transfer_size_transform_plain_and_suffixes();
+  failures += test_transfer_size_transform_rejects_invalid_values();
+  failures += test_detect_sdma_test_type();
+  failures += test_detect_sdma_ping_pong_options();
+  failures += test_test_ep_cli_options();
+  failures += test_rdma_cli_provider_alias_and_2node_fields();
+  failures += test_nvme_cli_rejects_non_power_of_two_queue_length();
+
+  if (failures == 0) {
+    printf("All xio-cli-options tests passed.\n");
+    return 0;
+  }
+  printf("%d xio-cli-options test(s) failed.\n", failures);
+  return 1;
+}


### PR DESCRIPTION
Add and register HIP unit tests for common helpers (env, COM, timing, TCP exchange layout, PCI MMIO bridge), SDMA config and packet layout, RdmaEp backend config plus extra rdma-ep and test-ep coverage, extended NVMe helper PRP cases, and xio-tester CLI option parsing.

Wire tests/unit/scripts (bash -n on repo scripts), tester targets behind BUILD_CLIENTS, and small CMake helper updates. Reject partial stoull matches in transferSizeTransform so suffix garbage like 12x is invalid.

Update docs/how-to/testing.rst CTest inventory for the new entries.
