### PR TITLE
Add HIP launch diagnostics and quiesce NVMe verify harnesses

### DIFF
--- a/scripts/test/test-nvme-ep-data-verification.sh
+++ b/scripts/test/test-nvme-ep-data-verification.sh
@@ -225,6 +225,10 @@ test_device() {
 
     echo "✓ Write completed"
 
+    # Allow controller and host driver to quiesce after GPU queue teardown
+    # before nvme-cli readback (avoids races with high QIDs / reset paths).
+    sleep 5
+
     echo ""
     echo "Step 2: Reading data back..."
 

--- a/scripts/test/test-nvme-ep-random-write-verify.sh
+++ b/scripts/test/test-nvme-ep-random-write-verify.sh
@@ -175,6 +175,9 @@ $XIO_TESTER --dump-pattern "$EXPECTED_BUF" \
     --dump-pattern-block-size "$LBA_SIZE" \
     --dump-pattern-offset 0 2>/dev/null
 
+# Quiesce before namespace readback in Step 3.
+sleep 5
+
 echo "Step 3: Computing LBAs and verifying..."
 
 python3 << PYEOF

--- a/src/common/xio-common.hip
+++ b/src/common/xio-common.hip
@@ -133,6 +133,48 @@ void printGpuDeviceDetails(int deviceId) {
   }
 }
 
+__host__ hipError_t clearHipLaunchError(const char* endpoint,
+                                        const char* kernel, uint32_t queue_id) {
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    ROCXIO_LOG_WARN("%s: cleared stale HIP error before %s "
+                    "launch for queue %u: %s (code: %d)\n",
+                    endpoint ? endpoint : "xio", kernel ? kernel : "kernel",
+                    queue_id, hipGetErrorString(err), err);
+  }
+  return err;
+}
+
+__host__ hipError_t checkHipLaunchError(const char* endpoint,
+                                        const char* kernel, uint32_t queue_id,
+                                        unsigned blocks, unsigned threads,
+                                        size_t shmem_bytes,
+                                        hipStream_t stream) {
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    ROCXIO_LOG_ERROR("%s: %s launch failed for queue %u "
+                     "(blocks=%u, threads=%u, shmem=%zu, stream=%p): "
+                     "%s (code: %d)\n",
+                     endpoint ? endpoint : "xio", kernel ? kernel : "kernel",
+                     queue_id, blocks, threads, shmem_bytes, (void*)stream,
+                     hipGetErrorString(err), err);
+  }
+  return err;
+}
+
+__host__ hipError_t syncHipKernel(const char* endpoint, const char* kernel,
+                                  uint32_t queue_id, hipStream_t stream) {
+  hipError_t err = stream ? hipStreamSynchronize(stream)
+                          : hipDeviceSynchronize();
+  if (err != hipSuccess) {
+    ROCXIO_LOG_ERROR("%s: %s sync failed for queue %u "
+                     "(stream=%p): %s (code: %d)\n",
+                     endpoint ? endpoint : "xio", kernel ? kernel : "kernel",
+                     queue_id, (void*)stream, hipGetErrorString(err), err);
+  }
+  return err;
+}
+
 void printStatistics(const std::vector<double>& durations,
                      unsigned totalIterations, unsigned numThreads,
                      unsigned readIterations, unsigned writeIterations,

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -1837,20 +1837,35 @@ __host__ hipError_t run(XioEndpointConfig* config) {
                     "(stream %p)\n",
                     qid, (void*)streams[q]);
 
+    (void)xio::clearHipLaunchError("nvme-ep", "gpuKernel", qid);
+
     hipLaunchKernelGGL(nvme_ep::gpuKernel, dim3(1), dim3(kernelThreads),
                        dynShmemBytes, streams[q], kernelConfig, ioParams,
                        qDoorbellParams, qBufParams);
+
+    hipError_t launchErr = xio::checkHipLaunchError("nvme-ep", "gpuKernel", qid,
+                                                    1, kernelThreads,
+                                                    dynShmemBytes, streams[q]);
+    if (launchErr != hipSuccess) {
+      result = launchErr;
+      goto cleanup;
+    }
   }
 
   ROCXIO_LOG_INFO("%u kernel%s launched.\n", numQueues,
                   numQueues > 1 ? "s" : "");
 
