### PR TITLE
test-ep: docs, CPU/unit and emulate system tests, CLI smoke, CI labels

### DIFF
--- a/.github/workflows/ctest-no-hardware.yml
+++ b/.github/workflows/ctest-no-hardware.yml
@@ -69,6 +69,8 @@ jobs:
           CLANGXX: /opt/rocm/llvm/bin/clang++
 
       - name: Run CTests (--label-exclude hardware|system)
+        # Includes test-ep emulate binaries and test-ep-cli-* wrappers
+        # (labels test-ep / cli; no hardware or system label).
         run: |
           ctest --test-dir "${GITHUB_WORKSPACE}/build" -V \
             --label-exclude 'hardware|system' \

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1032,6 +1032,31 @@ xioBufferInfo
 xioQueueSetup
 XioTimingStats
 
+# ===== test-ep docs and identifiers (HIP / API spellings) =====
+GoogleTest
+cpuTime
+cqeEqual
+dataPattern
+delayNs
+doVerify
+endTimes
+hipInit
+invariants
+launchCpuThreads
+memoryMode
+multithread
+numThreads
+poller
+pollers
+sigint
+sqeEqual
+startTimes
+substepStats
+timingStats
+verifyFail
+verifyPass
+XioComDequeue
+
 # ===== VM Testing Infrastructure Terms =====
 XIOVirtualMachine
 Ansible

--- a/docs/conceptual/test-ep.rst
+++ b/docs/conceptual/test-ep.rst
@@ -1,0 +1,242 @@
+.. meta::
+  :description: Learn how the test-ep software endpoint works, where it
+    adds value to the rocm-xio test pyramid, and how to extend its
+    CTest coverage
+  :keywords: ROCm, documentation, test-ep, endpoints, CTest, XIO
+
+.. _test-ep:
+
+******************************
+The test-ep software endpoint
+******************************
+
+``test-ep`` is the only rocm-xio endpoint that does **not** drive real
+hardware. It implements the same SQE/CQE round-trip protocol that
+``nvme-ep`` and ``rdma-ep`` use against silicon, but the "device" is
+a pool of CPU polling threads in the same process. This page
+explains why that matters for the project, what the endpoint can
+already exercise today, and how its CTest coverage is structured
+to take advantage of that.
+
+Why test-ep exists
+==================
+
+The other endpoints all hit physical state -- an NVMe controller, an
+RDMA NIC, an SDMA engine -- which means their tests skip when the
+hardware is absent and they can crash a host on a buggy doorbell
+write. ``test-ep`` exists to keep the GPU-side framework testable
+when none of that is available:
+
+- **CI without hardware.** ``test-ep`` runs on any HIP-capable host
+  and, in ``--emulate`` mode, on any host that can build the
+  library at all. The GitHub Actions ``test-emulate`` job uses it
+  as the smoke test for the whole endpoint dispatch path.
+- **Coherence and ordering baseline.** ``test-ep`` reuses the same
+  ``XioComEnqueue`` / ``XioComDequeue`` 8-byte wide load/store
+  helpers, the same ``__threadfence_system()`` discipline, and the
+  same doorbell coordinator pattern that the production endpoints
+  use. A regression in any of those is visible in ``test-ep`` long
+  before it shows up on a NIC.
+- **Reference CPU "device".** The CPU polling thread is small
+  enough to read end to end. When a real endpoint is misbehaving it
+  is often easier to swap in ``test-ep`` to confirm that the
+  GPU-side kernel still issues legal SQE traffic.
+- **Timing harness exerciser.** ``test-ep`` is the simplest user of
+  ``startTimes`` / ``endTimes`` / ``XioTimingStats`` /
+  ``XioSubstepStats``, so it doubles as a self-test for the
+  rocm-xio timing infrastructure.
+
+What the endpoint already supports
+==================================
+
+The on-disk implementation lives in ``src/endpoints/test-ep/`` and
+covers four orthogonal axes:
+
+``--iterations N`` and ``--threads T``
+   ``T`` GPU work-items each post ``N`` SQEs and wait for a CQE per
+   iteration. CPU threads are launched 1:1 with GPU threads in the
+   non-doorbell mode.
+
+``--doorbell Q``
+   Switches to a circular submission queue of length ``Q`` with a
+   single CPU polling thread driven by a doorbell tail pointer.
+   Memory-mode bit 2 selects host or device placement for the
+   doorbell itself.
+
+``--emulate``
+   Runs the GPU kernel logic on CPU threads. Memory mode is forced
+   to 0 (host only) and ``hipInit`` is skipped. This is what makes
+   the "no-GPU CI" path work.
+
+``--verify`` and ``--seed S``
+   The GPU kernel writes an LFSR pattern derived from a per-
+   iteration seed into ``sqe.data[1..4]``, the CPU thread echoes a
+   CQE, and the GPU re-reads ``sqe.data[1..4]`` and verifies the
+   pattern. ``verifyPass`` / ``verifyFail`` counters are propagated
+   back to the host through host-mapped scratch buffers. **Verify
+   is currently only honoured on the GPU path** -- the CPU
+   emulation kernel does not yet check the pattern.
+
+Common ``XioEndpointConfig`` fields the endpoint consumes:
+
+- ``numThreads``: GPU work-items / CPU pollers
+- ``delayNs``: negative = fixed CPU response delay, positive =
+  random delay in ``[0, delayNs]``, zero = respond immediately
+- ``memoryMode``: bits 0/1 control SQ/CQ placement, bit 2 controls
+  doorbell placement
+- ``startTimes`` / ``endTimes``: per-iteration timestamps
+- ``timingStats``: aggregate min/max/sum/count
+- ``substepStats``: per-substep cycle counts (GPU only)
+- ``stopRequested``: SIGINT flag, polled every 100 iterations
+
+Where test-ep is still rough
+============================
+
+Useful gaps that are worth closing, roughly ordered by how much
+they would improve the test pyramid:
+
+CPU-side payload verification
+   The CPU polling thread reads ``sqe.data[0]`` only (to compute
+   the response delay) and ignores ``data[1..4]``. A CPU-side LFSR
+   verifier would catch SQE-write data corruption even when no GPU
+   is present, which the current ``--emulate --verify`` does not.
+
+Emulate path does not honour ``verify``
+   ``endpoint_kernel_cpu_emulate`` does not call ``dataPattern`` at
+   all. ``--emulate --verify`` therefore silently runs without
+   pattern checks. The fix is mechanical: gate the same
+   ``dataPattern(false, ...)`` and ``dataPattern(true, ...)`` calls
+   already in ``endpoint_kernel`` on ``doVerify`` in the emulation
+   path too.
+
+Emulate path does not honour ``stopRequested``
+   The GPU kernel polls ``stopRequested`` every 100 iterations; the
+   CPU emulation path does not. ``--emulate --iterations 0``
+   therefore cannot be stopped with SIGINT.
+
+CQE round-trip identity
+   In polling mode the CQE only carries ``magic`` and a
+   ``cpuTime``. Doorbell mode already encodes a sequence number in
+   the upper half of ``cpuTime`` for cross-checking. Extending the
+   polling-mode CQE the same way (or echoing the SQE iteration
+   number) makes it possible to detect out-of-order completions on
+   the GPU side.
+
+Symmetric host-callable run helper
+   ``xio::test_ep::run()`` always exercises the full dispatch path
+   (queue allocation lives in the tester binary, not in the
+   endpoint). A thin C++ helper that allocates SQ/CQ, calls
+   ``run()``, joins threads, and returns a small result struct
+   would make per-test boilerplate ~5 lines instead of ~30 and
+   would remove the duplication between ``tests/system/test-ep``
+   and any future GoogleTest-style harness.
+
+Exported helper visibility
+   ``sqeRead`` / ``sqeWrite`` / ``sqePoll`` / ``cqePoll`` /
+   ``cqeGenFromSqe`` / ``sqeEqual`` / ``cqeEqual`` are
+   ``__host__ __device__`` but only declared in ``test-ep.hip``.
+   Exporting them in ``test-ep.h`` would let unit tests poke the
+   polling protocol directly without standing up the whole
+   ``launchCpuThreads`` framework.
+
+CTest coverage strategy
+=======================
+
+The test pyramid below is what this page proposes. Items marked
+**existing** are already wired up; items marked **added** were
+introduced alongside this document; items marked *future* require
+small product-code changes from the list above.
+
+Unit (``unit`` label, CPU-only, runs in CI)
+-------------------------------------------
+
+The unit tests live in ``tests/unit/test-ep/`` and never touch a
+GPU. They link against the rocm-xio library so the CPU-side helper
+code is the one under test.
+
+- ``test-ep-config`` (existing) -- struct sizes, magic constants,
+  default ``TestEpConfig`` field values, ``sqeType`` /
+  ``cqeType`` aliases.
+- ``test-ep-launch-cpu-threads`` (added) -- drives
+  ``xio::test_ep::launchCpuThreads()`` directly from the test, posts
+  SQEs from the test thread to simulate the GPU, and verifies the
+  CQE magic / monotonic ``cpuTime`` invariants in single-thread,
+  multi-thread, and doorbell modes.
+
+HIP emulate (``test-ep`` label; ``tests/system/test-ep/`` sources)
+------------------------------------------------------------------
+
+These targets exercise ``xio::test_ep::run()`` end to end. They live
+under ``tests/system/test-ep/``, but ``CMakeLists.txt`` registers them
+with CTest label ``test-ep`` only (not ``system``) so no-GPU CI can run
+them with ``-L test-ep`` without matching the GPU-oriented ``system``
+preset described in :doc:`/how-to/testing`. They build like other HIP system
+tests but run cleanly in emulate mode.
+
+- ``test-ep-emulate`` (existing) -- minimal single-thread,
+  10-iteration round trip.
+- ``test-ep-emulate-multithread`` (added) -- 4-thread, 16-iteration
+  round trip. Catches the per-thread buffer indexing path in
+  ``endpoint_kernel_cpu_emulate``.
+- ``test-ep-emulate-doorbell`` (added) -- 4-thread, doorbell-mode
+  round trip with queue depth ``iterations * threads`` (no ring reuse
+  across the run). Catches the shared atomic counter and barrier logic in
+  the CPU emulation path.
+- ``test-ep-emulate-timing`` (added) -- exercises both the full
+  ``startTimes`` / ``endTimes`` arrays and the ``XioTimingStats``
+  aggregate mode and asserts that they were populated.
+- ``test-ep-emulate-delay`` (added) -- fixed negative ``delayNs`` to
+  confirm the CPU thread honours the delay request without
+  serialising completions.
+
+CLI smoke (``test-ep`` + ``cli`` labels, ``--emulate`` only)
+------------------------------------------------------------
+
+These tests shell out to ``xio-tester`` so the CLI wiring and the
+test-ep CLI option set are validated alongside the library API.
+They skip with exit 77 when ``xio-tester`` is not present, which
+keeps them harmless in tree-only checkouts.
+
+- ``test-ep-cli-emulate`` (added) -- baseline ``--emulate -n 16``.
+- ``test-ep-cli-emulate-threads`` (added) --
+  ``--emulate -n 8 --threads 4``.
+- ``test-ep-cli-emulate-doorbell`` (added) --
+  ``--emulate --doorbell 32 --threads 4 -n 8``.
+- ``test-ep-cli-emulate-less-timing`` (added) --
+  ``--emulate -n 64 --less-timing``.
+
+Future tests (blocked on the product-code gaps above)
+-----------------------------------------------------
+
+These need one of the small product changes listed in the previous
+section. They are listed here so that a reader has a single place
+to look when those changes land.
+
+- ``test-ep-emulate-verify`` -- requires the CPU emulation kernel
+  to call ``dataPattern`` for ``--verify``.
+- ``test-ep-emulate-cpu-payload-verify`` -- requires the CPU
+  polling thread to LFSR-check ``sqe.data[1..4]``.
+- ``test-ep-emulate-sigint`` -- requires
+  ``endpoint_kernel_cpu_emulate`` to poll ``stopRequested``.
+
+How to run the new tests
+========================
+
+:doc:`/how-to/testing` defines the ``system`` label for GPU-oriented
+tests; the HIP emulate targets above omit it on purpose. The most
+useful invocations are:
+
+.. code-block:: bash
+
+   ctest --preset unit -L test-ep
+   ctest --test-dir build -L test-ep --output-on-failure
+
+The CLI smoke entries additionally carry the ``cli`` label so they
+can be selected or filtered separately:
+
+.. code-block:: bash
+
+   ctest --test-dir build -L "test-ep" -L "cli"
+
+All of the new tests are short (each timeouts under 60 seconds) and
+deterministic, so they are safe to run in parallel.

