### PR TITLE
Use project source directory for project paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ else()
 endif()
 
 # Add cmake/ to the module search path (all modes need this)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if(NOT XIO_DOCS_ONLY)
 
@@ -231,11 +231,11 @@ option(XIO_SDMA_OSS7
   ${_XIO_SDMA_OSS7_DEFAULT})
 
 # Project directories
-set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/include)
-set(ENDPOINTS_DIR ${CMAKE_SOURCE_DIR}/src/endpoints)
-set(ENDPOINTS_COMMON_DIR ${CMAKE_SOURCE_DIR}/src/endpoints/common)
-set(COMMON_DIR ${CMAKE_SOURCE_DIR}/src/common)
-set(TESTER_DIR ${CMAKE_SOURCE_DIR}/src/tester)
+set(INCLUDE_DIR ${PROJECT_SOURCE_DIR}/src/include)
+set(ENDPOINTS_DIR ${PROJECT_SOURCE_DIR}/src/endpoints)
+set(ENDPOINTS_COMMON_DIR ${PROJECT_SOURCE_DIR}/src/endpoints/common)
+set(COMMON_DIR ${PROJECT_SOURCE_DIR}/src/common)
+set(TESTER_DIR ${PROJECT_SOURCE_DIR}/src/tester)
 set(EXTERNAL_HEADERS_DIR ${INCLUDE_DIR}/external)
 set(RDMA_HEADERS_DIR ${EXTERNAL_HEADERS_DIR}/rdma)
 set(NVME_HEADERS_DIR ${EXTERNAL_HEADERS_DIR}/nvme)
@@ -672,7 +672,7 @@ include(CMakePackageConfigHelpers)
 
 # configure_package_config_file will automatically get version from project()
 configure_package_config_file(
-    ${CMAKE_SOURCE_DIR}/cmake/rocm-xio-config.cmake.in
+    ${PROJECT_SOURCE_DIR}/cmake/rocm-xio-config.cmake.in
     ${CMAKE_BINARY_DIR}/rocm-xio-config.cmake
     INSTALL_DESTINATION ${ROCM_XIO_CONFIG_INSTALL_DIR}
     PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR

--- a/cmake/XIOCodeGeneration.cmake
+++ b/cmake/XIOCodeGeneration.cmake
@@ -15,7 +15,7 @@ function(setup_code_generation)
 
   # Endpoint registry generation
   set(GEN_SCRIPT
-    ${CMAKE_SOURCE_DIR}/scripts/build/generate-endpoint-files.sh)
+    ${PROJECT_SOURCE_DIR}/scripts/build/generate-endpoint-files.sh)
   set(GEN_SENTINEL ${CMAKE_BINARY_DIR}/.endpoint-files-generated)
 
   add_custom_command(
@@ -44,7 +44,7 @@ function(setup_code_generation)
 
   # NVMe header fetching
   set(NVME_FETCH_SCRIPT
-    ${CMAKE_SOURCE_DIR}/scripts/build/fetch-nvme-headers.sh)
+    ${PROJECT_SOURCE_DIR}/scripts/build/fetch-nvme-headers.sh)
   set(NVME_KERNEL_HEADERS
     ${GEN_NVME_HEADERS_DIR}/linux-nvme.h
     ${GEN_NVME_HEADERS_DIR}/linux-nvme_ioctl.h)
@@ -62,7 +62,7 @@ function(setup_code_generation)
 
   # NVMe defines extraction
   set(NVME_EXTRACT_SCRIPT
-    ${CMAKE_SOURCE_DIR}/scripts/build/extract-nvme-defines.sh)
+    ${PROJECT_SOURCE_DIR}/scripts/build/extract-nvme-defines.sh)
 
   add_custom_command(
     OUTPUT ${GEN_NVME_EP_GENERATED}
@@ -92,9 +92,9 @@ function(setup_code_generation)
 
   # RDMA header fetching
   set(RDMA_FETCH_SCRIPT
-    ${CMAKE_SOURCE_DIR}/scripts/build/fetch-rdma-headers.sh)
+    ${PROJECT_SOURCE_DIR}/scripts/build/fetch-rdma-headers.sh)
   set(RDMA_GEN_SCRIPT
-    ${CMAKE_SOURCE_DIR}/scripts/build/generate-rdma-vendor-headers.sh)
+    ${PROJECT_SOURCE_DIR}/scripts/build/generate-rdma-vendor-headers.sh)
 
   # RDMA headers that need to be fetched
   set(RDMA_HEADERS


### PR DESCRIPTION
This PR replaces `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` for paths owned by rocm-xio. When rocm-xio is included through FetchContent, `CMAKE_SOURCE_DIR` points to the top-level consuming project, while `PROJECT_SOURCE_DIR` points to the rocm-xio source directory established by its project() call. Using `PROJECT_SOURCE_DIR` therefore allows scripts, headers, CMake modules, and package configuration files to be resolved correctly when rocm-xio is embedded as a dependency, while preserving the existing behavior for standalone builds where the two variables refer to the same directory.
