### PR TITLE
Handle nvme-ep queue residency overcommit

### DIFF
--- a/docs/reference/endpoints.rst
+++ b/docs/reference/endpoints.rst
@@ -96,6 +96,12 @@ stream, its own data buffers, and its own doorbell offset. Queue
 IDs are allocated as a contiguous range ending at the auto-detected
 (or explicit ``--queue-id``) value.
 
+The number of resident queue kernels is also bounded by GPU occupancy for the
+selected ``--batch-size`` and dynamic shared-memory footprint. If
+``--num-queues`` exceeds that resident capacity, finite runs continue with a
+warning and HIP serializes the extra stream kernels. Infinite runs fail before
+queue creation because non-resident queue kernels would otherwise never run.
+
 .. code-block:: bash
 
    # 2 independent queues, each doing 32 reads

--- a/src/endpoints/nvme-ep/nvme-ep.h
+++ b/src/endpoints/nvme-ep/nvme-ep.h
@@ -776,6 +776,45 @@ __global__ void gpuKernel(XioEndpointConfig config, nvmeIoParams ioParams,
                           nvmeBufferParams bufferParams);
 
 /**
+ * Host-side occupancy summary for the NVMe GPU kernel.
+ *
+ * The endpoint launches one kernel block per NVMe I/O queue.  Finite kernels
+ * can safely queue behind resident blocks, but infinite kernels must fit all
+ * requested queues on the GPU at once or some queues will never run.
+ */
+struct nvmeQueueResidency {
+  uint32_t activeBlocksPerMultiprocessor; /**< Resident blocks per CU/SM. */
+  uint32_t multiprocessorCount;           /**< GPU compute-unit count. */
+  uint32_t residentQueueCapacity;         /**< Maximum resident queue kernels. */
+};
+
+/**
+ * Compute the number of queue kernels that can be resident at once.
+ *
+ * @param activeBlocksPerMultiprocessor Blocks per compute unit from HIP
+ *                                      occupancy.
+ * @param multiprocessorCount Compute-unit count from HIP device properties.
+ * @return Total resident kernel-block capacity, or 0 if unknown.
+ */
+__host__ static inline uint32_t nvmeResidentQueueCapacity(
+  int activeBlocksPerMultiprocessor, int multiprocessorCount) {
+  if (activeBlocksPerMultiprocessor <= 0 || multiprocessorCount <= 0)
+    return 0;
+
+  uint64_t capacity = (uint64_t)activeBlocksPerMultiprocessor *
+                      (uint64_t)multiprocessorCount;
+  return capacity > UINT32_MAX ? UINT32_MAX : (uint32_t)capacity;
+}
+
+/**
+ * @return true when the requested queues exceed known resident capacity.
+ */
+__host__ static inline bool nvmeQueueResidencyExceeded(
+  uint16_t requestedQueues, uint32_t residentQueueCapacity) {
+  return residentQueueCapacity != 0 && requestedQueues > residentQueueCapacity;
+}
+
+/**
  * NVMe Endpoint Configuration Structure
  *
  * Contains all NVMe-specific configuration options that were previously

--- a/src/endpoints/nvme-ep/nvme-ep.hip
+++ b/src/endpoints/nvme-ep/nvme-ep.hip
@@ -1195,6 +1195,37 @@ static __host__ void dumpNvmeDataPrpIfRequested(
                  true);
 }
 
+static __host__ hipError_t queryNvmeKernelResidency(
+  unsigned kernelThreads, size_t dynShmemBytes,
+  nvme_ep::nvmeQueueResidency* residency) {
+  if (!residency)
+    return hipErrorInvalidValue;
+
+  *residency = {};
+
+  int deviceId = 0;
+  hipError_t err = hipGetDevice(&deviceId);
+  if (err != hipSuccess)
+    return err;
+
+  hipDeviceProp_t deviceProp = {};
+  err = hipGetDeviceProperties(&deviceProp, deviceId);
+  if (err != hipSuccess)
+    return err;
+
+  int activeBlocks = 0;
+  err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+    &activeBlocks, nvme_ep::gpuKernel, (int)kernelThreads, dynShmemBytes);
+  if (err != hipSuccess)
+    return err;
+
+  residency->activeBlocksPerMultiprocessor = (uint32_t)activeBlocks;
+  residency->multiprocessorCount = (uint32_t)deviceProp.multiProcessorCount;
+  residency->residentQueueCapacity = nvme_ep::nvmeResidentQueueCapacity(
+    activeBlocks, deviceProp.multiProcessorCount);
+  return hipSuccess;
+}
+
 /**
  * Run NVMe endpoint operations
  *
@@ -1276,6 +1307,53 @@ __host__ hipError_t run(XioEndpointConfig* config) {
                     kernelThreads, effBatch);
   }
   ROCXIO_LOG_INFO("Using queue length: %u entries\n", queue_size);
+
+  // Dynamic shared memory for batch timing
+  size_t dynShmemBytes = 0;
+  if (effBatch > 1) {
+    dynShmemBytes = effBatch * sizeof(unsigned long long int);
+  }
+
+  // Each NVMe queue launches one single-block kernel.  HIP will queue excess
+  // stream work, but infinite queue kernels never return, so any non-resident
+  // queues would never become active.
+  nvme_ep::nvmeQueueResidency residency = {};
+  hipError_t occupancyErr =
+    queryNvmeKernelResidency(kernelThreads, dynShmemBytes, &residency);
+  if (occupancyErr == hipSuccess && residency.residentQueueCapacity != 0) {
+    ROCXIO_LOG_INFO("NVMe queue GPU residency: %u active block%s/CU, "
+                    "%u CU%s, capacity %u queue kernel%s\n",
+                    residency.activeBlocksPerMultiprocessor,
+                    residency.activeBlocksPerMultiprocessor == 1 ? "" : "s",
+                    residency.multiprocessorCount,
+                    residency.multiprocessorCount == 1 ? "" : "s",
+                    residency.residentQueueCapacity,
+                    residency.residentQueueCapacity == 1 ? "" : "s");
+
+    if (nvme_ep::nvmeQueueResidencyExceeded(numQueues,
+                                            residency.residentQueueCapacity)) {
+      if (nvmeConfig->ioParams.infiniteMode) {
+        ROCXIO_LOG_ERROR("--num-queues %u exceeds GPU resident queue "
+                         "capacity %u for this kernel configuration. "
+                         "Infinite-mode kernels do not complete, so queued "
+                         "kernels would never run. Reduce --num-queues or "
+                         "--batch-size.\n",
+                         numQueues, residency.residentQueueCapacity);
+        return hipErrorNotSupported;
+      }
+
+      ROCXIO_LOG_WARN("--num-queues %u exceeds GPU resident queue "
+                      "capacity %u for this kernel configuration. HIP will "
+                      "serialize the extra finite queue kernels, so effective "
+                      "concurrency is capped at %u.\n",
+                      numQueues, residency.residentQueueCapacity,
+                      residency.residentQueueCapacity);
+    }
+  } else if (occupancyErr != hipSuccess) {
+    ROCXIO_LOG_WARN("Unable to query NVMe kernel occupancy: %s. "
+                    "Continuing without queue residency preflight.\n",
+                    hipGetErrorString(occupancyErr));
+  }
 
   // ---- Doorbell access setup (shared) ----
   if (nvmeConfig->doorbellParams.usePciMmioBridge) {
@@ -1398,12 +1476,6 @@ __host__ hipError_t run(XioEndpointConfig* config) {
                        nvmeConfig->bufferParams.bufferSize);
       return hipErrorInvalidValue;
     }
-  }
-
-  // Dynamic shared memory for batch timing
-  size_t dynShmemBytes = 0;
-  if (effBatch > 1) {
-    dynShmemBytes = effBatch * sizeof(unsigned long long int);
   }
 
   // ---- Per-queue state vectors ----

--- a/tests/unit/nvme-ep/test-nvme-config.hip
+++ b/tests/unit/nvme-ep/test-nvme-config.hip
@@ -182,6 +182,18 @@ int test_queue_length_validation() {
   return 0;
 }
 
+int test_queue_residency_capacity() {
+  ASSERT_EQ(nvmeResidentQueueCapacity(0, 120), 0u);
+  ASSERT_EQ(nvmeResidentQueueCapacity(8, 0), 0u);
+  ASSERT_EQ(nvmeResidentQueueCapacity(8, 120), 960u);
+
+  ASSERT_TRUE(!nvmeQueueResidencyExceeded(32, 960));
+  ASSERT_TRUE(!nvmeQueueResidencyExceeded(960, 960));
+  ASSERT_TRUE(nvmeQueueResidencyExceeded(961, 960));
+  ASSERT_TRUE(!nvmeQueueResidencyExceeded(961, 0));
+  return 0;
+}
+
 int test_nvme_page_size() {
   ASSERT_EQ(NVME_PAGE_SIZE, 4096);
   return 0;
@@ -211,6 +223,7 @@ int main() {
   failures += test_admin_response_size();
   failures += test_command_opcodes();
   failures += test_queue_length_validation();
+  failures += test_queue_residency_capacity();
   failures += test_nvme_page_size();
   failures += test_status_code_constants();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a HIP occupancy preflight for `xio-tester nvme-ep --num-queues`.
- Warn when finite multi-queue runs exceed resident GPU queue-kernel capacity and effective concurrency will be capped.
- Fail infinite overcommit before NVMe queue creation so non-resident queue kernels do not wait forever.
- Document the `--num-queues` GPU residency behavior and add unit coverage for the resident-capacity helper.

## Testing
- `git diff --check`
- `rg '^.{81,}$' docs/reference/endpoints.rst` (no matches)
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DGDA_BNXT=ON -DGDA_IONIC=ON` *(blocked: cloud image has no ROCm root directory; CMake fails in `CMakeDetermineHIPCompiler.cmake` before compiling)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6158f558-6187-461c-a043-c07542644015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6158f558-6187-461c-a043-c07542644015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