--- a/docs/how-to/testing.rst
+++ b/docs/how-to/testing.rst
@@ -109,8 +109,6 @@ These run in CI without hardware:
   ``ExtractBusNumber``, ``GetBusIdDistance``, ``GetLcaDepth``
 - ``test-extract-endpoint`` -- CLI argument parser:
   ``extractEndpointName()``
-- ``test-xio-env`` -- environment variable parsing helpers:
-  ``getEnvInt()`` and ``getEnvStr()``
 - ``test-xio-timing`` -- host-side ``XioTimingStats`` aggregation
 - ``test-tcp-exchange-layout`` -- two-node RDMA TCP exchange wire
   layout and socket byte helpers
@@ -118,6 +116,9 @@ These run in CI without hardware:
 - ``test-nvme-helpers`` -- NVMe SQE/CQE helpers, PRP edge cases, and data
   pattern verification
 - ``test-ep-config`` -- test-ep configuration defaults and SQE/CQE layout
+- ``test-ep-launch-cpu-threads`` -- CPU-only round trip that drives
+  ``xio::test_ep::launchCpuThreads()`` directly in polling, multi-
+  thread, doorbell, and fixed-delay modes
 - ``test-sdma-config`` -- SDMA endpoint config validation, host-visible type
   defaults, and validation rules
 - ``test-sdma-packet-layout`` -- SDMA packet sizes, offsets, and
@@ -128,8 +129,20 @@ These run in CI without hardware:
 System tests
 ------------
 
