### PR TITLE
[rocm-xio] qemu: vendor NVMe-to-VRAM P2P patch series

### DIFF
--- a/qemu/patches/0001-hw-nvme-add-properties-to-NvmeCtrl-for-p2p-to-device.patch
+++ b/qemu/patches/0001-hw-nvme-add-properties-to-NvmeCtrl-for-p2p-to-device.patch
@@ -1,0 +1,50 @@
+From 251cf60c57881bb03a4946e38b898ec1025a72f6 Mon Sep 17 00:00:00 2001
+From: John Tyler <jetyler@ualberta.ca>
+Date: Thu, 28 May 2026 10:08:22 -0600
+Subject: [PATCH 1/2] hw/nvme: add properties to NvmeCtrl for p2p to device
+ vram
+
+allows the user to specify vram-dev=<id of pci device>,vram-bus=<bus #
+of pcie device> when adding an emulated NVMe in QEMU to initiate p2p on
+GPU VRAM
+---
+ hw/nvme/ctrl.c | 3 +++
+ hw/nvme/nvme.h | 8 ++++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/hw/nvme/ctrl.c b/hw/nvme/ctrl.c
+index ef0f938f03..c2c8469184 100644
+--- a/hw/nvme/ctrl.c
++++ b/hw/nvme/ctrl.c
+@@ -9530,6 +9530,9 @@ static void nvme_exit(PCIDevice *pci_dev)
+ 
+ static const Property nvme_props[] = {
+     DEFINE_BLOCK_PROPERTIES(NvmeCtrl, namespace.blkconf),
++    DEFINE_PROP_LINK("vram-dev", NvmeCtrl, vram_dev, TYPE_PCI_DEVICE,
++                     PCIDevice *),
++    DEFINE_PROP_UINT8("vram-bar", NvmeCtrl, vram_bar, 0),
+     DEFINE_PROP_LINK("pmrdev", NvmeCtrl, pmr.dev, TYPE_MEMORY_BACKEND,
+                      HostMemoryBackend *),
+     DEFINE_PROP_LINK("subsys", NvmeCtrl, subsys, TYPE_NVME_SUBSYS,
+diff --git a/hw/nvme/nvme.h b/hw/nvme/nvme.h
+index 1d1e38eb90..f767aa3f96 100644
+--- a/hw/nvme/nvme.h
++++ b/hw/nvme/nvme.h
+@@ -624,6 +624,14 @@ typedef struct NvmeCtrl {
+         hwaddr            cba;
+     } pmr;
+ 
++    /*
++     * Optional VFIO passthrough device whose BAR is the source/sink for
++     * P2P DMA (e.g. a GPU's VRAM aperture). Resolved from the "vram-dev"
++     * link property; "vram-bar" selects which BAR.
++     */
++    PCIDevice *vram_dev;
++    uint8_t    vram_bar;
++
+     uint8_t     aer_mask;
+     NvmeRequest **aer_reqs;
+     QTAILQ_HEAD(, NvmeAsyncEvent) aer_queue;
+-- 
+2.43.0
+

--- a/qemu/patches/0002-hw-nvme-use-pci_get_bar_addr-to-programatically-quer.patch
+++ b/qemu/patches/0002-hw-nvme-use-pci_get_bar_addr-to-programatically-quer.patch
@@ -1,0 +1,83 @@
+From 623a7fab893a926844d39fc401f055ef4acc1074 Mon Sep 17 00:00:00 2001
+From: John Tyler <jetyler@ualberta.ca>
+Date: Thu, 28 May 2026 10:09:26 -0600
+Subject: [PATCH 2/2] hw/nvme: use pci_get_bar_addr to programatically query
+ address of BAR for VRAM check
+
+allows the user to p2p to device VRAM
+---
+ hw/nvme/ctrl.c | 41 ++++++++++++++++++++++-------------------
+ 1 file changed, 22 insertions(+), 19 deletions(-)
+
+diff --git a/hw/nvme/ctrl.c b/hw/nvme/ctrl.c
+index c2c8469184..e6c115f8fa 100644
+--- a/hw/nvme/ctrl.c
++++ b/hw/nvme/ctrl.c
+@@ -828,26 +828,29 @@ static uint16_t nvme_map_addr_pmr(NvmeCtrl *n, QEMUIOVector *iov, hwaddr addr,
+ }
+ 
+ /*
+- * GPU VRAM P2P DMA support for emulated NVMe
++ * GPU VRAM P2P DMA support for emulated NVMe.
+  *
+- * Detects if a guest physical address falls within a VFIO passthrough
+- * GPU's VRAM BAR range. This allows the emulated NVMe controller to
+- * perform DMA directly from GPU VRAM for peer-to-peer transfers.
+- *
+- * Note: This range detection is a proof-of-concept. A production
+- * implementation should discover VFIO device BARs dynamically or
+- * use device properties to configure the range.
++ * Returns true if [addr, addr+len) lies entirely within the live BAR
++ * window of the VFIO passthrough device configured via the "vram-dev"
++ * and "vram-bar" properties. The BAR address is read from the PCIDevice
++ * each call so it tracks BAR reprogramming by the guest.
+  */
+-static inline bool nvme_addr_is_vram(hwaddr addr, hwaddr len)
++static inline bool nvme_addr_is_vram(NvmeCtrl *n, hwaddr addr, hwaddr len)
+ {
+-    hwaddr hi = addr + len - 1;
+-    
+-    /*
+-     * Typical AMD GPU VRAM BAR range in guest physical address space.
+-     * This matches a 16GB BAR starting at 0xc400000000.
+-     * TODO: Make this configurable via device property.
+-     */
+-    return (addr >= 0xc400000000ULL && hi < 0xc800000000ULL);
++    PCIDevice *dev = n->vram_dev;
++    pcibus_t base, size;
++
++    if (!dev) {
++        return false;
++    }
++
++    base = pci_get_bar_addr(dev, n->vram_bar);
++    size = dev->io_regions[n->vram_bar].size;
++    if (base == PCI_BAR_UNMAPPED || !size) {
++        return false;
++    }
++
++    return addr >= base && (addr + len) <= (base + size);
+ }
+ 
+ /*
+@@ -932,7 +935,7 @@ static uint16_t nvme_map_addr(NvmeCtrl *n, NvmeSg *sg, hwaddr addr, size_t len)
+         cmb = true;
+     } else if (nvme_addr_is_pmr(n, addr)) {
+         pmr = true;
+-    } else if (nvme_addr_is_vram(addr, len)) {
++    } else if (nvme_addr_is_vram(n, addr, len)) {
+         vram = true;
+     }
+ 
+@@ -989,7 +992,7 @@ static inline bool nvme_addr_is_dma(NvmeCtrl *n, hwaddr addr)
+ {
+     /* VRAM, CMB, and PMR are not DMA - they use direct memory mapping */
+     return !(nvme_addr_is_cmb(n, addr) || nvme_addr_is_pmr(n, addr) ||
+-             nvme_addr_is_vram(addr, 1));
++             nvme_addr_is_vram(n, addr, 1));
+ }
+ 
+ static uint16_t nvme_map_prp(NvmeCtrl *n, NvmeSg *sg, uint64_t prp1,
+-- 
+2.43.0
+

--- a/qemu/patches/README.md
+++ b/qemu/patches/README.md
@@ -1,0 +1,42 @@
+<!--
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+SPDX-License-Identifier: MIT
+-->
+
+## Base revision
+
+The patches apply on top of:
+
+```
+remote: https://github.com/sbates130272/qemu
+branch: dev/stephen/pci-mmio-bridge-submit
+```
+
+## Applying
+
+The patches are standard `git format-patch` output and apply with `patch`,
+matching the apply style used by the kernel driver series in this repo
+(`patch -p1 --fuzz=3`):
+
+```bash
+git clone https://github.com/sbates130272/qemu qemu
+cd qemu
+git checkout dev/stephen/pci-mmio-bridge-submit
+for p in <path-to>/qemu/patches/0*.patch; do
+    patch -p1 --fuzz=3 < "$p"
+done
+```
+
+They also apply cleanly with `git am` if you want to preserve authorship and
+commit messages in the resulting tree:
+
+```bash
+git am <path-to>/qemu/patches/0*.patch
+```
+
+After applying, build as usual:
+
+```bash
+./configure --target-list=x86_64-softmmu --enable-kvm
+make -j"$(nproc)"
+```


### PR DESCRIPTION
## Motivation

In the mmio-bridge fork of QEMU, we want to look up the pci BAR address to find where the mmio bridge can live.

I can't open PRs on [this](https://github.com/sbates130272/qemu) repo, since the GitLab mirror bot automatically closes it. The pci-mmio-bridge is closely related to rocm-xio, so this PR is drafted here just for review!

## Technical Details

You can use the `vram-dev=vfio-host<VRAM_DEV_INDEX>,vram-bar<VRAM_BAR>` commands when launching QEMU to specify the device that has VRAM that where the MMIO will be bridged to.

## Test Plan

The NVMe tracepoints can be inspected, `pci_nvme_vram_p2p_mr_found` is triggered on NVMe writes from GPU VRAM that utilize the MMIO bridge. The address and size can be verified to confirm that it matches the GPU BAR window shown in `lspci -v`.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
