### PR TITLE
[rocm-xio] move dma-buf teardown out of vram_buffers_lock spinlock

### DIFF
--- a/kernel/rocm-xio/rocm-xio.c
+++ b/kernel/rocm-xio/rocm-xio.c
@@ -1610,20 +1610,27 @@ static void __exit rocm_xio_exit(void) {
   spin_unlock(&queue_addrs_lock);
 
   /* Clean up registered buffers */
-  spin_lock(&vram_buffers_lock);
-  list_for_each_entry_safe(entry, tmp, &vram_buffers, list) {
-    list_del(&entry->list);
-    /* Cleanup passthrough attachment if needed */
-    if (entry->is_passthrough && entry->sgt && entry->attach && entry->dmabuf) {
-      dma_buf_unmap_attachment(entry->attach, entry->sgt, DMA_BIDIRECTIONAL);
-      dma_buf_detach(entry->dmabuf, entry->attach);
-      dma_buf_put(entry->dmabuf);
-      if (entry->nvme_pdev)
-        pci_dev_put(entry->nvme_pdev);
+  {
+    LIST_HEAD(to_free);
+
+    spin_lock(&vram_buffers_lock);
+    list_splice_init(&vram_buffers, &to_free);
+    spin_unlock(&vram_buffers_lock);
+
+    list_for_each_entry_safe(entry, tmp, &to_free, list) {
+      list_del(&entry->list);
+      /* Cleanup passthrough attachment if needed */
+      if (entry->is_passthrough && entry->sgt && entry->attach &&
+          entry->dmabuf) {
+        dma_buf_unmap_attachment(entry->attach, entry->sgt, DMA_BIDIRECTIONAL);
+        dma_buf_detach(entry->dmabuf, entry->attach);
+        dma_buf_put(entry->dmabuf);
+        if (entry->nvme_pdev)
+          pci_dev_put(entry->nvme_pdev);
+      }
+      kfree(entry);
     }
-    kfree(entry);
   }
-  spin_unlock(&vram_buffers_lock);
 
   /* Clean up contiguous DMA allocations */
   {


### PR DESCRIPTION
## Motivation

Fix a call to sleeping functions while holding a spin lock unnecessarily.

## Technical Details

rocm_xio_exit() called dma_buf_unmap_attachment(), dma_buf_detach() and dma_buf_put() while holding the vram_buffers_lock spinlock. Those calls may sleep, triggering "sleeping function called from invalid context" on rmmod and a nesting violation on PREEMPT_RT. Splice the list into a local head under the lock, drop the lock, then perform the dma-buf teardown and kfree outside it, matching the splice-then-free pattern already used for contig_allocs and quiesced_ns in the same function.

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