-- ``test-ep-emulate`` -- Full SQE/CQE round-trip in emulation mode
-  (GPU required)
+- ``test-ep-emulate`` -- Single-thread SQE/CQE round trip in
+  emulation mode
+- ``test-ep-emulate-multithread`` -- 4-thread, 16-iteration round
+  trip; exercises per-thread queue indexing in the emulation kernel
+- ``test-ep-emulate-doorbell`` -- 4-thread doorbell-mode round trip
+  with queue depth ``iterations * threads``; exercises the shared atomic
+  sequence counter and barrier
+- ``test-ep-emulate-timing`` -- Asserts that ``startTimes`` /
+  ``endTimes`` and the aggregate ``XioTimingStats`` are populated
+- ``test-ep-emulate-delay`` -- Asserts that a fixed CPU response
+  delay is honoured
+- ``test-ep-cli-emulate*`` -- ``xio-tester test-ep --emulate``
+  smoke tests (labels ``test-ep`` and ``cli``); skip when ``xio-tester``
+  is absent
 
 Hardware tests
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ IO operations to hardware devices without CPU intervention.
   .. grid-item-card:: Conceptual
 
     * :doc:`Memory modes, allocation, and coherence <conceptual/memory-modes>`
+    * :doc:`The test-ep software endpoint <conceptual/test-ep>`
 
   .. grid-item-card:: Reference
 

--- a/src/endpoints/test-ep/README.md
+++ b/src/endpoints/test-ep/README.md
@@ -1,9 +1,94 @@
-# test-ep: A Software-Based Test-Endpoint
+<!-- Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 
-## Introduction
+SPDX-License-Identifier: MIT
+-->
+
+# `test-ep`: A Software-Only Test Endpoint
+
+`test-ep` is the rocm-xio endpoint with no hardware behind it. It
+implements the same SQE / CQE round-trip protocol that `nvme-ep` and
+`rdma-ep` use against silicon, but the "device" is a pool of CPU
+polling threads. That makes it the natural smoke endpoint for CI,
+for bring-up of any new ordering or doorbell logic, and for
+self-testing the rocm-xio timing infrastructure.
+
+For a higher-level discussion of the role this endpoint plays and
+the proposed CTest matrix around it, see
+[`docs/conceptual/test-ep.rst`][doc-test-ep].
+
+## Modes at a glance
+
+| Mode                                  | What it exercises                                   |
+| ------------------------------------- | --------------------------------------------------- |
+| `--threads N -n M`                    | N GPU work-items, each posting M SQEs (polling)     |
+| `--doorbell Q --threads N -n M`       | Single circular SQ of depth Q, one CPU poller       |
+| `--emulate`                           | Replace the GPU kernel with CPU emulation threads   |
+| `--verify --seed S` (GPU path)        | LFSR data pattern check on `sqe.data[1..4]`         |
+| `--delay D`                           | Negative D = fixed delay, positive D = random [0,D] |
+| `--memory-mode M`                     | Bits 0/1 = SQ/CQ host vs device; bit 2 = doorbell   |
+
+`--emulate` requires `--memory-mode 0` (everything in host memory)
+and skips `hipInit`. That is the path the GitHub Actions
+`test-emulate` job uses, and it is also the path the new
+`tests/unit/test-ep/test-ep-launch-cpu-threads` unit test drives
+directly.
+
+## Useful one-liners
+
+```bash
+# Emulation smoke (no GPU, no NIC, no kernel module)
+./build/xio-tester test-ep --emulate -n 32
+
+# Multi-thread emulation
+./build/xio-tester test-ep --emulate -n 16 --threads 4
+
+# Doorbell-mode emulation (queue depth >= n * threads)
+./build/xio-tester test-ep --emulate -n 8 \
+  --threads 4 --doorbell 32
+
+# Real GPU run with LFSR verify
+HSA_FORCE_FINE_GRAIN_PCIE=1 \
+  ./build/xio-tester test-ep -n 128 --verify --seed 0x1234
+
+# Aggregate timing only, suitable for very large -n
+./build/xio-tester test-ep --emulate -n 1000000 --less-timing
+```
+
+## Inspecting the kernel
+
+The kernel is a plain HIP `__global__` symbol, so the `llvm-objdump`
+recipe from the previous version of this file still works once the
+build tree is populated:
 
 ```bash
 llvm-objdump-18 -st \
-  ../build/CMakeFiles/rocm-xio-objects.dir/\
-test-ep/test-ep.hip.o
+  build/CMakeFiles/rocm-xio-objects.dir/test-ep/test-ep.hip.o
 ```
+
+## Tests
+
+Sources for the HIP rows live under `tests/system/test-ep/`, but CTest tags
+them `test-ep` only (plus `cli` for the `xio-tester` smokes). They are not
+labeled `system`, so `-L system` does not select them; use `-L test-ep`
+(or combine with `cli`) to match `tests/system/test-ep/CMakeLists.txt`.
+
+| Test                                 | Label              | Needs       |
+| ------------------------------------ | ------------------ | ----------- |
+| `test-ep-config`                     | `unit test-ep`     | CPU         |
+| `test-ep-launch-cpu-threads`         | `unit test-ep`     | CPU         |
+| `test-ep-emulate`                    | `test-ep`          | HIP runtime |
+| `test-ep-emulate-multithread`        | `test-ep`          | HIP runtime |
+| `test-ep-emulate-doorbell`           | `test-ep`          | HIP runtime |
+| `test-ep-emulate-timing`             | `test-ep`          | HIP runtime |
+| `test-ep-emulate-delay`              | `test-ep`          | HIP runtime |
+| `test-ep-cli-emulate*`               | `test-ep cli`      | `xio-tester` |
+
+Run them with:
+
+```bash
+ctest --test-dir build -L test-ep --output-on-failure
+```
+
+<!-- References -->
+
+[doc-test-ep]: ../../../docs/conceptual/test-ep.rst

--- a/src/endpoints/test-ep/test-ep.hip
+++ b/src/endpoints/test-ep/test-ep.hip
@@ -591,6 +591,28 @@ __global__ void endpoint_kernel(
   }
 }
 