-  // Wait for all GPU kernels to complete
-  result = hipDeviceSynchronize();
-  if (result != hipSuccess) {
-    ROCXIO_LOG_INFO("Device synchronization error: "
-                    "%s (code: %d).\n",
-                    hipGetErrorString(result), result);
+  // Wait for all GPU kernels to complete.  Stream-specific sync gives a
+  // precise queue id in multi-queue mode while preserving default-stream
+  // behavior for the single-queue path.
+  for (uint16_t q = 0; q < numQueues; q++) {
+    uint16_t qid = q < nvmeConfig->queueIds.size()
+                     ? nvmeConfig->queueIds[q]
+                     : (uint16_t)(baseQueueId + q);
+    result = xio::syncHipKernel("nvme-ep", "gpuKernel", qid, streams[q]);
+    if (result != hipSuccess) {
+      goto cleanup;
+    }
   }
 
   // ---- Verify read buffers ----

--- a/src/endpoints/rdma-ep/rdma-ep.hip
+++ b/src/endpoints/rdma-ep/rdma-ep.hip
@@ -542,12 +542,17 @@ static hipError_t rdma_ep_loopback(xio::XioEndpointConfig* config,
     if (!kStats && !forceLessTiming)
       kStats = config->timingStats;
 
+    const char* kernelName = useBatch ? "rdma_ep_batch_kernel"
+                                      : "rdma_ep_kernel";
+    const unsigned launchThreads = useBatch ? batchSize + 1 : 1;
+    const size_t launchShmem = useBatch
+                                 ? batchSize * sizeof(unsigned long long int)
+                                 : 0;
+    (void)xio::clearHipLaunchError("rdma-ep", kernelName, q);
     if (useBatch) {
-      size_t shmem = batchSize * sizeof(unsigned long long int);
-      unsigned threads = batchSize + 1;
-      hipLaunchKernelGGL(rdma_ep::rdma_ep_batch_kernel, dim3(1), dim3(threads),
-                         shmem, queues[q].stream, queues[q].gpu_qp,
-                         static_cast<uint8_t*>(queues[q].buf),
+      hipLaunchKernelGGL(rdma_ep::rdma_ep_batch_kernel, dim3(1),
+                         dim3(launchThreads), launchShmem, queues[q].stream,
+                         queues[q].gpu_qp, static_cast<uint8_t*>(queues[q].buf),
                          cfg->transferSize, batchSize, config->iterations,
                          kStats, config->stopRequested, cfg->verify, cfg->seed,
                          queues[q].verifyPass, queues[q].verifyFail);
@@ -562,21 +567,21 @@ static hipError_t rdma_ep_loopback(xio::XioEndpointConfig* config,
                          config->substepStats);
     }
 
-    hipError_t le = hipGetLastError();
+    hipError_t le = xio::checkHipLaunchError("rdma-ep", kernelName, q, 1,
+                                             launchThreads, launchShmem,
+                                             queues[q].stream);
     if (le != hipSuccess) {
-      ROCXIO_LOG_ERROR("rdma-ep: Kernel launch failed"
-                       " (queue %u): %s\n",
-                       q, hipGetErrorString(le));
       result = le;
       goto cleanup;
     }
   }
 
-  {
-    hipError_t syncErr = hipDeviceSynchronize();
+  for (uint16_t q = 0; q < numQueues; q++) {
+    const char* kernelName = useBatch ? "rdma_ep_batch_kernel"
+                                      : "rdma_ep_kernel";
+    hipError_t syncErr = xio::syncHipKernel("rdma-ep", kernelName, q,
+                                            queues[q].stream);
     if (syncErr != hipSuccess) {
-      ROCXIO_LOG_ERROR("rdma-ep: Kernel sync failed: %s\n",
-                       hipGetErrorString(syncErr));
       result = syncErr;
       goto cleanup;
     }
@@ -835,9 +840,13 @@ hipError_t run(XioEndpointConfig* config) {
       ROCXIO_LOG_INFO("rdma-ep: WRITE %u bytes"
                       " to server...\n",
                       write_size);
+      (void)xio::clearHipLaunchError("rdma-ep", "rdma_write_kernel", 0);
       hipLaunchKernelGGL(rdma_write_kernel, dim3(1), dim3(1), 0, 0, gpu_qp,
                          remote_data, data_region, write_size);
-      herr = hipDeviceSynchronize();
+      herr = xio::checkHipLaunchError("rdma-ep", "rdma_write_kernel", 0, 1, 1,
+                                      0, nullptr);
+      if (herr == hipSuccess)
+        herr = xio::syncHipKernel("rdma-ep", "rdma_write_kernel", 0, nullptr);
       if (herr != hipSuccess) {
         ROCXIO_LOG_ERROR("rdma-ep: WRITE kernel failed:"
                          " %s\n",
@@ -950,11 +959,17 @@ hipError_t run(XioEndpointConfig* config) {
     }
 
     if (cfg->isClient) {
+      (void)xio::clearHipLaunchError("rdma-ep", "pingpong_client_kernel", 0);
       hipLaunchKernelGGL(pingpong_client_kernel, dim3(1), dim3(1), 0, 0, gpu_qp,
                          reinterpret_cast<PingPongBuf*>(pp_send_buf),
                          reinterpret_cast<volatile PingPongBuf*>(pp_recv_buf),
                          remote_recv, pp_size, pp_iters, d_errors, d_elapsed);
-      herr = hipDeviceSynchronize();
+      herr = xio::checkHipLaunchError("rdma-ep", "pingpong_client_kernel", 0, 1,
+                                      1, 0, nullptr);
+      if (herr == hipSuccess) {
+        herr = xio::syncHipKernel("rdma-ep", "pingpong_client_kernel", 0,
+                                  nullptr);
+      }
       if (herr != hipSuccess) {
         ROCXIO_LOG_ERROR("rdma-ep: Pingpong client kernel"
                          " failed: %s\n",
@@ -999,11 +1014,17 @@ hipError_t run(XioEndpointConfig* config) {
                       " all %u iterations correct.\n",
                       pp_iters);
     } else {
+      (void)xio::clearHipLaunchError("rdma-ep", "pingpong_server_kernel", 0);
       hipLaunchKernelGGL(pingpong_server_kernel, dim3(1), dim3(1), 0, 0, gpu_qp,
                          reinterpret_cast<PingPongBuf*>(pp_send_buf),
                          reinterpret_cast<volatile PingPongBuf*>(pp_recv_buf),
                          remote_recv, pp_size, pp_iters, d_errors);
-      herr = hipDeviceSynchronize();
+      herr = xio::checkHipLaunchError("rdma-ep", "pingpong_server_kernel", 0, 1,
+                                      1, 0, nullptr);
+      if (herr == hipSuccess) {
+        herr = xio::syncHipKernel("rdma-ep", "pingpong_server_kernel", 0,
+                                  nullptr);
+      }
       if (herr != hipSuccess) {
         ROCXIO_LOG_ERROR("rdma-ep: Pingpong server kernel"
                          " failed: %s\n",

--- a/src/endpoints/sdma-ep/sdma-ep.hip
+++ b/src/endpoints/sdma-ep/sdma-ep.hip
@@ -926,10 +926,17 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_p2p_kernel", 0);
     hipLaunchKernelGGL(sdma_p2p_kernel, dim3(numBlocks), dim3(threadsPerBlock),
                        0, 0, sdmaHandles[0], dstBuf, srcBuf, transferSize,
                        config->iterations, signals[0][0], config->startTimes,
                        config->endTimes, config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_p2p_kernel", 0, numBlocks,
+                                   threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
   } else if (testType == "buffer-reuse") {
     // For buffer-reuse kernel, launch on both GPUs with different ranks
     // signals[0] and signals[1] are device arrays containing signal pointers
@@ -941,12 +948,19 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 0);
     hipLaunchKernelGGL(sdma_buffer_reuse_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[0], dstBuf,
                        srcBuf, nElem, config->iterations, signals[0],
                        /*rank*/ 0, counter0, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 0,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
 
     // Launch rank 1 (responder) on destination GPU with dstGpu->srcGpu handle
     // Swap buffer arguments: rank 1's src should point to where rank 0 wrote
@@ -956,12 +970,19 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 1);
     hipLaunchKernelGGL(sdma_buffer_reuse_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[1], srcBuf,
                        dstBuf, nElem, config->iterations, signals[1],
                        /*rank*/ 1, counter1, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_buffer_reuse_kernel", 1,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
   } else if (testType == "ping-pong") {
     // For ping-pong kernel, launch on both GPUs with different ranks
     // signals[0] and signals[1] are device arrays containing signal pointers
@@ -973,12 +994,19 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 0);
     hipLaunchKernelGGL(sdma_ping_pong_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[0], dstBuf,
                        srcBuf, nElem, config->iterations, signals[0],
                        /*rank*/ 0, counter0, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 0,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
 
     // Launch rank 1 (responder) on destination GPU with dstGpu->srcGpu handle
     // Swap buffer arguments: rank 1's src should point to where rank 0 wrote
@@ -988,24 +1016,23 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
+    (void)xio::clearHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 1);
     hipLaunchKernelGGL(sdma_ping_pong_kernel, dim3(numBlocks),
                        dim3(threadsPerBlock), 0, 0, sdmaHandles[1], srcBuf,
                        dstBuf, nElem, config->iterations, signals[1],
                        /*rank*/ 1, counter1, useCounter, useFlush,
                        config->startTimes, config->endTimes,
                        config->stopRequested);
+    err = xio::checkHipLaunchError("sdma-ep", "sdma_ping_pong_kernel", 1,
+                                   numBlocks, threadsPerBlock, 0, nullptr);
+    if (err != hipSuccess) {
+      cleanupAll();
+      return err;
+    }
   } else {
     std::cerr << "Unknown test type: " << testType << std::endl;
     cleanupAll();
     return hipErrorInvalidValue;
-  }
-
-  err = hipGetLastError();
-  if (err != hipSuccess) {
-    std::cerr << "Kernel launch failed: " << hipGetErrorString(err)
-              << std::endl;
-    cleanupAll();
-    return err;
   }
 
   // Wait for kernel to complete
@@ -1016,7 +1043,7 @@ hipError_t run(XioEndpointConfig* config) {
     cleanupAll();
     return err;
   }
-  err = hipDeviceSynchronize();
+  err = xio::syncHipKernel("sdma-ep", testType.c_str(), 0, nullptr);
   if (err != hipSuccess) {
     std::cerr << "Device sync on srcGpu failed: " << hipGetErrorString(err)
               << std::endl;
@@ -1033,7 +1060,7 @@ hipError_t run(XioEndpointConfig* config) {
       cleanupAll();
       return err;
     }
-    err = hipDeviceSynchronize();
+    err = xio::syncHipKernel("sdma-ep", testType.c_str(), 1, nullptr);
     if (err != hipSuccess) {
       std::cerr << "Device sync on dstGpu failed: " << hipGetErrorString(err)
                 << std::endl;

--- a/src/endpoints/test-ep/test-ep.hip
+++ b/src/endpoints/test-ep/test-ep.hip
@@ -973,6 +973,7 @@ hipError_t run(XioEndpointConfig* config) {
         *d_vFail = 0;
     }
 
+    (void)xio::clearHipLaunchError("test-ep", "endpoint_kernel", 0);
     hipLaunchKernelGGL(endpoint_kernel, dim3(1), dim3(config->numThreads), 0, 0,
                        sqePtr, cqePtr, config->startTimes, config->endTimes,
                        config->timingStats, config->iterations,
@@ -981,7 +982,8 @@ hipError_t run(XioEndpointConfig* config) {
                        testEpConfig->verify, testEpConfig->seed, d_vPass,
                        d_vFail);
 
-    err = hipGetLastError();
+    err = xio::checkHipLaunchError("test-ep", "endpoint_kernel", 0, 1,
+                                   config->numThreads, 0, nullptr);
     if (err != hipSuccess) {
       for (auto& thread : cpuThreadHandles)
         thread.join();
@@ -992,7 +994,7 @@ hipError_t run(XioEndpointConfig* config) {
       return err;
     }
 
-    err = hipDeviceSynchronize();
+    err = xio::syncHipKernel("test-ep", "endpoint_kernel", 0, nullptr);
     if (err != hipSuccess) {
       for (auto& thread : cpuThreadHandles)
         thread.join();

--- a/src/include/xio.h
+++ b/src/include/xio.h
@@ -7,6 +7,7 @@
 #define XIO_H
 
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <memory>
@@ -127,6 +128,56 @@ std::string getModelName(int deviceId);
  * @param deviceId HIP device identifier.
  */
 void printGpuDeviceDetails(int deviceId);
+
+/**
+ * @brief Clear and report any pending HIP launch error before a kernel launch.
+ *
+ * HIP records some launch/setup failures asynchronously in per-thread runtime
+ * state. Calling this immediately before a launch prevents stale failures from
+ * being attributed to the next kernel. A non-success return is diagnostic only;
+ * callers normally continue to launch after this helper returns.
+ *
+ * @param endpoint Endpoint name used in the diagnostic message.
+ * @param kernel Kernel name used in the diagnostic message.
+ * @param queue_id Logical queue identifier for the launch.
+ * @return The stale HIP status that was cleared, or hipSuccess.
+ */
+__host__ hipError_t clearHipLaunchError(const char* endpoint,
+                                        const char* kernel, uint32_t queue_id);
+
+/**
+ * @brief Check and report the HIP status for the most recent kernel launch.
+ *
+ * Call this immediately after hipLaunchKernelGGL() and before synchronization.
+ * The helper reports the endpoint, kernel, logical queue id, launch dimensions,
+ * dynamic shared memory, and stream so launch-configuration failures are
+ * reported near their source instead of surfacing later at synchronization.
+ *
+ * @param endpoint Endpoint name used in the diagnostic message.
+ * @param kernel Kernel name used in the diagnostic message.
+ * @param queue_id Logical queue identifier for the launch.
+ * @param blocks Number of blocks requested by the launch.
+ * @param threads Number of threads per block requested by the launch.
+ * @param shmem_bytes Dynamic shared memory bytes requested by the launch.
+ * @param stream HIP stream used for the launch, or nullptr for default stream.
+ * @return hipSuccess when the launch was accepted, otherwise the HIP error.
+ */
+__host__ hipError_t checkHipLaunchError(const char* endpoint,
+                                        const char* kernel, uint32_t queue_id,
+                                        unsigned blocks, unsigned threads,
+                                        size_t shmem_bytes, hipStream_t stream);
+
+/**
+ * @brief Synchronize after a kernel launch and log failures.
+ *
+ * @param endpoint Endpoint name used in the diagnostic message.
+ * @param kernel Kernel name used in the diagnostic message.
+ * @param queue_id Logical queue identifier for the launched kernel.
+ * @param stream HIP stream to synchronize, or nullptr for default stream.
+ * @return hipSuccess when synchronization succeeds, otherwise the HIP error.
+ */
+__host__ hipError_t syncHipKernel(const char* endpoint, const char* kernel,
+                                  uint32_t queue_id, hipStream_t stream);
 
 /**
  * @brief Print timing statistics from duration data.

--- a/tests/system/nvme-ep/CMakeLists.txt
+++ b/tests/system/nvme-ep/CMakeLists.txt
@@ -80,7 +80,7 @@ xio_add_script_test(
   NAME nvme-verify-rand-host-mem
   SCRIPT ${_verify_wrapper}
   LABELS hardware nvme verify
-  TIMEOUT 30
+  TIMEOUT 120
   ARGS ${_rand_script}
   ENVIRONMENT
     "MEMORY_MODE=0"
@@ -93,7 +93,7 @@ xio_add_script_test(
   NAME nvme-verify-rand-device-mem
   SCRIPT ${_verify_wrapper}
   LABELS hardware nvme verify
-  TIMEOUT 30
+  TIMEOUT 120
   ARGS ${_rand_script}
   ENVIRONMENT
     "MEMORY_MODE=8"


### PR DESCRIPTION
Introduce shared host helpers clearHipLaunchError, checkHipLaunchError, and syncHipKernel in xio-common.hip with declarations in xio.h so launch failures and synchronization errors log endpoint, kernel name, queue id, grid, shared memory, and stream context.

Use the helpers at nvme-ep gpuKernel launch sites: clear stale errors before launch, validate launch configuration, and synchronize per HIP stream (multi-queue) or default stream (single-queue) instead of a single global hipDeviceSynchronize.

Apply the same pattern to rdma-ep loopback and client/server paths and to sdma-ep kernel launches, including per-launch checks and stream-aware or default sync where appropriate. Harden test-ep endpoint_kernel launch and sync in non-emulate mode.

NVMe system tests: sleep five seconds after xio-tester completes before nvme read in test-nvme-ep-data-verification.sh, and after dump-pattern before Python readback in test-nvme-ep-random-write-verify.sh, to reduce races with controller teardown and host read paths. Raise CTest timeouts for nvme-verify-rand-host-mem and nvme-verify-rand-device-mem from 30s to 120s to match other verify tests.

Note: run-this-now.sh remains untracked; stage only the intended paths before commit.
