### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,112 @@ sudo env \
 Use `rdma statistic show` to observe `rocm-rdma-ionic0` traffic. For long
 runs, watch GPU power management and temperatures as described in
 `docs/how-to/testing.rst`.
+
+## Cursor Cloud specific instructions
+
+The Cloud Agent VM has no AMD GPU, NVMe SSD, or RDMA NIC hardware.
+All work is limited to compilation, unit/integration tests, linting,
+and documentation builds.
+
+The Cursor Cloud VM startup script (managed by the Cursor platform,
+not stored in this repo) installs the latest release of ROCm from
+`repo.radeon.com` along with the build and lint dependencies listed
+below. Check the CI workflows (`.github/workflows/`) for the
+container image tag currently in use and keep the installed ROCm
+release in sync when that tag changes.
+
+### Available scope
+
+**Configure and build:**
+
+```bash
+cmake -DROCM_PATH=/opt/rocm -DBUILD_TESTING=ON -S . -B build
+cmake --build build -j
+```
+
+**Unit tests:**
+
+```bash
+ctest -L unit --test-dir build
+```
+
+**All no-hardware tests** (mirrors `ctest-no-hardware.yml`):
+
+```bash
+HSA_FORCE_FINE_GRAIN_PCIE=1 \
+  ctest --test-dir build \
+    --label-exclude 'hardware|system' \
+    --resource-spec-file "$PWD/build/ctest-resources.json" \
+    --parallel "$(nproc)" \
+    --output-on-failure
+```
+
+**Clang-format lint** (mirrors `build-check.yml`):
+
+```bash
+git ls-files '*.cpp' '*.h' '*.hpp' '*.c' '*.cc' '*.hip' \
+  | grep -v 'src/include/external/' \
+  | xargs clang-format-18 --style=file --dry-run --Werror
+```
+
+**ShellCheck** (mirrors `scripts-check.yml`):
+
+```bash
+find scripts -name '*.sh' \
+  -exec shellcheck --severity=warning --exclude=SC2086 {} +
+```
+
+**Spell check and RST lint** (mirrors `spell-check.yml` and
+`docs-check.yml`):
+
+```bash
+source .venv/bin/activate
+pyspelling -c .spellcheck.yml
+codespell
+doc8 docs/ --max-line-length 80 \
+  --ignore-path docs/sphinx/requirements.txt
+```
+
+**Sphinx docs build** (mirrors `docs-check.yml`):
+
+```bash
+source .venv/bin/activate
+cmake -S . -B build-docs \
+  -DXIO_DOCS_ONLY=ON -DXIO_BUILD_DOCS=ON
+cmake --build build-docs --target sphinx-html
+```
+
+**Kernel module build:**
+
+```bash
+make -C kernel/rocm-xio
+```
+
+**xio-tester emulation demo:**
+
+```bash
+./build/xio-tester test-ep --emulate -n 32 --threads 2 -v
+```
+
+### Gotchas
+
+- The system CXX compiler is clang-18 (not the ROCm `amdclang++`).
+  The `libstdc++-14-dev` and clang-18 runtime dev packages must be
+  installed for test and tester linking to succeed. The VM startup
+  script handles this.
+- `nvme-ep-generated.h` in `src/include/` is auto-generated and
+  excluded from version control. Lint checks must exclude it or use
+  `git ls-files` to enumerate sources.
+- The Python venv at `.venv/` is used only for Sphinx docs and lint
+  tools (codespell, pyspelling, doc8). Activate it before running
+  those tools: `source .venv/bin/activate`.
+- Without a GPU, `rocminfo` returns no devices; CMake defaults
+  `XIODetectGPUs` to 1 GPU for CTest resource specs.
+- Tests labeled `hardware` or `system` require real AMD GPU or NIC
+  hardware and will fail in the Cloud Agent VM. Always pass
+  `--label-exclude 'hardware|system'` to `ctest`.
+- The VM kernel differs from the installed headers package. The VM
+  startup script creates a link from
+  `/lib/modules/$(uname -r)/build` to the installed headers so
+  `make` in `kernel/rocm-xio` works. Debug type generation is
+  skipped at build time; this is harmless for compilation checks.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a `## Cursor Cloud specific instructions` section to `AGENTS.md`
documenting the Cloud Agent VM environment constraints and available
development tasks.

## Changes

- **AGENTS.md**: New section covering the Cloud Agent VM scope (no
  GPU, NVMe, or RDMA hardware). References the latest ROCm release
  (not pinned to any specific version) and directs agents to check
  the CI workflow container tags when syncing. Uses fenced code
  blocks (not a Markdown table) so pipe-containing commands are
  directly copyable. Clarifies that the "VM startup script" is
  managed by the Cursor platform, not stored in this repo. Covers
  every CI check: configure, build, unit tests, clang-format lint,
  shellcheck, pyspelling, codespell, doc8 RST lint, Sphinx docs
  build, kernel module build, and xio-tester emulation. Documents
  gotchas for linker deps, generated-header lint exclusion, Python
  venv usage, GPU detection defaults, test label filtering, and
  kernel-header mismatch.

## Copilot review items addressed

1. **Escaped pipes in table** -- Replaced the Markdown table with
   fenced code blocks so `|` characters in shell pipelines and
   `ctest --label-exclude` regexes are directly copyable.
2. **"Update script" undefined** -- Clarified that it refers to the
   Cursor Cloud VM startup script managed by the platform, not a
   file in this repository.

## Verification

All text passes the existing pyspelling, codespell, and doc8 checks
without adding new wordlist entries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2a25d01-ecd1-4108-9428-1c12a43bcfb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2a25d01-ecd1-4108-9428-1c12a43bcfb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