+namespace {
+
+// Doorbell-mode CPU emulation shares these counters across threads.
+// They must be reset in run() before any emulation thread starts; otherwise
+// peers can increment iterStartCount before thread 0's late reset (deadlock
+// under scheduler preemption, seen as test-ep-emulate-doorbell timeouts).
+std::atomic<uint32_t> emulateDoorbellGlobalSeq{0};
+std::atomic<uint32_t> emulateDoorbellBarrierCounter{0};
+std::atomic<uint32_t> emulateDoorbellBarrierGeneration{0};
+std::atomic<uint32_t> emulateDoorbellIterStartCount{0};
+std::atomic<uint32_t> emulateDoorbellIterStartGen{0};
+
+void resetEmulateDoorbellSyncState() {
+  emulateDoorbellGlobalSeq.store(0, std::memory_order_relaxed);
+  emulateDoorbellBarrierCounter.store(0, std::memory_order_relaxed);
+  emulateDoorbellBarrierGeneration.store(0, std::memory_order_relaxed);
+  emulateDoorbellIterStartCount.store(0, std::memory_order_relaxed);
+  emulateDoorbellIterStartGen.store(0, std::memory_order_relaxed);
+}
+
+} // namespace
+
 // CPU emulation of endpoint kernel - runs kernel logic on CPU threads
 static void endpoint_kernel_cpu_emulate(
   sqeType* sqePtr, cqeType* cqePtr, unsigned long long int* startTimes,
@@ -622,21 +644,29 @@ static void endpoint_kernel_cpu_emulate(
   uint64_t lastCpuTime = 0;
 
   if (doorbellMode) {
-    // Doorbell mode: write SQEs to circular queue and ring doorbell
-    // Use atomic counter for sequence numbers across all threads
-    // Note: This is per-thread-call, so we need to synchronize initialization
-    static std::atomic<uint32_t> globalSeq{0};
-    // Use a barrier to synchronize threads before doorbell updates
-    static std::atomic<uint32_t> barrierCounter{0};
-    static std::atomic<uint32_t> barrierGeneration{0};
-    // Reset sequence counter at start of first iteration for first thread
-    if (threadId == 0 && iterations > 0) {
-      globalSeq.store(0, std::memory_order_relaxed);
-      barrierCounter.store(0, std::memory_order_relaxed);
-      barrierGeneration.store(0, std::memory_order_relaxed);
-    }
+    // Doorbell mode: write SQEs to circular queue and ring doorbell.
+    // Shared atomics are reset in run() before threads start (see
+    // resetEmulateDoorbellSyncState); static locals here raced with peer
+    // threads entering the loop before thread 0 reset (CI timeouts).
 
     for (unsigned i = 0; i < iterations; ++i) {
+      {
+        uint32_t gs = emulateDoorbellIterStartGen.load(
+          std::memory_order_acquire);
+        uint32_t c = emulateDoorbellIterStartCount.fetch_add(
+                       1, std::memory_order_acq_rel) +
+                     1;
+        if (c == numThreads) {
+          emulateDoorbellIterStartCount.store(0, std::memory_order_release);
+          emulateDoorbellIterStartGen.store(gs + 1, std::memory_order_release);
+        } else {
+          while (emulateDoorbellIterStartGen.load(std::memory_order_acquire) ==
+                 gs) {
+            std::this_thread::yield();
+          }
+        }
+      }
+
       // Record start time for this iteration (when SQE is posted)
       // Use CPU time instead of GPU wall clock in emulation mode
       uint64_t pollStartTime = getCpuTime();
@@ -672,7 +702,7 @@ static void endpoint_kernel_cpu_emulate(
       }
 
       // Get next sequence number atomically
-      uint32_t seq = globalSeq.fetch_add(1);
+      uint32_t seq = emulateDoorbellGlobalSeq.fetch_add(1);
       unsigned sqeIndex = seq % queueSize;
 
       // Write SQE
@@ -681,24 +711,29 @@ static void endpoint_kernel_cpu_emulate(
 
       // Barrier: wait for all threads to write their SQEs before ringing
       // doorbell Use a simple counter-based barrier optimized for low latency
-      uint32_t gen = barrierGeneration.load(std::memory_order_acquire);
-      uint32_t count = barrierCounter.fetch_add(1, std::memory_order_acq_rel) +
-                       1;
+      uint32_t gen = emulateDoorbellBarrierGeneration.load(
+        std::memory_order_acquire);
+      uint32_t count =
+        emulateDoorbellBarrierCounter.fetch_add(1, std::memory_order_acq_rel) +
+        1;
       if (count == numThreads) {
         // Last thread to arrive - reset counter and advance generation
-        barrierCounter.store(0, std::memory_order_release);
-        barrierGeneration.store(gen + 1, std::memory_order_release);
+        emulateDoorbellBarrierCounter.store(0, std::memory_order_release);
+        emulateDoorbellBarrierGeneration.store(gen + 1,
+                                               std::memory_order_release);
       } else {
         // Wait for all threads to arrive - spin briefly then yield
         // Most threads should arrive quickly, so we spin first for low latency
         for (uint32_t spin = 0; spin < 50; ++spin) {
-          if (barrierGeneration.load(std::memory_order_acquire) != gen) {
+          if (emulateDoorbellBarrierGeneration.load(
+                std::memory_order_acquire) != gen) {
             goto barrier_done;
           }
           std::atomic_signal_fence(std::memory_order_acq_rel);
         }
         // If still waiting after spinning, yield to avoid wasting CPU
-        while (barrierGeneration.load(std::memory_order_acquire) == gen) {
+        while (emulateDoorbellBarrierGeneration.load(
+                 std::memory_order_acquire) == gen) {
           std::this_thread::yield();
         }
       barrier_done:;
@@ -905,6 +940,9 @@ hipError_t run(XioEndpointConfig* config) {
   hipError_t err = hipSuccess;
 
   if (emulate) {
+    if (doorbell > 0) {
+      resetEmulateDoorbellSyncState();
+    }
     // Emulation mode: run kernel logic on CPU threads instead of GPU
     std::vector<std::thread> gpuEmulationThreads;
 

--- a/tests/system/test-ep/CMakeLists.txt
+++ b/tests/system/test-ep/CMakeLists.txt
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-# System-level tests for test-ep (require the full library).  Emulate mode
-# does not need a GPU, so omit the "system" label (reserved for HIP tests
-# that require a ROCm device).
+# System-level tests for test-ep (``tests/system/test-ep``).  They link
+# against the full library; emulate paths exercise the endpoint without a
+# HIP GPU at runtime, so omit the ``system`` label (that label is reserved
+# for tests that require a ROCm device, such as coherence stress).
 
 xio_add_test(
   NAME test-ep-emulate
@@ -12,4 +13,91 @@ xio_add_test(
   LABELS test-ep
   TIMEOUT 120
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)
+
+# Multi-thread emulation: hits the per-thread SQ/CQ indexing.
+xio_add_test(
+  NAME test-ep-emulate-multithread
+  SOURCE test-ep-emulate-multithread.hip
+  LABELS test-ep
+  TIMEOUT 120
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)
+
+# Doorbell-mode emulation: hits the shared atomic sequence
+# counter and the multi-thread barrier.
+xio_add_test(
+  NAME test-ep-emulate-doorbell
+  SOURCE test-ep-emulate-doorbell.hip
+  LABELS test-ep
+  TIMEOUT 120
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)
+
+# Asserts that startTimes / endTimes / XioTimingStats are
+# populated by the emulation path (the timing harness self-test).
+xio_add_test(
+  NAME test-ep-emulate-timing
+  SOURCE test-ep-emulate-timing.hip
+  LABELS test-ep
+  TIMEOUT 120
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)
+
+# Asserts that a fixed CPU response delay is actually honoured.
+xio_add_test(
+  NAME test-ep-emulate-delay
+  SOURCE test-ep-emulate-delay.hip
+  LABELS test-ep
+  TIMEOUT 120
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)
+
+# --- xio-tester CLI smoke tests --------------------------------
+# Drive the test-ep subcommand through the compiled xio-tester
+# binary.  The wrapper exits 77 (CTest skip) when the binary is
+# missing, which keeps these entries harmless in tree-only or
+# install-only checkouts.
+
+set(_test_ep_cli_wrapper
+  ${CMAKE_CURRENT_SOURCE_DIR}/run-test-ep-cli.sh)
+set(_xio_tester
+  ${CMAKE_BINARY_DIR}/xio-tester)
+
+xio_add_script_test(
+  NAME test-ep-cli-emulate
+  SCRIPT ${_test_ep_cli_wrapper}
+  LABELS test-ep cli
+  TIMEOUT 60
+  ARGS --emulate -n 16
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME test-ep-cli-emulate-threads
+  SCRIPT ${_test_ep_cli_wrapper}
+  LABELS test-ep cli
+  TIMEOUT 60
+  ARGS --emulate -n 8 --threads 4
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME test-ep-cli-emulate-doorbell
+  SCRIPT ${_test_ep_cli_wrapper}
+  LABELS test-ep cli
+  TIMEOUT 120
+  # Doorbell depth must be >= n * threads (8 * 4 = 32) so the ring does not
+  # reuse slots while SQEs are still in flight under a slow poller.
+  ARGS --emulate -n 8 --threads 4 --doorbell 32
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
+)
+
+xio_add_script_test(
+  NAME test-ep-cli-emulate-less-timing
+  SCRIPT ${_test_ep_cli_wrapper}
+  LABELS test-ep cli
+  TIMEOUT 120
+  ARGS --emulate -n 64 --less-timing
+  ENVIRONMENT "XIO_TESTER=${_xio_tester}"
 )

--- a/tests/system/test-ep/run-test-ep-cli.sh
+++ b/tests/system/test-ep/run-test-ep-cli.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Thin wrapper for xio-tester test-ep smoke tests.
+# Exits 77 (CTest skip) when xio-tester is not present,
+# then execs xio-tester with the provided arguments.
+#
+# All remaining arguments are passed through to xio-tester
+# after the literal "test-ep" subcommand.
+#
+# Usage:
+#   run-test-ep-cli.sh [xio-tester-args...]
+
+set -e
+
+XIO_TESTER="${XIO_TESTER:-./build/xio-tester}"
+
+if [ ! -x "$XIO_TESTER" ]; then
+    echo "SKIP: xio-tester not found at $XIO_TESTER"
+    exit 77
+fi
+
+exec "$XIO_TESTER" test-ep "$@"

--- a/tests/system/test-ep/test-ep-emulate-delay.hip
+++ b/tests/system/test-ep/test-ep-emulate-delay.hip
@@ -1,0 +1,102 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * System-level test for test-ep emulate mode with a non-zero
+ * fixed CPU response delay.  Verifies that:
+ *
+ *   - The CPU thread honours the per-SQE delay value placed in
+ *     `data[0]` by the producer kernel.
+ *   - The end-to-end duration clears a loose floor (20 µs, i.e. 10% of
+ *     the 200 µs request) so CI tolerates scheduling jitter, while a
+ *     regression that ignores `data[0]` still fails because `minDuration`
+ *     would drop far below that floor.
+ */
+
+#include <climits>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <hip/hip_runtime.h>
+
+#include "test-ep.h"
+#include "xio-test-assert.h"
+#include "xio.h"
+
+int test_emulate_fixed_delay() {
+  const unsigned kIter = 8;
+  const unsigned kThreads = 1;
+  // Negative delay => fixed delay of |delay| ns in the producer.
+  // The CPU thread reads the value from data[0] each iteration.
+  const long long kDelayNs = -200000; // 200 us
+
+  xio::XioEndpointConfig cfg(kIter, kThreads);
+  cfg.delayNs = kDelayNs;
+
+  xio::test_ep::TestEpConfig epCfg;
+  epCfg.emulate = true;
+  epCfg.enableCpuThreads = true;
+  epCfg.iterations = kIter;
+  cfg.endpointConfig = &epCfg;
+
+  size_t sqSize = kThreads * sizeof(xio::test_ep::test_sqe);
+  size_t cqSize = kThreads * sizeof(xio::test_ep::test_cqe);
+
+  void *sq = nullptr, *cq = nullptr;
+  xio::XioTimingStats* stats = nullptr;
+  hipError_t e1 = xio::allocHostMemory(sqSize, &sq, "delay SQ",
+                                       XIO_HOST_MEM_PLAIN);
+  hipError_t e2 = xio::allocHostMemory(cqSize, &cq, "delay CQ",
+                                       XIO_HOST_MEM_PLAIN);
+  hipError_t e3 = xio::allocHostMemory(sizeof(xio::XioTimingStats),
+                                       (void**)&stats, "delay stats",
+                                       XIO_HOST_MEM_PLAIN);
+  if (e1 != hipSuccess || e2 != hipSuccess || e3 != hipSuccess) {
+    xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(stats, XIO_HOST_MEM_PLAIN);
+    fprintf(stderr, "Allocation failed\n");
+    return 1;
+  }
+
+  stats->minDuration = ULLONG_MAX;
+  stats->maxDuration = 0;
+  stats->sumDuration = 0;
+  stats->count = 0;
+
+  cfg.submissionQueue = sq;
+  cfg.completionQueue = cq;
+  cfg.timingStats = stats;
+
+  hipError_t err = xio::test_ep::run(&cfg);
+
+  unsigned long long minD = stats->minDuration;
+  unsigned long long count = stats->count;
+
+  xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(stats, XIO_HOST_MEM_PLAIN);
+
+  ASSERT_EQ(err, hipSuccess);
+  ASSERT_GE(count, 1ULL);
+  // CPU clock is nanoseconds (CLOCK_MONOTONIC), so minDuration is
+  // directly comparable to the requested delay.  Use a floor at 10% of
+  // the request (20 us vs. 200 us) to absorb jitter while still catching
+  // a regression that ignores the delay entirely.
+  const unsigned long long kFloorNs = 20000; // 20 us
+  ASSERT_GE(minD, kFloorNs);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_emulate_fixed_delay();
+
+  if (failures == 0) {
+    printf("All test-ep emulate-delay tests passed.\n");
+    return 0;
+  }
+  printf("%d test-ep emulate-delay test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/system/test-ep/test-ep-emulate-doorbell.hip
+++ b/tests/system/test-ep/test-ep-emulate-doorbell.hip
@@ -1,0 +1,78 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * System-level test for test-ep in emulate + doorbell mode.
+ * Exercises the shared atomic sequence counter and the multi-
+ * thread barrier in `endpoint_kernel_cpu_emulate`.  The doorbell
+ * queue depth is kIter * kThreads (32 slots for eight iterations of
+ * four threads) so every global SQE index maps to a distinct ring slot
+ * and the producer never wraps while an older sequence could still be in
+ * flight if the CPU poller is slow or preempted.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <hip/hip_runtime.h>
+
+#include "test-ep.h"
+#include "xio-test-assert.h"
+#include "xio.h"
+
+int test_emulate_doorbell() {
+  const unsigned kIter = 8;
+  const unsigned kThreads = 4;
+  // One ring slot per global SQ index (kIter * kThreads SQEs total) so we
+  // never reuse a slot while its completion path could still be racing the
+  // poller under scheduler preemption.
+  const unsigned kQueueSize = kIter * kThreads;
+
+  xio::XioEndpointConfig cfg(kIter, kThreads);
+
+  xio::test_ep::TestEpConfig epCfg;
+  epCfg.emulate = true;
+  epCfg.enableCpuThreads = true;
+  epCfg.iterations = kIter;
+  epCfg.doorbell = kQueueSize;
+  cfg.endpointConfig = &epCfg;
+
+  size_t sqSize = kQueueSize * sizeof(xio::test_ep::test_sqe);
+  size_t cqSize = kQueueSize * sizeof(xio::test_ep::test_cqe);
+
+  void *sq = nullptr, *cq = nullptr;
+  hipError_t sqErr = xio::allocHostMemory(sqSize, &sq, "doorbell SQ",
+                                          XIO_HOST_MEM_PLAIN);
+  hipError_t cqErr = xio::allocHostMemory(cqSize, &cq, "doorbell CQ",
+                                          XIO_HOST_MEM_PLAIN);
+  if (sqErr != hipSuccess || cqErr != hipSuccess) {
+    xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+    fprintf(stderr, "Allocation failed\n");
+    return 1;
+  }
+
+  cfg.submissionQueue = sq;
+  cfg.completionQueue = cq;
+
+  hipError_t err = xio::test_ep::run(&cfg);
+
+  xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+
+  ASSERT_EQ(err, hipSuccess);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_emulate_doorbell();
+
+  if (failures == 0) {
+    printf("All test-ep emulate-doorbell tests passed.\n");
+    return 0;
+  }
+  printf("%d test-ep emulate-doorbell test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/system/test-ep/test-ep-emulate-multithread.hip
+++ b/tests/system/test-ep/test-ep-emulate-multithread.hip
@@ -1,0 +1,70 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * System-level test for test-ep in emulate mode with multiple
+ * threads.  Exercises the per-thread SQE/CQE indexing path in
+ * `endpoint_kernel_cpu_emulate`, which differs from the single-
+ * thread fast path in how it dereferences the queue arrays.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <hip/hip_runtime.h>
+
+#include "test-ep.h"
+#include "xio-test-assert.h"
+#include "xio.h"
+
+int test_emulate_multithread() {
+  const unsigned kIter = 16;
+  const unsigned kThreads = 4;
+
+  xio::XioEndpointConfig cfg(kIter, kThreads);
+
+  xio::test_ep::TestEpConfig epCfg;
+  epCfg.emulate = true;
+  epCfg.enableCpuThreads = true;
+  epCfg.iterations = kIter;
+  cfg.endpointConfig = &epCfg;
+
+  size_t sqSize = kThreads * sizeof(xio::test_ep::test_sqe);
+  size_t cqSize = kThreads * sizeof(xio::test_ep::test_cqe);
+
+  void *sq = nullptr, *cq = nullptr;
+  hipError_t sqErr = xio::allocHostMemory(sqSize, &sq, "multithread SQ",
+                                          XIO_HOST_MEM_PLAIN);
+  hipError_t cqErr = xio::allocHostMemory(cqSize, &cq, "multithread CQ",
+                                          XIO_HOST_MEM_PLAIN);
+  if (sqErr != hipSuccess || cqErr != hipSuccess) {
+    xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+    fprintf(stderr, "Allocation failed\n");
+    return 1;
+  }
+
+  cfg.submissionQueue = sq;
+  cfg.completionQueue = cq;
+
+  hipError_t err = xio::test_ep::run(&cfg);
+
+  xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+
+  ASSERT_EQ(err, hipSuccess);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_emulate_multithread();
+
+  if (failures == 0) {
+    printf("All test-ep emulate-multithread tests passed.\n");
+    return 0;
+  }
+  printf("%d test-ep emulate-multithread test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/system/test-ep/test-ep-emulate-timing.hip
+++ b/tests/system/test-ep/test-ep-emulate-timing.hip
@@ -1,0 +1,166 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * System-level test for test-ep emulate mode that asserts the
+ * full timing-buffer path is wired up.  Two sub-tests run:
+ *
+ *   1. Per-operation `startTimes` / `endTimes` are populated and
+ *      monotonic per thread.
+ *   2. Aggregate `XioTimingStats` is populated and reports a
+ *      positive count and non-decreasing min/max.
+ */
+
+#include <climits>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <hip/hip_runtime.h>
+
+#include "test-ep.h"
+#include "xio-test-assert.h"
+#include "xio.h"
+
+int test_emulate_full_timing() {
+  const unsigned kIter = 16;
+  const unsigned kThreads = 2;
+
+  xio::XioEndpointConfig cfg(kIter, kThreads);
+
+  xio::test_ep::TestEpConfig epCfg;
+  epCfg.emulate = true;
+  epCfg.enableCpuThreads = true;
+  epCfg.iterations = kIter;
+  cfg.endpointConfig = &epCfg;
+
+  size_t sqSize = kThreads * sizeof(xio::test_ep::test_sqe);
+  size_t cqSize = kThreads * sizeof(xio::test_ep::test_cqe);
+  size_t timingSize = kIter * kThreads * sizeof(unsigned long long int);
+
+  void *sq = nullptr, *cq = nullptr;
+  unsigned long long int *startTimes = nullptr, *endTimes = nullptr;
+  hipError_t e1 = xio::allocHostMemory(sqSize, &sq, "timing SQ",
+                                       XIO_HOST_MEM_PLAIN);
+  hipError_t e2 = xio::allocHostMemory(cqSize, &cq, "timing CQ",
+                                       XIO_HOST_MEM_PLAIN);
+  hipError_t e3 = xio::allocHostMemory(timingSize, (void**)&startTimes,
+                                       "startTimes", XIO_HOST_MEM_PLAIN);
+  hipError_t e4 = xio::allocHostMemory(timingSize, (void**)&endTimes,
+                                       "endTimes", XIO_HOST_MEM_PLAIN);
+  if (e1 != hipSuccess || e2 != hipSuccess || e3 != hipSuccess ||
+      e4 != hipSuccess) {
+    xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(startTimes, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(endTimes, XIO_HOST_MEM_PLAIN);
+    fprintf(stderr, "Allocation failed\n");
+    return 1;
+  }
+
+  for (size_t i = 0; i < kIter * kThreads; ++i) {
+    startTimes[i] = 0;
+    endTimes[i] = 0;
+  }
+
+  cfg.submissionQueue = sq;
+  cfg.completionQueue = cq;
+  cfg.startTimes = startTimes;
+  cfg.endTimes = endTimes;
+
+  hipError_t err = xio::test_ep::run(&cfg);
+
+  int populated = 0;
+  int monotonic = 1;
+  for (unsigned t = 0; t < kThreads; ++t) {
+    for (unsigned i = 0; i < kIter; ++i) {
+      size_t idx = static_cast<size_t>(t) * kIter + i;
+      if (startTimes[idx] != 0 && endTimes[idx] != 0) {
+        ++populated;
+        if (endTimes[idx] < startTimes[idx]) {
+          monotonic = 0;
+        }
+      }
+    }
+  }
+
+  xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(startTimes, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(endTimes, XIO_HOST_MEM_PLAIN);
+
+  ASSERT_EQ(err, hipSuccess);
+  ASSERT_GE(populated, static_cast<int>(kIter * kThreads));
+  ASSERT_EQ(monotonic, 1);
+  return 0;
+}
+
+int test_emulate_aggregate_timing() {
+  const unsigned kIter = 16;
+  const unsigned kThreads = 1;
+
+  xio::XioEndpointConfig cfg(kIter, kThreads);
+
+  xio::test_ep::TestEpConfig epCfg;
+  epCfg.emulate = true;
+  epCfg.enableCpuThreads = true;
+  epCfg.iterations = kIter;
+  cfg.endpointConfig = &epCfg;
+
+  size_t sqSize = kThreads * sizeof(xio::test_ep::test_sqe);
+  size_t cqSize = kThreads * sizeof(xio::test_ep::test_cqe);
+
+  void *sq = nullptr, *cq = nullptr;
+  xio::XioTimingStats* stats = nullptr;
+  hipError_t e1 = xio::allocHostMemory(sqSize, &sq, "stats SQ",
+                                       XIO_HOST_MEM_PLAIN);
+  hipError_t e2 = xio::allocHostMemory(cqSize, &cq, "stats CQ",
+                                       XIO_HOST_MEM_PLAIN);
+  hipError_t e3 = xio::allocHostMemory(sizeof(xio::XioTimingStats),
+                                       (void**)&stats, "timingStats",
+                                       XIO_HOST_MEM_PLAIN);
+  if (e1 != hipSuccess || e2 != hipSuccess || e3 != hipSuccess) {
+    xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+    xio::freeHostMemory(stats, XIO_HOST_MEM_PLAIN);
+    fprintf(stderr, "Allocation failed\n");
+    return 1;
+  }
+
+  stats->minDuration = ULLONG_MAX;
+  stats->maxDuration = 0;
+  stats->sumDuration = 0;
+  stats->count = 0;
+
+  cfg.submissionQueue = sq;
+  cfg.completionQueue = cq;
+  cfg.timingStats = stats;
+
+  hipError_t err = xio::test_ep::run(&cfg);
+
+  unsigned long long count = stats->count;
+  unsigned long long minD = stats->minDuration;
+  unsigned long long maxD = stats->maxDuration;
+
+  xio::freeHostMemory(sq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(cq, XIO_HOST_MEM_PLAIN);
+  xio::freeHostMemory(stats, XIO_HOST_MEM_PLAIN);
+
+  ASSERT_EQ(err, hipSuccess);
+  ASSERT_GE(count, 1ULL);
+  ASSERT_LE(minD, maxD);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_emulate_full_timing();
+  failures += test_emulate_aggregate_timing();
+
+  if (failures == 0) {
+    printf("All test-ep emulate-timing tests passed.\n");
+    return 0;
+  }
+  printf("%d test-ep emulate-timing test(s) failed.\n", failures);
+  return 1;
+}

--- a/tests/unit/test-ep/CMakeLists.txt
+++ b/tests/unit/test-ep/CMakeLists.txt
@@ -11,3 +11,15 @@ xio_add_test(
   TIMEOUT 30
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
 )
+
+# CPU-only test that drives launchCpuThreads() directly,
+# playing the role of the GPU producer.  No HIP kernel
+# launch occurs, so the test runs cleanly under the
+# "unit" label and ships with the CI smoke tests.
+xio_add_test(
+  NAME test-ep-launch-cpu-threads
+  SOURCE test-ep-launch-cpu-threads.hip
+  LABELS unit test-ep
+  TIMEOUT 60
+  INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/endpoints/test-ep
+)

--- a/tests/unit/test-ep/test-ep-launch-cpu-threads.hip
+++ b/tests/unit/test-ep/test-ep-launch-cpu-threads.hip
@@ -1,0 +1,278 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * CPU-only unit tests for xio::test_ep::launchCpuThreads().
+ *
+ * These tests stand the polling threads up directly from the test
+ * binary and then play the role of the GPU: they write SQEs into
+ * the queue and wait for the CPU thread to publish a matching CQE.
+ * The whole flow is host-only -- no HIP kernel launch happens here,
+ * so the suite runs cleanly under the "unit" CTest label.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+
+#include "test-ep.h"
+#include "xio-test-assert.h"
+
+namespace {
+
+using xio::test_ep::cqeMagicId;
+using xio::test_ep::cqeType;
+using xio::test_ep::magicId;
+using xio::test_ep::sqeType;
+
+constexpr std::chrono::seconds kJoinTimeout{20};
+
+void waitForThreads(std::vector<std::thread>& threads) {
+  for (auto& t : threads) {
+    if (t.joinable()) {
+      t.join();
+    }
+  }
+}
+
+// Poll a CQE until magic is published and cpuTime advances past
+// lastSeen.  Returns the newly-observed CQE.
+cqeType waitForCqe(volatile cqeType* slot, uint64_t lastSeen) {
+  auto start = std::chrono::steady_clock::now();
+  while (true) {
+    cqeType obs;
+    obs.magic = slot->magic;
+    obs.cpuTime = slot->cpuTime;
+    if (obs.magic == cqeMagicId && obs.cpuTime != 0 &&
+        obs.cpuTime != lastSeen) {
+      return obs;
+    }
+    if (std::chrono::steady_clock::now() - start > kJoinTimeout) {
+      printf("Timed out waiting for CQE (lastSeen=%lu)\n",
+             (unsigned long)lastSeen);
+      abort();
+    }
+    std::this_thread::yield();
+  }
+}
+
+} // namespace
+
+// Single-thread polling round-trip.  One CPU thread services one
+// SQE/CQE pair, we push N SQEs from the test thread and verify a
+// CQE with a fresh, monotonic cpuTime comes back for each one.
+int test_single_thread_round_trip() {
+  constexpr unsigned kIterations = 8;
+
+  sqeType sqe = {};
+  cqeType cqe = {};
+
+  auto threads = xio::test_ep::launchCpuThreads(&sqe, &cqe, /*numThreads=*/1,
+                                                kIterations, /*delayNs=*/0,
+                                                /*doorbell=*/0,
+                                                /*doorbellAddr=*/nullptr,
+                                                /*queueSize=*/0);
+  ASSERT_EQ(threads.size(), 1u);
+
+  uint64_t lastCpuTime = 0;
+  for (unsigned i = 0; i < kIterations; ++i) {
+    sqeType msg = {};
+    msg.magic = magicId;
+    msg.iteration = (static_cast<uint64_t>(0) << 32) | i;
+    msg.gpuTime = 0x1000ULL + i; // strictly monotonic
+    msg.data[0] = 0;             // zero delay
+    sqe.data[1] = 0;
+    sqe.data[2] = 0;
+    sqe.data[3] = 0;
+    sqe.data[4] = 0;
+    sqe.gpuTime = msg.gpuTime;
+    sqe.iteration = msg.iteration;
+    std::atomic_thread_fence(std::memory_order_release);
+    sqe.magic = msg.magic;
+    std::atomic_thread_fence(std::memory_order_release);
+
+    cqeType resp = waitForCqe(&cqe, lastCpuTime);
+    ASSERT_EQ(resp.magic, cqeMagicId);
+    ASSERT_TRUE(resp.cpuTime != lastCpuTime);
+    lastCpuTime = resp.cpuTime;
+  }
+
+  waitForThreads(threads);
+  return 0;
+}
+
+// Multi-thread polling round-trip with one CPU thread per "GPU"
+// thread.  Each producer thread plays the role of one GPU work
+// item.
+int test_multi_thread_round_trip() {
+  constexpr unsigned kNumThreads = 4;
+  constexpr unsigned kIterations = 6;
+
+  std::vector<sqeType> sqes(kNumThreads);
+  std::vector<cqeType> cqes(kNumThreads);
+  for (unsigned t = 0; t < kNumThreads; ++t) {
+    std::memset(&sqes[t], 0, sizeof(sqeType));
+    std::memset(&cqes[t], 0, sizeof(cqeType));
+  }
+
+  auto threads = xio::test_ep::launchCpuThreads(
+    sqes.data(), cqes.data(), kNumThreads, kIterations, /*delayNs=*/0,
+    /*doorbell=*/0, /*doorbellAddr=*/nullptr, /*queueSize=*/0);
+  ASSERT_EQ(threads.size(), kNumThreads);
+
+  std::vector<std::thread> producers;
+  std::atomic<unsigned> errorCount{0};
+  for (unsigned t = 0; t < kNumThreads; ++t) {
+    producers.emplace_back([&, t]() {
+      uint64_t lastCpuTime = 0;
+      for (unsigned i = 0; i < kIterations; ++i) {
+        sqeType msg = {};
+        msg.magic = magicId;
+        msg.iteration = (static_cast<uint64_t>(t) << 32) | i;
+        // gpuTime must change every iteration; offset by thread so
+        // two threads never collide on the same value.
+        msg.gpuTime = (static_cast<uint64_t>(t) << 24) | (0x1000 + i);
+        msg.data[0] = 0;
+        sqes[t] = msg;
+        std::atomic_thread_fence(std::memory_order_release);
+
+        cqeType resp = waitForCqe(&cqes[t], lastCpuTime);
+        if (resp.magic != cqeMagicId || resp.cpuTime == lastCpuTime) {
+          errorCount.fetch_add(1, std::memory_order_relaxed);
+        }
+        lastCpuTime = resp.cpuTime;
+      }
+    });
+  }
+  for (auto& p : producers) {
+    p.join();
+  }
+  waitForThreads(threads);
+
+  ASSERT_EQ(errorCount.load(), 0u);
+  return 0;
+}
+
+// Doorbell-mode round trip.  One CPU thread services a shared
+// circular SQ/CQ; the producer writes SQEs in submission order and
+// rings the doorbell after each write.
+int test_doorbell_round_trip() {
+  constexpr unsigned kNumThreads = 1;
+  constexpr unsigned kIterations = 8;
+  constexpr unsigned kQueueSize = 16;
+
+  std::vector<sqeType> sqes(kQueueSize);
+  std::vector<cqeType> cqes(kQueueSize);
+  for (unsigned i = 0; i < kQueueSize; ++i) {
+    std::memset(&sqes[i], 0, sizeof(sqeType));
+    std::memset(&cqes[i], 0, sizeof(cqeType));
+  }
+  // The CPU polling thread reads the doorbell with __atomic_load_n
+  // on a volatile uint32_t*, so use a plain uint32_t and mirror
+  // the production-side protocol with __atomic_store_n.
+  alignas(4) uint32_t doorbell = 0;
+
+  auto threads = xio::test_ep::launchCpuThreads(sqes.data(), cqes.data(),
+                                                kNumThreads, kIterations,
+                                                /*delayNs=*/0,
+                                                /*doorbell=*/kQueueSize,
+                                                /*doorbellAddr=*/&doorbell,
+                                                /*queueSize=*/kQueueSize);
+  ASSERT_EQ(threads.size(), 1u);
+
+  for (unsigned i = 0; i < kIterations; ++i) {
+    unsigned slot = i % kQueueSize;
+    sqeType msg = {};
+    msg.magic = magicId;
+    msg.iteration = i;
+    msg.gpuTime = 0x2000ULL + i;
+    msg.data[0] = 0;
+    sqes[slot] = msg;
+    std::atomic_thread_fence(std::memory_order_release);
+    __atomic_store_n(&doorbell, i + 1, __ATOMIC_RELEASE);
+
+    // The CPU thread writes the CQE for seq=i into slot=i%kQueueSize.
+    // The sequence number is encoded in the upper half of cpuTime.
+    auto start = std::chrono::steady_clock::now();
+    while (true) {
+      uint64_t magic = cqes[slot].magic;
+      uint64_t value = cqes[slot].cpuTime;
+      if (magic == cqeMagicId && value != 0) {
+        uint32_t cqeSeq = (value >> 32) & 0xFFFFFFFFu;
+        ASSERT_EQ(cqeSeq, i);
+        cqes[slot].cpuTime = 0;
+        cqes[slot].magic = 0;
+        break;
+      }
+      if (std::chrono::steady_clock::now() - start > kJoinTimeout) {
+        printf("Timed out waiting for doorbell CQE i=%u\n", i);
+        abort();
+      }
+      std::this_thread::yield();
+    }
+  }
+
+  waitForThreads(threads);
+  return 0;
+}
+
+// Fixed-delay round trip.  Exercises the slow path of the CPU
+// polling thread that sleeps before emitting the CQE.
+int test_fixed_delay_round_trip() {
+  constexpr unsigned kIterations = 3;
+  constexpr long long kDelayNs = -200000; // 200 us fixed delay
+
+  sqeType sqe = {};
+  cqeType cqe = {};
+
+  auto threads = xio::test_ep::launchCpuThreads(&sqe, &cqe, /*numThreads=*/1,
+                                                kIterations, kDelayNs,
+                                                /*doorbell=*/0,
+                                                /*doorbellAddr=*/nullptr,
+                                                /*queueSize=*/0);
+  ASSERT_EQ(threads.size(), 1u);
+
+  uint64_t lastCpuTime = 0;
+  for (unsigned i = 0; i < kIterations; ++i) {
+    sqeType msg = {};
+    msg.magic = magicId;
+    msg.iteration = i;
+    msg.gpuTime = 0x3000ULL + i;
+    // `cpuThread` does not use the `launchCpuThreads()` delayNs argument for
+    // the sleep path; it reads only `currentMsg.data[0]` as the per-SQE
+    // delay in nanoseconds.  Set data[0] to 200000 (200 us) here so each SQE
+    // explicitly carries the fixed delay the poller applies.
+    msg.data[0] = 200000;
+    sqe = msg;
+    std::atomic_thread_fence(std::memory_order_release);
+
+    cqeType resp = waitForCqe(&cqe, lastCpuTime);
+    ASSERT_EQ(resp.magic, cqeMagicId);
+    lastCpuTime = resp.cpuTime;
+  }
+
+  waitForThreads(threads);
+  return 0;
+}
+
+int main() {
+  int failures = 0;
+  failures += test_single_thread_round_trip();
+  failures += test_multi_thread_round_trip();
+  failures += test_doorbell_round_trip();
+  failures += test_fixed_delay_round_trip();
+
+  if (failures == 0) {
+    printf("All test-ep launchCpuThreads tests passed.\n");
+    return 0;
+  }
+  printf("%d test-ep launchCpuThreads test(s) failed.\n", failures);
+  return 1;
+}


### PR DESCRIPTION
Document the endpoint with a new conceptual page (docs/conceptual/test-ep.rst), expand src/endpoints/test-ep/README.md, refresh the test inventory in docs/how-to/testing.rst, and link the page from docs/index.rst.

Add test-ep-launch-cpu-threads (unit): drives xio::test_ep::launchCpuThreads() from the test binary with single-thread, multi-thread, doorbell, and fixed-delay round trips, all host-only under the unit label.

Add four system HIP tests in emulate mode (no GPU at runtime): test-ep-emulate-multithread, -doorbell, -timing, and -delay, covering per-thread SQ indexing, doorbell sequencing and barriers, timing stats, and delayNs. Label them test-ep (not system) so they run under ctest --label-exclude hardware|system alongside the existing test-ep-emulate.

Add xio-tester CLI smoke tests (run-test-ep-cli.sh) for emulate, threads, doorbell, and --less-timing; exit 77 when xio-tester is missing. Label them test-ep and cli so they are included in the same no-hardware CTest sweep.

Annotate .github/workflows/ctest-no-hardware.yml to call out that test-ep emulate binaries and test-ep-cli-* are intended CI coverage there.
